### PR TITLE
chore: Update version to 0.3.1 and refine tokenizers dependency configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oar-ocr"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Wang Xin <xinwang614@gmail.com>"]
@@ -49,7 +49,7 @@ thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ab_glyph = { version = "0.2", optional = true }
-tokenizers = "0.22"
+tokenizers = { version = "0.22", default-features = false, features = ["progressbar", "onig"] }
 clipper2 = "0.5.3"
 
 [dev-dependencies]


### PR DESCRIPTION
This pull request makes minor updates to the `Cargo.toml` file, including a version bump and an adjustment to the `tokenizers` dependency configuration.

* Version update:
  * Bumped the package version from `0.3.0` to `0.3.1` in `Cargo.toml`.

* Dependency configuration:
  * Changed the `tokenizers` dependency to disable default features and explicitly enable the `progressbar` and `onig` features in `Cargo.toml`.