### PR TITLE
feat: add ColorMode enum and update NormalizeImage to support BGR color mode.

### DIFF
--- a/src/processors/normalization.rs
+++ b/src/processors/normalization.rs
@@ -347,7 +347,8 @@ impl NormalizeImage {
                     for y in 0..h.min(height_img as usize) {
                         for x in 0..w.min(width as usize) {
                             let pixel = rgb_img.get_pixel(x as u32, y as u32);
-                            for (c, &src_c) in src_channels.iter().enumerate().take(channels.min(3)) {
+                            for (c, &src_c) in src_channels.iter().enumerate().take(channels.min(3))
+                            {
                                 let channel_value = pixel[src_c] as f32;
                                 let dst_idx =
                                     batch_offset + y * max_width * channels + x * channels + c;


### PR DESCRIPTION
Most PaddleOCR models are trained on BGR images (see [PP-OCRv5 config](https://github.com/PaddlePaddle/PaddleOCR/blob/main/configs/rec/PP-OCRv5/PP-OCRv5_server_rec.yml#L119)).

However, this repository uses RGB images for inference, which may lead to degraded performance.

This PR introduces an `enum ColorMode` to control the image color format and sets BGR as the default mode.