### PR TITLE
build(deps): update candle dependencies from 0.9.2 to 0.10.2

### DIFF
--- a/oar-ocr-vl/Cargo.toml
+++ b/oar-ocr-vl/Cargo.toml
@@ -27,9 +27,9 @@ metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
 [dependencies]
 oar-ocr-core.workspace = true
 image = "0.25.6"
-candle-core = "0.9.2"
-candle-nn = "0.9.2"
-candle-transformers = "0.9.2"
+candle-core = "0.10.2"
+candle-nn = "0.10.2"
+candle-transformers = "0.10.2"
 once_cell = "1.19"
 regex = "1.11.1"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
- Update candle-core from 0.9.2 to 0.10.2
- Update candle-nn from 0.9.2 to 0.10.2
- Update candle-transformers from 0.9.2 to 0.10.2
- Align with latest candle release for improved performance and stability