### PR TITLE
docs: improve Rust documentation formatting

### DIFF
--- a/src/core/batch.rs
+++ b/src/core/batch.rs
@@ -24,20 +24,20 @@ pub type Tensor1D = ndarray::ArrayD<f32>;
 /// This struct contains the instances, input paths, and indexes for a batch of data.
 /// It's used in the OCR pipeline to process multiple inputs together for efficiency.
 pub struct BatchData {
-    /// The instances in the batch, stored as Arc<str> for efficient sharing.
+    /// The instances in the batch, stored as `Arc<str>` for efficient sharing.
     pub instances: Vec<Arc<str>>,
-    /// The input paths for the instances in the batch, stored as Arc<str> for efficient sharing.
+    /// The input paths for the instances in the batch, stored as `Arc<str>` for efficient sharing.
     pub input_paths: Vec<Arc<str>>,
     /// The indexes of the instances in the original data set.
     pub indexes: Vec<usize>,
 }
 
 impl BatchData {
-    /// Creates a new BatchData instance from shared Arc<str> paths and indexes.
+    /// Creates a new BatchData instance from shared `Arc<str>` paths and indexes.
     ///
     /// # Arguments
     ///
-    /// * `paths` - A vector of Arc<str> representing the paths to the instances.
+    /// * `paths` - A vector of `Arc<str>` representing the paths to the instances.
     /// * `indexes` - A vector of usize representing the indexes of the instances in the original data set.
     ///
     /// # Returns

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -238,7 +238,7 @@ pub trait ConfigValidator {
     }
 }
 
-/// Implementation of From<ConfigError> for String.
+/// Implementation of `From<ConfigError>` for String.
 ///
 /// This allows ConfigError to be converted to a String representation.
 impl From<ConfigError> for String {

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -253,7 +253,7 @@ pub trait ImageReader {
     ///
     /// # Constraints
     ///
-    /// * `P` must implement AsRef<Path> + Send + Sync.
+    /// * `P` must implement `AsRef<Path>` + Send + Sync.
     fn apply<P: AsRef<Path> + Send + Sync>(
         &self,
         imgs: impl IntoIterator<Item = P>,
@@ -271,7 +271,7 @@ pub trait ImageReader {
     ///
     /// # Constraints
     ///
-    /// * `P` must implement AsRef<Path> + Send + Sync.
+    /// * `P` must implement `AsRef<Path>` + Send + Sync.
     fn read_single<P: AsRef<Path> + Send + Sync>(
         &self,
         img_path: P,

--- a/src/processors/mod.rs
+++ b/src/processors/mod.rs
@@ -7,14 +7,14 @@
 //!
 //! # Modules
 //!
-//! * [`decode`] - Text decoding utilities for converting model predictions to readable text
-//! * [`geometry`] - Geometric primitives and algorithms for OCR processing
-//! * [`normalization`] - Image normalization utilities for preparing images for OCR models
-//! * [`ocr_resize`] - OCR-specific image resizing functionality
-//! * [`postprocess`] - Post-processing utilities for OCR pipeline outputs
-//! * [`resize`] - General image resizing utilities for OCR preprocessing
-//! * [`types`] - Type definitions used across the processors module
-//! * [`utils`] - Additional utility functions for image processing
+//! * `decode` - Text decoding utilities for converting model predictions to readable text
+//! * `geometry` - Geometric primitives and algorithms for OCR processing
+//! * `normalization` - Image normalization utilities for preparing images for OCR models
+//! * `ocr_resize` - OCR-specific image resizing functionality
+//! * `postprocess` - Post-processing utilities for OCR pipeline outputs
+//! * `resize` - General image resizing utilities for OCR preprocessing
+//! * `types` - Type definitions used across the processors module
+//! * `utils` - Additional utility functions for image processing
 
 mod decode;
 mod geometry;

--- a/src/processors/utils.rs
+++ b/src/processors/utils.rs
@@ -140,8 +140,8 @@ impl Crop {
     /// # Arguments
     ///
     /// * `crop_size` - Slice containing the crop dimensions. Can be:
-    ///   - 1 element: square crop of size crop_size[0] x crop_size[0]
-    ///   - 2 elements: rectangular crop of size crop_size[0] x crop_size[1]
+    ///   - 1 element: square crop of size crop_size\[0\] x crop_size\[0\]
+    ///   - 2 elements: rectangular crop of size crop_size\[0\] x crop_size\[1\]
     /// * `mode` - String representation of the crop mode ("center" or "topleft").
     ///
     /// # Returns


### PR DESCRIPTION
- Wrap type names in backticks for proper rendering
- Fix module reference formatting in processors/mod.rs
- Escape square brackets in array index documentation