### PR TITLE
build: dont pull in ureq on default-features = false

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/greatv/oar-ocr"
 homepage = "https://github.com/greatv/oar-ocr"
 
 [workspace.dependencies]
-oar-ocr-core = { version = "0.6.2", path = "oar-ocr-core" }
-oar-ocr-derive = { version = "0.6.2", path = "oar-ocr-derive" }
+oar-ocr-core = { version = "0.6.2", path = "oar-ocr-core", default-features = false }
+oar-ocr-derive = { version = "0.6.2", path = "oar-ocr-derive", default-features = false }
 
 [package]
 name = "oar-ocr"

--- a/oar-ocr-core/Cargo.toml
+++ b/oar-ocr-core/Cargo.toml
@@ -27,7 +27,7 @@ coreml = ["ort/coreml"]
 webgpu = ["ort/webgpu"]
 openvino = ["ort/openvino"]
 # Auto-download ONNX Runtime binaries during build (enabled by default).
-download-binaries = ["ort/download-binaries"]
+download-binaries = ["ort/download-binaries", "ort/tls-native"]
 
 [dependencies]
 oar-ocr-derive.workspace = true
@@ -39,7 +39,7 @@ regex = "1.11.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 toml = "1.0"
-ort = { version = "2.0.0-rc.12", default-features = false, features = [ "std", "ndarray", "tracing", "tls-native", "copy-dylibs" ] }
+ort = { version = "2.0.0-rc.12", default-features = false, features = [ "std", "ndarray", "tracing", "copy-dylibs" ] }
 ndarray = "0.17"
 nalgebra = "0.34"
 rayon = "1.8"

--- a/oar-ocr-core/Cargo.toml
+++ b/oar-ocr-core/Cargo.toml
@@ -34,7 +34,6 @@ oar-ocr-derive.workspace = true
 image = "0.25.6"
 imageproc = "0.26.0"
 itertools = "0.14"
-once_cell = "1.19"
 regex = "1.11.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/oar-ocr-core/src/domain/structure.rs
+++ b/oar-ocr-core/src/domain/structure.rs
@@ -6,16 +6,16 @@
 use super::text_region::TextRegion;
 use crate::processors::BoundingBox;
 use image::RgbImage;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 /// Title numbering pattern for detecting section numbers like 1, 1.2, 1.2.3, (1), 一、etc.
 /// This follows standard title numbering pattern.
-static TITLE_NUMBERING_REGEX: Lazy<Regex> = Lazy::new(|| {
+static TITLE_NUMBERING_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?x)
         ^\s*

--- a/oar-ocr-core/src/processors/decode.rs
+++ b/oar-ocr-core/src/processors/decode.rs
@@ -5,9 +5,9 @@
 //! It includes structures and methods for converting model predictions into
 //! readable text strings with confidence scores.
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 /// Decoded batch outputs along with positional metadata.
 pub type PositionedDecodeResult = (
@@ -18,7 +18,7 @@ pub type PositionedDecodeResult = (
     Vec<usize>,
 );
 
-static ALPHANUMERIC_REGEX: Lazy<Regex> = Lazy::new(|| {
+static ALPHANUMERIC_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"[a-zA-Z0-9 :*./%+-]")
         .unwrap_or_else(|e| panic!("Failed to compile regex pattern: {e}"))
 });

--- a/oar-ocr-core/src/processors/formula_preprocess.rs
+++ b/oar-ocr-core/src/processors/formula_preprocess.rs
@@ -7,21 +7,21 @@ use crate::core::OCRError;
 use image::imageops::{FilterType, overlay, resize};
 use image::{DynamicImage, RgbImage};
 use ndarray::{Array2, Array3, Array4};
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
 // Static regex patterns for LaTeX normalization
-static CHINESE_TEXT_PATTERN: Lazy<Regex> = Lazy::new(|| {
+static CHINESE_TEXT_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\\text\s*\{([^{}]*[\u{4e00}-\u{9fff}]+[^{}]*)\}")
         .unwrap_or_else(|e| panic!("Failed to compile Chinese text regex pattern: {e}"))
 });
 
-static TEXT_COMMAND_PATTERN: Lazy<Regex> = Lazy::new(|| {
+static TEXT_COMMAND_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(\\(operatorname|mathrm|text|mathbf)\s?\*?\s*\{.*?\})")
         .unwrap_or_else(|e| panic!("Failed to compile text command regex pattern: {e}"))
 });
 
-static LETTER_TO_NONLETTER_PATTERN: Lazy<Regex> = Lazy::new(|| {
+static LETTER_TO_NONLETTER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"([a-zA-Z])\s+([^a-zA-Z])")
         .unwrap_or_else(|e| panic!("Failed to compile letter to nonletter regex pattern: {e}"))
 });


### PR DESCRIPTION
`oar-ocr` accidentally turns on default features of `oar-ocr-core` and `oar-ocr-core` accidentally turns on `native-tls`, even if that feature is not needed with `default-features = false`.

Ensure that `default-features = false` does not pull in web stuff.