### PR TITLE
 perf: reduce image copies in OCR pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,19 +10,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            clippy-features: ""
-          - os: macos-latest
-            clippy-features: "--features metal"
-          - os: windows-latest
-            clippy-features: ""
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -30,21 +20,48 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          # Install components needed for linting and formatting
           components: rustfmt, clippy
 
       - name: Cache Cargo dependencies
-        # Use a dedicated action for caching Rust projects
         uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Run Clippy linter
-        # Run clippy on all workspace members with warnings-as-errors
+      - name: Run common Clippy lints
         run: |
           cargo clippy --all-targets --all -- -D warnings
-          cargo clippy --all-targets -p oar-ocr-vl ${{ matrix.clippy-features }} -- -D warnings
+          cargo clippy --all-targets -p oar-ocr-vl -- -D warnings
+
+  test:
+    name: Test (${{ matrix.os }})
+    needs: preflight
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            vl_feature_check: ""
+          - os: macos-latest
+            vl_feature_check: "--features metal"
+          - os: windows-latest
+            vl_feature_check: ""
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run platform-specific Clippy lints
+        if: matrix.vl_feature_check != ''
+        run: cargo clippy --all-targets -p oar-ocr-vl ${{ matrix.vl_feature_check }} -- -D warnings
 
       - name: Run tests in debug mode
         run: cargo test --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "0.6.3"
 edition = "2024"
+rust-version = "1.95"
 license = "Apache-2.0"
 authors = ["Wang Xin <xinwang614@gmail.com>"]
 repository = "https://github.com/greatv/oar-ocr"
@@ -18,6 +19,7 @@ oar-ocr-derive = { version = "0.6.3", path = "oar-ocr-derive", default-features 
 name = "oar-ocr"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/oar-ocr-core/Cargo.toml
+++ b/oar-ocr-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oar-ocr-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/oar-ocr-core/src/core/traits/task.rs
+++ b/oar-ocr-core/src/core/traits/task.rs
@@ -8,6 +8,7 @@ use crate::core::OCRError;
 use image::RgbImage;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use std::sync::Arc;
 
 // Generate TaskType enum from the central task registry
 crate::with_task_registry!(crate::impl_task_type_enum);
@@ -155,7 +156,7 @@ impl<T: Task> TaskRunner<T> {
 #[derive(Debug, Clone)]
 pub struct ImageTaskInput {
     /// Input images
-    pub images: Vec<RgbImage>,
+    pub images: Vec<Arc<RgbImage>>,
     /// Optional metadata per image
     pub metadata: Vec<Option<String>>,
 }
@@ -165,6 +166,15 @@ impl ImageTaskInput {
     pub fn new(images: Vec<RgbImage>) -> Self {
         let count = images.len();
         Self {
+            images: images.into_iter().map(Arc::new).collect(),
+            metadata: vec![None; count],
+        }
+    }
+
+    /// Creates a new image task input from shared images.
+    pub fn from_arc_images(images: Vec<Arc<RgbImage>>) -> Self {
+        let count = images.len();
+        Self {
             images,
             metadata: vec![None; count],
         }
@@ -172,13 +182,28 @@ impl ImageTaskInput {
 
     /// Creates a new image task input with metadata.
     pub fn with_metadata(images: Vec<RgbImage>, metadata: Vec<Option<String>>) -> Self {
-        Self { images, metadata }
+        Self {
+            images: images.into_iter().map(Arc::new).collect(),
+            metadata,
+        }
+    }
+
+    /// Converts shared images into owned images for model APIs that still take ownership.
+    ///
+    /// This avoids a copy when the image is uniquely owned and clones only when another
+    /// pipeline stage still holds the same image.
+    pub fn into_owned_images(self) -> Vec<RgbImage> {
+        self.images
+            .into_iter()
+            .map(|img| Arc::try_unwrap(img).unwrap_or_else(|img| (*img).clone()))
+            .collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[test]
     fn test_task_type_name() {
@@ -225,5 +250,32 @@ mod tests {
         assert_eq!(input.images.len(), 2);
         assert_eq!(input.metadata.len(), 2);
         assert!(input.metadata.iter().all(|m| m.is_none()));
+    }
+
+    #[test]
+    fn test_into_owned_images_reuses_unique_arc() {
+        let mut image = RgbImage::new(2, 1);
+        image.put_pixel(0, 0, image::Rgb([1, 2, 3]));
+        let input = ImageTaskInput::from_arc_images(vec![Arc::new(image)]);
+
+        let owned = input.into_owned_images();
+
+        assert_eq!(owned.len(), 1);
+        assert_eq!(owned[0].get_pixel(0, 0).0, [1, 2, 3]);
+    }
+
+    #[test]
+    fn test_into_owned_images_clones_when_arc_is_shared() {
+        let mut image = RgbImage::new(2, 1);
+        image.put_pixel(1, 0, image::Rgb([9, 8, 7]));
+        let shared = Arc::new(image);
+        let input = ImageTaskInput::from_arc_images(vec![Arc::clone(&shared)]);
+
+        let owned = input.into_owned_images();
+
+        assert_eq!(Arc::strong_count(&shared), 1);
+        assert_eq!(owned.len(), 1);
+        assert_eq!(owned[0].get_pixel(1, 0).0, [9, 8, 7]);
+        assert_eq!(shared.get_pixel(1, 0).0, [9, 8, 7]);
     }
 }

--- a/oar-ocr-core/src/domain/adapters/document_orientation_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/document_orientation_adapter.rs
@@ -79,7 +79,7 @@ impl ModelAdapter for DocumentOrientationAdapter {
         // Use model to get predictions with error context
         let model_output = self
             .model
-            .forward(input.images, &postprocess_config)
+            .forward(input.into_owned_images(), &postprocess_config)
             .map_err(|e| {
                 OCRError::adapter_execution_error(
                     "DocumentOrientationAdapter",

--- a/oar-ocr-core/src/domain/adapters/document_rectification_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/document_rectification_adapter.rs
@@ -37,7 +37,7 @@ impl ModelAdapter for UVDocRectifierAdapter {
     ) -> Result<<Self::Task as Task>::Output, OCRError> {
         let batch_len = input.images.len();
         // Use the UVDoc model to rectify images
-        let model_output = self.model.forward(input.images).map_err(|e| {
+        let model_output = self.model.forward(input.into_owned_images()).map_err(|e| {
             OCRError::adapter_execution_error(
                 "UVDocRectifierAdapter",
                 format!("model forward (batch_size={})", batch_len),

--- a/oar-ocr-core/src/domain/adapters/formula_recognition_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/formula_recognition_adapter.rs
@@ -172,13 +172,16 @@ impl ModelAdapter for FormulaRecognitionAdapter {
         let batch_len = input.images.len();
 
         // Preprocess and infer
-        let batch_tensor = self.model.preprocess(input.images).map_err(|e| {
-            OCRError::adapter_execution_error(
-                "FormulaRecognitionAdapter",
-                format!("preprocess (batch_size={})", batch_len),
-                e,
-            )
-        })?;
+        let batch_tensor = self
+            .model
+            .preprocess(input.into_owned_images())
+            .map_err(|e| {
+                OCRError::adapter_execution_error(
+                    "FormulaRecognitionAdapter",
+                    format!("preprocess (batch_size={})", batch_len),
+                    e,
+                )
+            })?;
         let token_ids = self.model.infer(&batch_tensor).map_err(|e| {
             OCRError::adapter_execution_error(
                 "FormulaRecognitionAdapter",

--- a/oar-ocr-core/src/domain/adapters/layout_detection_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/layout_detection_adapter.rs
@@ -1119,6 +1119,7 @@ impl ModelAdapter for LayoutDetectionAdapter {
         // Use provided config or fall back to stored config
         let effective_config = config.unwrap_or(&self.config);
         let batch_len = input.images.len();
+        let images = input.into_owned_images();
 
         // Run model-specific forward pass
         let (predictions, img_shapes) = match &self.model {
@@ -1126,9 +1127,8 @@ impl ModelAdapter for LayoutDetectionAdapter {
                 let postprocess_config = PicoDetPostprocessConfig {
                     num_classes: self.model_config.num_classes,
                 };
-                let (output, img_shapes) = model
-                    .forward(input.images.clone(), &postprocess_config)
-                    .map_err(|e| {
+                let (output, img_shapes) =
+                    model.forward(images, &postprocess_config).map_err(|e| {
                         OCRError::adapter_execution_error(
                             "LayoutDetectionAdapter",
                             format!("PicoDet forward (batch_size={})", batch_len),
@@ -1141,9 +1141,8 @@ impl ModelAdapter for LayoutDetectionAdapter {
                 let postprocess_config = RTDetrPostprocessConfig {
                     num_classes: self.model_config.num_classes,
                 };
-                let (output, img_shapes) = model
-                    .forward(input.images.clone(), &postprocess_config)
-                    .map_err(|e| {
+                let (output, img_shapes) =
+                    model.forward(images, &postprocess_config).map_err(|e| {
                         OCRError::adapter_execution_error(
                             "LayoutDetectionAdapter",
                             format!("RTDetr forward (batch_size={})", batch_len),
@@ -1156,9 +1155,8 @@ impl ModelAdapter for LayoutDetectionAdapter {
                 let postprocess_config = PPDocLayoutPostprocessConfig {
                     num_classes: self.model_config.num_classes,
                 };
-                let (output, img_shapes) = model
-                    .forward(input.images, &postprocess_config)
-                    .map_err(|e| {
+                let (output, img_shapes) =
+                    model.forward(images, &postprocess_config).map_err(|e| {
                         tracing::error!("PPDocLayout forward error: {:?}", e);
                         OCRError::adapter_execution_error(
                             "LayoutDetectionAdapter",

--- a/oar-ocr-core/src/domain/adapters/seal_text_detection_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/seal_text_detection_adapter.rs
@@ -54,7 +54,7 @@ impl ModelAdapter for SealTextDetectionAdapter {
         // Use the DB model to detect seal text with error context
         let model_output = self.model
             .forward(
-                input.images,
+                input.into_owned_images(),
                 effective_config.score_threshold,
                 effective_config.box_threshold,
                 effective_config.unclip_ratio,

--- a/oar-ocr-core/src/domain/adapters/table_cell_detection_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/table_cell_detection_adapter.rs
@@ -154,7 +154,7 @@ impl ModelAdapter for TableCellDetectionAdapter {
                     num_classes: self.model_config.num_classes,
                 };
                 let (output, img_shapes) = model
-                    .forward(input.images, &postprocess_config)
+                    .forward(input.into_owned_images(), &postprocess_config)
                     .map_err(|e| {
                         OCRError::adapter_execution_error(
                             "TableCellDetectionAdapter",

--- a/oar-ocr-core/src/domain/adapters/table_classification_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/table_classification_adapter.rs
@@ -74,7 +74,7 @@ impl ModelAdapter for TableClassificationAdapter {
         // Use model to get predictions with error context
         let model_output = self
             .model
-            .forward(input.images, &postprocess_config)
+            .forward(input.into_owned_images(), &postprocess_config)
             .map_err(|e| {
                 OCRError::adapter_execution_error(
                     "TableClassificationAdapter",

--- a/oar-ocr-core/src/domain/adapters/table_structure_recognition_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/table_structure_recognition_adapter.rs
@@ -78,7 +78,7 @@ impl ModelAdapter for TableStructureRecognitionAdapter {
         tracing::debug!("Processing {} table images", num_images);
 
         // Run model forward pass on all images
-        let model_output = self.model.forward(input.images).map_err(|e| {
+        let model_output = self.model.forward(input.into_owned_images()).map_err(|e| {
             OCRError::adapter_execution_error(
                 "TableStructureRecognitionAdapter",
                 format!("model forward (batch_size={})", num_images),

--- a/oar-ocr-core/src/domain/adapters/text_detection_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/text_detection_adapter.rs
@@ -43,7 +43,7 @@ impl ModelAdapter for TextDetectionAdapter {
         // Use the DB model to detect text with error context
         let model_output = self.model
             .forward(
-                input.images,
+                input.into_owned_images(),
                 effective_config.score_threshold,
                 effective_config.box_threshold,
                 effective_config.unclip_ratio,

--- a/oar-ocr-core/src/domain/adapters/text_line_orientation_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/text_line_orientation_adapter.rs
@@ -74,7 +74,7 @@ impl ModelAdapter for TextLineOrientationAdapter {
         // Use model to get predictions with error context
         let model_output = self
             .model
-            .forward(input.images, &postprocess_config)
+            .forward(input.into_owned_images(), &postprocess_config)
             .map_err(|e| {
                 OCRError::adapter_execution_error(
                     "TextLineOrientationAdapter",

--- a/oar-ocr-core/src/domain/adapters/text_recognition_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/text_recognition_adapter.rs
@@ -43,7 +43,7 @@ impl ModelAdapter for TextRecognitionAdapter {
         // Use the CRNN model to recognize text
         let model_output = self
             .model
-            .forward(input.images, self.return_word_box)
+            .forward(input.into_owned_images(), self.return_word_box)
             .map_err(|e| {
                 OCRError::adapter_execution_error(
                     "TextRecognitionAdapter",

--- a/oar-ocr-core/src/domain/tasks/validation.rs
+++ b/oar-ocr-core/src/domain/tasks/validation.rs
@@ -5,10 +5,11 @@
 
 use crate::core::OCRError;
 use image::RgbImage;
+use std::borrow::Borrow;
 
 /// Ensures an image batch is non-empty and each image has positive dimensions.
 pub(crate) fn ensure_non_empty_images(
-    images: &[RgbImage],
+    images: &[impl Borrow<RgbImage>],
     empty_batch_message: &str,
 ) -> Result<(), OCRError> {
     ensure_images_with(images, empty_batch_message, |idx, width, height| {
@@ -20,7 +21,7 @@ pub(crate) fn ensure_non_empty_images(
 
 /// Generic helper for validating non-empty RgbImage collections with custom error messaging.
 pub(crate) fn ensure_images_with(
-    images: &[RgbImage],
+    images: &[impl Borrow<RgbImage>],
     empty_batch_message: &str,
     zero_dim_message: impl Fn(usize, u32, u32) -> String,
 ) -> Result<(), OCRError> {
@@ -31,6 +32,7 @@ pub(crate) fn ensure_images_with(
     }
 
     for (idx, img) in images.iter().enumerate() {
+        let img = img.borrow();
         let (width, height) = (img.width(), img.height());
         if width == 0 || height == 0 {
             return Err(OCRError::InvalidInput {

--- a/oar-ocr-core/src/processors/normalization.rs
+++ b/oar-ocr-core/src/processors/normalization.rs
@@ -33,6 +33,17 @@ impl NormalizeImage {
         batch_size > 1 && total_output_bytes > Self::PARALLEL_NORMALIZE_MIN_BYTES
     }
 
+    fn src_channels(&self) -> [usize; 3] {
+        match self.color_order {
+            ColorOrder::RGB => [0, 1, 2],
+            ColorOrder::BGR => [2, 1, 0],
+        }
+    }
+
+    fn image_len(width: u32, height: u32, channels: usize) -> usize {
+        width as usize * height as usize * channels
+    }
+
     /// Creates a new NormalizeImage instance with the specified parameters.
     ///
     /// # Arguments
@@ -463,50 +474,29 @@ impl NormalizeImage {
 
     fn normalize_rgb(&self, rgb_img: &RgbImage) -> Vec<f32> {
         let (width, height) = rgb_img.dimensions();
-        let channels = 3;
-
-        // Map channel index based on color order
-        // RGB: c=0->R, c=1->G, c=2->B (same as pixel layout)
-        // BGR: c=0->B, c=1->G, c=2->R (swap R and B)
-        let map_channel = |c: u32| -> usize {
-            match self.color_order {
-                ColorOrder::RGB => c as usize,
-                ColorOrder::BGR => match c {
-                    0 => 2, // B -> pixel[2]
-                    1 => 1, // G -> pixel[1]
-                    2 => 0, // R -> pixel[0]
-                    _ => c as usize,
-                },
-            }
-        };
-
-        let mut result = vec![0.0f32; (channels * height * width) as usize];
+        let channels = 3usize;
+        let src_channels = self.src_channels();
+        let mut result = vec![0.0f32; Self::image_len(width, height, channels)];
 
         match self.order {
             TensorLayout::CHW => {
-                let plane = (height * width) as usize;
-                for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
-                    for c in 0..channels {
-                        let src_c = map_channel(c);
-                        let channel_value = pixel[src_c] as f32;
-                        let dst_idx = c as usize * plane + pixel_idx;
-
-                        result[dst_idx] =
-                            channel_value * self.alpha[c as usize] + self.beta[c as usize];
+                let plane = width as usize * height as usize;
+                for c in 0..channels {
+                    let src_c = src_channels[c];
+                    let plane_offset = c * plane;
+                    for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
+                        result[plane_offset + pixel_idx] =
+                            pixel[src_c] as f32 * self.alpha[c] + self.beta[c];
                     }
                 }
                 result
             }
             TensorLayout::HWC => {
                 for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
-                    let dst_base = pixel_idx * channels as usize;
+                    let dst_base = pixel_idx * channels;
                     for c in 0..channels {
-                        let src_c = map_channel(c);
-                        let channel_value = pixel[src_c] as f32;
-                        let dst_idx = dst_base + c as usize;
-
-                        result[dst_idx] =
-                            channel_value * self.alpha[c as usize] + self.beta[c as usize];
+                        let src_c = src_channels[c];
+                        result[dst_base + c] = pixel[src_c] as f32 * self.alpha[c] + self.beta[c];
                     }
                 }
                 result
@@ -526,21 +516,22 @@ impl NormalizeImage {
     pub fn normalize_to(&self, img: DynamicImage) -> Result<ndarray::Array4<f32>, OCRError> {
         let rgb_img = into_rgb8_no_copy(img);
         let (width, height) = rgb_img.dimensions();
-        let channels = 3;
+        let channels = 3usize;
+        let image_len = Self::image_len(width, height, channels);
 
         match self.order {
             TensorLayout::CHW => {
                 let result = self.normalize_rgb(&rgb_img);
 
                 ndarray::Array4::from_shape_vec(
-                    (1, channels as usize, height as usize, width as usize),
+                    (1, channels, height as usize, width as usize),
                     result,
                 )
                 .map_err(|e| {
                     OCRError::tensor_operation_error(
                         "normalization_tensor_creation_chw",
-                        &[1, channels as usize, height as usize, width as usize],
-                        &[(channels * height * width) as usize],
+                        &[1, channels, height as usize, width as usize],
+                        &[image_len],
                         &format!("Failed to create CHW normalization tensor for {}x{} image with {} channels",
                             width, height, channels),
                         e,
@@ -551,14 +542,14 @@ impl NormalizeImage {
                 let result = self.normalize_rgb(&rgb_img);
 
                 ndarray::Array4::from_shape_vec(
-                    (1, height as usize, width as usize, channels as usize),
+                    (1, height as usize, width as usize, channels),
                     result,
                 )
                 .map_err(|e| {
                     OCRError::tensor_operation_error(
                         "normalization_tensor_creation_hwc",
-                        &[1, height as usize, width as usize, channels as usize],
-                        &[(height * width * channels) as usize],
+                        &[1, height as usize, width as usize, channels],
+                        &[image_len],
                         &format!("Failed to create HWC normalization tensor for {}x{} image with {} channels",
                             width, height, channels),
                         e,
@@ -607,14 +598,9 @@ impl NormalizeImage {
         }
 
         let (width, height) = (first_width, first_height);
-        let channels = 3u32;
+        let channels = 3usize;
 
-        // Pre-compute channel mapping for BGR support
-        // src_channels[c] gives the source pixel index for output channel c
-        let src_channels: [usize; 3] = match self.color_order {
-            ColorOrder::RGB => [0, 1, 2],
-            ColorOrder::BGR => [2, 1, 0], // B from pixel[2], G from pixel[1], R from pixel[0]
-        };
+        let src_channels = self.src_channels();
 
         // Clone alpha/beta for parallel closure
         let alpha = self.alpha.clone();
@@ -622,9 +608,10 @@ impl NormalizeImage {
 
         match self.order {
             TensorLayout::CHW => {
-                let mut result = vec![0.0f32; batch_size * (channels * height * width) as usize];
+                let img_size = Self::image_len(width, height, channels);
+                let plane = width as usize * height as usize;
+                let mut result = vec![0.0f32; batch_size * img_size];
 
-                let img_size = (channels * height * width) as usize;
                 // The threshold is based on total output size for the whole batch rather than
                 // per-image size. This keeps tiny batches serial even when the batch has multiple
                 // images, and avoids rayon overhead for common OCR crops.
@@ -635,15 +622,11 @@ impl NormalizeImage {
                         let batch_offset = batch_idx * img_size;
                         let batch_slice = &mut result[batch_offset..batch_offset + img_size];
                         for c in 0..channels {
-                            let src_c = src_channels[c as usize];
-                            for y in 0..height {
-                                for x in 0..width {
-                                    let pixel = rgb_img.get_pixel(x, y);
-                                    let channel_value = pixel[src_c] as f32;
-                                    let dst_idx = (c * height * width + y * width + x) as usize;
-                                    batch_slice[dst_idx] =
-                                        channel_value * alpha[c as usize] + beta[c as usize];
-                                }
+                            let src_c = src_channels[c];
+                            let plane_offset = c * plane;
+                            for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
+                                batch_slice[plane_offset + pixel_idx] =
+                                    pixel[src_c] as f32 * alpha[c] + beta[c];
                             }
                         }
                     }
@@ -652,15 +635,11 @@ impl NormalizeImage {
                         |(batch_idx, batch_slice)| {
                             let rgb_img = &rgb_imgs[batch_idx];
                             for c in 0..channels {
-                                let src_c = src_channels[c as usize];
-                                for y in 0..height {
-                                    for x in 0..width {
-                                        let pixel = rgb_img.get_pixel(x, y);
-                                        let channel_value = pixel[src_c] as f32;
-                                        let dst_idx = (c * height * width + y * width + x) as usize;
-                                        batch_slice[dst_idx] =
-                                            channel_value * alpha[c as usize] + beta[c as usize];
-                                    }
+                                let src_c = src_channels[c];
+                                let plane_offset = c * plane;
+                                for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
+                                    batch_slice[plane_offset + pixel_idx] =
+                                        pixel[src_c] as f32 * alpha[c] + beta[c];
                                 }
                             }
                         },
@@ -668,12 +647,7 @@ impl NormalizeImage {
                 }
 
                 ndarray::Array4::from_shape_vec(
-                    (
-                        batch_size,
-                        channels as usize,
-                        height as usize,
-                        width as usize,
-                    ),
+                    (batch_size, channels, height as usize, width as usize),
                     result,
                 )
                 .map_err(|e| {
@@ -684,9 +658,9 @@ impl NormalizeImage {
                 })
             }
             TensorLayout::HWC => {
-                let mut result = vec![0.0f32; batch_size * (height * width * channels) as usize];
+                let img_size = Self::image_len(width, height, channels);
+                let mut result = vec![0.0f32; batch_size * img_size];
 
-                let img_size = (height * width * channels) as usize;
                 // Match the CHW path: parallelism is gated by total batch output size so that
                 // small OCR crops stay serial unless the batch is large enough to amortize rayon.
                 let use_parallel =
@@ -695,17 +669,12 @@ impl NormalizeImage {
                     for (batch_idx, rgb_img) in rgb_imgs.iter().enumerate() {
                         let batch_offset = batch_idx * img_size;
                         let batch_slice = &mut result[batch_offset..batch_offset + img_size];
-                        for y in 0..height {
-                            for x in 0..width {
-                                let pixel = rgb_img.get_pixel(x, y);
-                                for c in 0..channels {
-                                    let src_c = src_channels[c as usize];
-                                    let channel_value = pixel[src_c] as f32;
-                                    let dst_idx =
-                                        (y * width * channels + x * channels + c) as usize;
-                                    batch_slice[dst_idx] =
-                                        channel_value * alpha[c as usize] + beta[c as usize];
-                                }
+                        for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
+                            let dst_base = pixel_idx * channels;
+                            for c in 0..channels {
+                                let src_c = src_channels[c];
+                                batch_slice[dst_base + c] =
+                                    pixel[src_c] as f32 * alpha[c] + beta[c];
                             }
                         }
                     }
@@ -713,17 +682,12 @@ impl NormalizeImage {
                     result.par_chunks_mut(img_size).enumerate().for_each(
                         |(batch_idx, batch_slice)| {
                             let rgb_img = &rgb_imgs[batch_idx];
-                            for y in 0..height {
-                                for x in 0..width {
-                                    let pixel = rgb_img.get_pixel(x, y);
-                                    for c in 0..channels {
-                                        let src_c = src_channels[c as usize];
-                                        let channel_value = pixel[src_c] as f32;
-                                        let dst_idx =
-                                            (y * width * channels + x * channels + c) as usize;
-                                        batch_slice[dst_idx] =
-                                            channel_value * alpha[c as usize] + beta[c as usize];
-                                    }
+                            for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
+                                let dst_base = pixel_idx * channels;
+                                for c in 0..channels {
+                                    let src_c = src_channels[c];
+                                    batch_slice[dst_base + c] =
+                                        pixel[src_c] as f32 * alpha[c] + beta[c];
                                 }
                             }
                         },
@@ -731,12 +695,7 @@ impl NormalizeImage {
                 }
 
                 ndarray::Array4::from_shape_vec(
-                    (
-                        batch_size,
-                        height as usize,
-                        width as usize,
-                        channels as usize,
-                    ),
+                    (batch_size, height as usize, width as usize, channels),
                     result,
                 )
                 .map_err(|e| {

--- a/oar-ocr-core/src/processors/normalization.rs
+++ b/oar-ocr-core/src/processors/normalization.rs
@@ -481,10 +481,9 @@ impl NormalizeImage {
         match self.order {
             TensorLayout::CHW => {
                 let plane = width as usize * height as usize;
-                for (c, &src_c) in src_channels.iter().enumerate() {
-                    let plane_offset = c * plane;
-                    for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
-                        result[plane_offset + pixel_idx] =
+                for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
+                    for (c, &src_c) in src_channels.iter().enumerate() {
+                        result[c * plane + pixel_idx] =
                             pixel[src_c] as f32 * self.alpha[c] + self.beta[c];
                     }
                 }
@@ -619,10 +618,9 @@ impl NormalizeImage {
                     for (batch_idx, rgb_img) in rgb_imgs.iter().enumerate() {
                         let batch_offset = batch_idx * img_size;
                         let batch_slice = &mut result[batch_offset..batch_offset + img_size];
-                        for (c, &src_c) in src_channels.iter().enumerate() {
-                            let plane_offset = c * plane;
-                            for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
-                                batch_slice[plane_offset + pixel_idx] =
+                        for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
+                            for (c, &src_c) in src_channels.iter().enumerate() {
+                                batch_slice[c * plane + pixel_idx] =
                                     pixel[src_c] as f32 * alpha[c] + beta[c];
                             }
                         }
@@ -631,10 +629,9 @@ impl NormalizeImage {
                     result.par_chunks_mut(img_size).enumerate().for_each(
                         |(batch_idx, batch_slice)| {
                             let rgb_img = &rgb_imgs[batch_idx];
-                            for (c, &src_c) in src_channels.iter().enumerate() {
-                                let plane_offset = c * plane;
-                                for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
-                                    batch_slice[plane_offset + pixel_idx] =
+                            for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
+                                for (c, &src_c) in src_channels.iter().enumerate() {
+                                    batch_slice[c * plane + pixel_idx] =
                                         pixel[src_c] as f32 * alpha[c] + beta[c];
                                 }
                             }
@@ -844,6 +841,61 @@ mod tests {
                 expected.index_axis(Axis(0), 0)
             );
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_normalize_batch_to_preserves_batch_and_layout_semantics() -> Result<(), OCRError> {
+        let chw = NormalizeImage::with_color_order(
+            Some(1.0),
+            Some(vec![0.0, 0.0, 0.0]),
+            Some(vec![1.0, 1.0, 1.0]),
+            Some(TensorLayout::CHW),
+            Some(ColorOrder::RGB),
+        )?;
+        let hwc = NormalizeImage::with_color_order(
+            Some(1.0),
+            Some(vec![0.0, 0.0, 0.0]),
+            Some(vec![1.0, 1.0, 1.0]),
+            Some(TensorLayout::HWC),
+            Some(ColorOrder::RGB),
+        )?;
+
+        let img_a = RgbImage::from_fn(2, 2, |x, y| {
+            let base = (y * 2 + x) as u8 * 3 + 1;
+            Rgb([base, base + 1, base + 2])
+        });
+        let img_b = RgbImage::from_fn(2, 2, |x, y| {
+            let base = (y * 2 + x) as u8 * 3 + 21;
+            Rgb([base, base + 1, base + 2])
+        });
+
+        let chw_batch = chw.normalize_batch_to(vec![
+            DynamicImage::ImageRgb8(img_a.clone()),
+            DynamicImage::ImageRgb8(img_b.clone()),
+        ])?;
+        assert_eq!(chw_batch.shape(), &[2, 3, 2, 2]);
+        assert_eq!(
+            chw_batch.iter().copied().collect::<Vec<_>>(),
+            vec![
+                1.0, 4.0, 7.0, 10.0, 2.0, 5.0, 8.0, 11.0, 3.0, 6.0, 9.0, 12.0, 21.0, 24.0, 27.0,
+                30.0, 22.0, 25.0, 28.0, 31.0, 23.0, 26.0, 29.0, 32.0,
+            ]
+        );
+
+        let hwc_batch = hwc.normalize_batch_to(vec![
+            DynamicImage::ImageRgb8(img_a),
+            DynamicImage::ImageRgb8(img_b),
+        ])?;
+        assert_eq!(hwc_batch.shape(), &[2, 2, 2, 3]);
+        assert_eq!(
+            hwc_batch.iter().copied().collect::<Vec<_>>(),
+            vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 21.0, 22.0, 23.0,
+                24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0,
+            ]
+        );
 
         Ok(())
     }

--- a/oar-ocr-core/src/processors/normalization.rs
+++ b/oar-ocr-core/src/processors/normalization.rs
@@ -481,8 +481,7 @@ impl NormalizeImage {
         match self.order {
             TensorLayout::CHW => {
                 let plane = width as usize * height as usize;
-                for c in 0..channels {
-                    let src_c = src_channels[c];
+                for (c, &src_c) in src_channels.iter().enumerate() {
                     let plane_offset = c * plane;
                     for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
                         result[plane_offset + pixel_idx] =
@@ -494,8 +493,7 @@ impl NormalizeImage {
             TensorLayout::HWC => {
                 for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
                     let dst_base = pixel_idx * channels;
-                    for c in 0..channels {
-                        let src_c = src_channels[c];
+                    for (c, &src_c) in src_channels.iter().enumerate() {
                         result[dst_base + c] = pixel[src_c] as f32 * self.alpha[c] + self.beta[c];
                     }
                 }
@@ -621,8 +619,7 @@ impl NormalizeImage {
                     for (batch_idx, rgb_img) in rgb_imgs.iter().enumerate() {
                         let batch_offset = batch_idx * img_size;
                         let batch_slice = &mut result[batch_offset..batch_offset + img_size];
-                        for c in 0..channels {
-                            let src_c = src_channels[c];
+                        for (c, &src_c) in src_channels.iter().enumerate() {
                             let plane_offset = c * plane;
                             for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
                                 batch_slice[plane_offset + pixel_idx] =
@@ -634,8 +631,7 @@ impl NormalizeImage {
                     result.par_chunks_mut(img_size).enumerate().for_each(
                         |(batch_idx, batch_slice)| {
                             let rgb_img = &rgb_imgs[batch_idx];
-                            for c in 0..channels {
-                                let src_c = src_channels[c];
+                            for (c, &src_c) in src_channels.iter().enumerate() {
                                 let plane_offset = c * plane;
                                 for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
                                     batch_slice[plane_offset + pixel_idx] =
@@ -671,8 +667,7 @@ impl NormalizeImage {
                         let batch_slice = &mut result[batch_offset..batch_offset + img_size];
                         for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
                             let dst_base = pixel_idx * channels;
-                            for c in 0..channels {
-                                let src_c = src_channels[c];
+                            for (c, &src_c) in src_channels.iter().enumerate() {
                                 batch_slice[dst_base + c] =
                                     pixel[src_c] as f32 * alpha[c] + beta[c];
                             }
@@ -684,8 +679,7 @@ impl NormalizeImage {
                             let rgb_img = &rgb_imgs[batch_idx];
                             for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
                                 let dst_base = pixel_idx * channels;
-                                for c in 0..channels {
-                                    let src_c = src_channels[c];
+                                for (c, &src_c) in src_channels.iter().enumerate() {
                                     batch_slice[dst_base + c] =
                                         pixel[src_c] as f32 * alpha[c] + beta[c];
                                 }

--- a/oar-ocr-core/src/processors/normalization.rs
+++ b/oar-ocr-core/src/processors/normalization.rs
@@ -6,7 +6,7 @@
 
 use crate::core::OCRError;
 use crate::processors::types::{ColorOrder, TensorLayout};
-use image::DynamicImage;
+use image::{DynamicImage, RgbImage};
 use rayon::prelude::*;
 
 /// Normalizes images for OCR processing.
@@ -27,6 +27,12 @@ pub struct NormalizeImage {
 }
 
 impl NormalizeImage {
+    const PARALLEL_NORMALIZE_MIN_BYTES: usize = 1_048_576;
+
+    fn should_parallelize(batch_size: usize, total_output_bytes: usize) -> bool {
+        batch_size > 1 && total_output_bytes > Self::PARALLEL_NORMALIZE_MIN_BYTES
+    }
+
     /// Creates a new NormalizeImage instance with the specified parameters.
     ///
     /// # Arguments
@@ -451,7 +457,11 @@ impl NormalizeImage {
     ///
     /// A vector of normalized pixel values as f32
     fn normalize(&self, img: DynamicImage) -> Vec<f32> {
-        let rgb_img = img.to_rgb8();
+        let rgb_img = into_rgb8_no_copy(img);
+        self.normalize_rgb(&rgb_img)
+    }
+
+    fn normalize_rgb(&self, rgb_img: &RgbImage) -> Vec<f32> {
         let (width, height) = rgb_img.dimensions();
         let channels = 3;
 
@@ -470,39 +480,33 @@ impl NormalizeImage {
             }
         };
 
+        let mut result = vec![0.0f32; (channels * height * width) as usize];
+
         match self.order {
             TensorLayout::CHW => {
-                let mut result = vec![0.0f32; (channels * height * width) as usize];
+                let plane = (height * width) as usize;
+                for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
+                    for c in 0..channels {
+                        let src_c = map_channel(c);
+                        let channel_value = pixel[src_c] as f32;
+                        let dst_idx = c as usize * plane + pixel_idx;
 
-                for c in 0..channels {
-                    let src_c = map_channel(c);
-                    for y in 0..height {
-                        for x in 0..width {
-                            let pixel = rgb_img.get_pixel(x, y);
-                            let channel_value = pixel[src_c] as f32;
-                            let dst_idx = (c * height * width + y * width + x) as usize;
-
-                            result[dst_idx] =
-                                channel_value * self.alpha[c as usize] + self.beta[c as usize];
-                        }
+                        result[dst_idx] =
+                            channel_value * self.alpha[c as usize] + self.beta[c as usize];
                     }
                 }
                 result
             }
             TensorLayout::HWC => {
-                let mut result = vec![0.0f32; (height * width * channels) as usize];
+                for (pixel_idx, pixel) in rgb_img.pixels().enumerate() {
+                    let dst_base = pixel_idx * channels as usize;
+                    for c in 0..channels {
+                        let src_c = map_channel(c);
+                        let channel_value = pixel[src_c] as f32;
+                        let dst_idx = dst_base + c as usize;
 
-                for y in 0..height {
-                    for x in 0..width {
-                        let pixel = rgb_img.get_pixel(x, y);
-                        for c in 0..channels {
-                            let src_c = map_channel(c);
-                            let channel_value = pixel[src_c] as f32;
-                            let dst_idx = (y * width * channels + x * channels + c) as usize;
-
-                            result[dst_idx] =
-                                channel_value * self.alpha[c as usize] + self.beta[c as usize];
-                        }
+                        result[dst_idx] =
+                            channel_value * self.alpha[c as usize] + self.beta[c as usize];
                     }
                 }
                 result
@@ -520,40 +524,13 @@ impl NormalizeImage {
     ///
     /// A Result containing the normalized image as a 4D tensor or an OCRError.
     pub fn normalize_to(&self, img: DynamicImage) -> Result<ndarray::Array4<f32>, OCRError> {
-        let rgb_img = img.to_rgb8();
+        let rgb_img = into_rgb8_no_copy(img);
         let (width, height) = rgb_img.dimensions();
         let channels = 3;
 
-        // Map channel index based on color order
-        let map_channel = |c: u32| -> usize {
-            match self.color_order {
-                ColorOrder::RGB => c as usize,
-                ColorOrder::BGR => match c {
-                    0 => 2,
-                    1 => 1,
-                    2 => 0,
-                    _ => c as usize,
-                },
-            }
-        };
-
         match self.order {
             TensorLayout::CHW => {
-                let mut result = vec![0.0f32; (channels * height * width) as usize];
-
-                for c in 0..channels {
-                    let src_c = map_channel(c);
-                    for y in 0..height {
-                        for x in 0..width {
-                            let pixel = rgb_img.get_pixel(x, y);
-                            let channel_value = pixel[src_c] as f32;
-                            let dst_idx = (c * height * width + y * width + x) as usize;
-
-                            result[dst_idx] =
-                                channel_value * self.alpha[c as usize] + self.beta[c as usize];
-                        }
-                    }
-                }
+                let result = self.normalize_rgb(&rgb_img);
 
                 ndarray::Array4::from_shape_vec(
                     (1, channels as usize, height as usize, width as usize),
@@ -571,21 +548,7 @@ impl NormalizeImage {
                 })
             }
             TensorLayout::HWC => {
-                let mut result = vec![0.0f32; (height * width * channels) as usize];
-
-                for y in 0..height {
-                    for x in 0..width {
-                        let pixel = rgb_img.get_pixel(x, y);
-                        for c in 0..channels {
-                            let src_c = map_channel(c);
-                            let channel_value = pixel[src_c] as f32;
-                            let dst_idx = (y * width * channels + x * channels + c) as usize;
-
-                            result[dst_idx] =
-                                channel_value * self.alpha[c as usize] + self.beta[c as usize];
-                        }
-                    }
-                }
+                let result = self.normalize_rgb(&rgb_img);
 
                 ndarray::Array4::from_shape_vec(
                     (1, height as usize, width as usize, channels as usize),
@@ -629,7 +592,7 @@ impl NormalizeImage {
 
         let batch_size = imgs.len();
 
-        let rgb_imgs: Vec<_> = imgs.into_iter().map(|img| img.to_rgb8()).collect();
+        let rgb_imgs: Vec<_> = imgs.into_iter().map(into_rgb8_no_copy).collect();
         let dimensions: Vec<_> = rgb_imgs.iter().map(|img| img.dimensions()).collect();
 
         let (first_width, first_height) = dimensions.first().copied().unwrap_or((0, 0));
@@ -662,19 +625,25 @@ impl NormalizeImage {
                 let mut result = vec![0.0f32; batch_size * (channels * height * width) as usize];
 
                 let img_size = (channels * height * width) as usize;
-                if batch_size == 1 {
-                    // Avoid rayon overhead for single-image batches
-                    let rgb_img = &rgb_imgs[0];
-                    let batch_slice = &mut result[0..img_size];
-                    for c in 0..channels {
-                        let src_c = src_channels[c as usize];
-                        for y in 0..height {
-                            for x in 0..width {
-                                let pixel = rgb_img.get_pixel(x, y);
-                                let channel_value = pixel[src_c] as f32;
-                                let dst_idx = (c * height * width + y * width + x) as usize;
-                                batch_slice[dst_idx] =
-                                    channel_value * alpha[c as usize] + beta[c as usize];
+                // The threshold is based on total output size for the whole batch rather than
+                // per-image size. This keeps tiny batches serial even when the batch has multiple
+                // images, and avoids rayon overhead for common OCR crops.
+                let use_parallel =
+                    Self::should_parallelize(batch_size, result.len() * std::mem::size_of::<f32>());
+                if !use_parallel {
+                    for (batch_idx, rgb_img) in rgb_imgs.iter().enumerate() {
+                        let batch_offset = batch_idx * img_size;
+                        let batch_slice = &mut result[batch_offset..batch_offset + img_size];
+                        for c in 0..channels {
+                            let src_c = src_channels[c as usize];
+                            for y in 0..height {
+                                for x in 0..width {
+                                    let pixel = rgb_img.get_pixel(x, y);
+                                    let channel_value = pixel[src_c] as f32;
+                                    let dst_idx = (c * height * width + y * width + x) as usize;
+                                    batch_slice[dst_idx] =
+                                        channel_value * alpha[c as usize] + beta[c as usize];
+                                }
                             }
                         }
                     }
@@ -718,19 +687,25 @@ impl NormalizeImage {
                 let mut result = vec![0.0f32; batch_size * (height * width * channels) as usize];
 
                 let img_size = (height * width * channels) as usize;
-                if batch_size == 1 {
-                    // Avoid rayon overhead for single-image batches
-                    let rgb_img = &rgb_imgs[0];
-                    let batch_slice = &mut result[0..img_size];
-                    for y in 0..height {
-                        for x in 0..width {
-                            let pixel = rgb_img.get_pixel(x, y);
-                            for c in 0..channels {
-                                let src_c = src_channels[c as usize];
-                                let channel_value = pixel[src_c] as f32;
-                                let dst_idx = (y * width * channels + x * channels + c) as usize;
-                                batch_slice[dst_idx] =
-                                    channel_value * alpha[c as usize] + beta[c as usize];
+                // Match the CHW path: parallelism is gated by total batch output size so that
+                // small OCR crops stay serial unless the batch is large enough to amortize rayon.
+                let use_parallel =
+                    Self::should_parallelize(batch_size, result.len() * std::mem::size_of::<f32>());
+                if !use_parallel {
+                    for (batch_idx, rgb_img) in rgb_imgs.iter().enumerate() {
+                        let batch_offset = batch_idx * img_size;
+                        let batch_slice = &mut result[batch_offset..batch_offset + img_size];
+                        for y in 0..height {
+                            for x in 0..width {
+                                let pixel = rgb_img.get_pixel(x, y);
+                                for c in 0..channels {
+                                    let src_c = src_channels[c as usize];
+                                    let channel_value = pixel[src_c] as f32;
+                                    let dst_idx =
+                                        (y * width * channels + x * channels + c) as usize;
+                                    batch_slice[dst_idx] =
+                                        channel_value * alpha[c as usize] + beta[c as usize];
+                                }
                             }
                         }
                     }
@@ -775,10 +750,18 @@ impl NormalizeImage {
     }
 }
 
+fn into_rgb8_no_copy(img: DynamicImage) -> RgbImage {
+    match img {
+        DynamicImage::ImageRgb8(img) => img,
+        img => img.to_rgb8(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use image::{Rgb, RgbImage};
+    use ndarray::Axis;
 
     #[test]
     fn test_normalize_image_color_order_rgb_vs_bgr_chw() -> Result<(), OCRError> {
@@ -835,6 +818,80 @@ mod tests {
 
         assert_eq!(rgb_out[0], vec![5.0, 5.0, 6.0]); // (R-1)/2, (G-2)/4, (B-3)/5
         assert_eq!(bgr_out[0], vec![6.0, 5.0, 5.0]); // (B-3)/5, (G-2)/4, (R-1)/2
+        Ok(())
+    }
+
+    #[test]
+    fn test_should_parallelize_threshold_behavior() {
+        assert!(!NormalizeImage::should_parallelize(
+            1,
+            NormalizeImage::PARALLEL_NORMALIZE_MIN_BYTES * 4,
+        ));
+        assert!(!NormalizeImage::should_parallelize(
+            4,
+            NormalizeImage::PARALLEL_NORMALIZE_MIN_BYTES,
+        ));
+        assert!(NormalizeImage::should_parallelize(
+            4,
+            NormalizeImage::PARALLEL_NORMALIZE_MIN_BYTES + 1,
+        ));
+    }
+
+    #[test]
+    fn test_normalize_batch_to_matches_single_image_paths_for_serial_and_parallel()
+    -> Result<(), OCRError> {
+        let normalizer = NormalizeImage::with_color_order(
+            Some(1.0),
+            Some(vec![0.0, 0.0, 0.0]),
+            Some(vec![1.0, 1.0, 1.0]),
+            Some(TensorLayout::CHW),
+            Some(ColorOrder::RGB),
+        )?;
+
+        let mut small_a = RgbImage::new(1, 1);
+        small_a.put_pixel(0, 0, Rgb([1, 2, 3]));
+        let mut small_b = RgbImage::new(1, 1);
+        small_b.put_pixel(0, 0, Rgb([4, 5, 6]));
+        let small_batch = vec![
+            DynamicImage::ImageRgb8(small_a.clone()),
+            DynamicImage::ImageRgb8(small_b.clone()),
+        ];
+        let serial = normalizer.normalize_batch_to(small_batch)?;
+        let serial_expected = [
+            normalizer.normalize_to(DynamicImage::ImageRgb8(small_a))?,
+            normalizer.normalize_to(DynamicImage::ImageRgb8(small_b))?,
+        ];
+
+        assert_eq!(serial.len_of(Axis(0)), serial_expected.len());
+        for (idx, expected) in serial_expected.iter().enumerate() {
+            assert_eq!(
+                serial.index_axis(Axis(0), idx).to_owned(),
+                expected.index_axis(Axis(0), 0)
+            );
+        }
+
+        let large_a =
+            RgbImage::from_fn(512, 512, |x, y| Rgb([(x % 251) as u8, (y % 241) as u8, 7]));
+        let large_b =
+            RgbImage::from_fn(512, 512, |x, y| Rgb([11, (x % 239) as u8, (y % 233) as u8]));
+        let parallel_batch = vec![
+            DynamicImage::ImageRgb8(large_a.clone()),
+            DynamicImage::ImageRgb8(large_b.clone()),
+        ];
+        let parallel = normalizer.normalize_batch_to(parallel_batch)?;
+        let parallel_expected = [
+            normalizer.normalize_to(DynamicImage::ImageRgb8(large_a))?,
+            normalizer.normalize_to(DynamicImage::ImageRgb8(large_b))?,
+        ];
+
+        assert_eq!(parallel.len_of(Axis(0)), parallel_expected.len());
+        for (idx, expected) in parallel_expected.iter().enumerate() {
+            assert_eq!(
+                parallel.index_axis(Axis(0), idx).to_owned(),
+                expected.index_axis(Axis(0), 0)
+            );
+        }
+
         Ok(())
     }
 }

--- a/oar-ocr-derive/Cargo.toml
+++ b/oar-ocr-derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oar-ocr-derive"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/oar-ocr-vl/Cargo.toml
+++ b/oar-ocr-vl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oar-ocr-vl"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -19,10 +20,20 @@ categories = ["computer-vision", "science"]
 
 [features]
 default = []
+download-binaries = ["oar-ocr-core/download-binaries"]
 # When enabled, turns on Candle's CUDA backend for GPU acceleration.
-cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
+cuda = [
+    "candle-core/cuda",
+    "candle-nn/cuda",
+    "candle-transformers/cuda",
+    "oar-ocr-core/cuda",
+]
 # When enabled, turns on Candle's Metal backend for GPU acceleration on Apple devices.
-metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
+metal = [
+    "candle-core/metal",
+    "candle-nn/metal",
+    "candle-transformers/metal",
+]
 
 [dependencies]
 oar-ocr-core.workspace = true

--- a/oar-ocr-vl/README.md
+++ b/oar-ocr-vl/README.md
@@ -33,6 +33,13 @@ Add `oar-ocr-vl` to your project:
 cargo add oar-ocr-vl
 ```
 
+If you use ONNX-based helpers from `oar-ocr-core` and want ORT binaries to be fetched
+automatically during build, enable `download-binaries` explicitly:
+
+```bash
+cargo add oar-ocr-vl --features download-binaries
+```
+
 To enable GPU acceleration (CUDA), add the feature flag:
 
 ```bash

--- a/src/oarocr/ocr.rs
+++ b/src/oarocr/ocr.rs
@@ -83,6 +83,10 @@ pub struct OAROCRBuilder {
 }
 
 impl OAROCRBuilder {
+    // Guardrail against pathological user input. This is intentionally generous and
+    // not a model-tuned throughput limit.
+    const MAX_BATCH_SIZE: usize = 4096;
+
     /// Creates a new OCR builder with required components.
     ///
     /// # Arguments
@@ -140,7 +144,8 @@ impl OAROCRBuilder {
     ///
     /// This controls how many images are sent to the text detection adapter per call.
     /// If a detector cannot batch the provided images (e.g., mismatched sizes), the
-    /// pipeline falls back to per-image detection.
+    /// pipeline falls back to per-image detection. Values are validated in `build()`
+    /// and must be within `1..=MAX_BATCH_SIZE`.
     pub fn image_batch_size(mut self, size: usize) -> Self {
         self.image_batch_size = Some(size);
         self
@@ -149,7 +154,8 @@ impl OAROCRBuilder {
     /// Sets the batch size for processing detected text regions.
     ///
     /// Controls memory usage during text recognition. Smaller values use less memory.
-    /// Recommended: 32 for medium VRAM, 16 for low VRAM/CPU.
+    /// Recommended: 32 for medium VRAM, 16 for low VRAM/CPU. Values are validated
+    /// in `build()` and must be within `1..=MAX_BATCH_SIZE`.
     pub fn region_batch_size(mut self, size: usize) -> Self {
         self.region_batch_size = Some(size);
         self
@@ -219,6 +225,13 @@ impl OAROCRBuilder {
     ///
     /// This instantiates all adapters and returns an `OAROCR` instance ready for prediction.
     pub fn build(self) -> Result<OAROCR, OCRError> {
+        if let Some(size) = self.image_batch_size {
+            Self::validate_batch_size("image_batch_size", size)?;
+        }
+        if let Some(size) = self.region_batch_size {
+            Self::validate_batch_size("region_batch_size", size)?;
+        }
+
         // Load character dictionary for text recognition
         let char_dict = std::fs::read_to_string(&self.character_dict_path).map_err(|e| {
             OCRError::InvalidInput {
@@ -355,6 +368,19 @@ impl OAROCRBuilder {
             region_batch_size: self.region_batch_size,
         })
     }
+
+    fn validate_batch_size(field: &str, size: usize) -> Result<(), OCRError> {
+        if size == 0 || size > Self::MAX_BATCH_SIZE {
+            return Err(OCRError::validation_error(
+                "OAROCRBuilder",
+                field,
+                &format!("1..={}", Self::MAX_BATCH_SIZE),
+                &size.to_string(),
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 /// OCR runtime for executing text detection and recognition.
@@ -378,7 +404,7 @@ pub struct OAROCR {
 struct CroppedTextRegion {
     detection_index: usize,
     bbox: BoundingBox,
-    image: image::RgbImage,
+    image: Arc<image::RgbImage>,
     wh_ratio: f32,
     line_orientation_angle: Option<f32>,
 }
@@ -488,10 +514,9 @@ impl OAROCR {
         while start < prepared.len() {
             let end = (start + det_batch_size).min(prepared.len());
 
-            // Adapter boundary: must clone to transfer ownership
-            let batch_images: Vec<image::RgbImage> = prepared[start..end]
+            let batch_images: Vec<Arc<image::RgbImage>> = prepared[start..end]
                 .iter()
-                .map(|(_, preprocess)| (*preprocess.image).clone())
+                .map(|(_, preprocess)| Arc::clone(&preprocess.image))
                 .collect();
 
             match self.detect_sorted_text_boxes_batch(batch_images) {
@@ -568,13 +593,13 @@ impl OAROCR {
 
     fn detect_sorted_text_boxes_batch(
         &self,
-        images: Vec<image::RgbImage>,
+        images: Vec<Arc<image::RgbImage>>,
     ) -> Result<Vec<Vec<BoundingBox>>, OCRError> {
         if images.is_empty() {
             return Ok(Vec::new());
         }
 
-        let input = ImageTaskInput::new(images);
+        let input = ImageTaskInput::from_arc_images(images);
         let det = self.pipeline.text_detection_adapter.execute(input, None)?;
 
         let mut results: Vec<Vec<BoundingBox>> = Vec::with_capacity(det.detections.len());
@@ -588,9 +613,9 @@ impl OAROCR {
 
     fn detect_sorted_text_boxes(
         &self,
-        image: &image::RgbImage,
+        image: &Arc<image::RgbImage>,
     ) -> Result<Vec<BoundingBox>, OCRError> {
-        let input = ImageTaskInput::new(vec![image.clone()]);
+        let input = ImageTaskInput::from_arc_images(vec![Arc::clone(image)]);
         let det = self.pipeline.text_detection_adapter.execute(input, None)?;
 
         let boxes = det
@@ -644,8 +669,6 @@ impl OAROCR {
             let Some(img) = crop_result else {
                 continue;
             };
-            // Small cropped images: clone is acceptable
-            let img = (*img).clone();
             let wh_ratio = img.width() as f32 / img.height().max(1) as f32;
             regions.push(CroppedTextRegion {
                 detection_index: idx,
@@ -674,8 +697,8 @@ impl OAROCR {
             return Ok(());
         }
 
-        let input_images = regions.iter().map(|r| r.image.clone()).collect();
-        let input = ImageTaskInput::new(input_images);
+        let input_images = regions.iter().map(|r| Arc::clone(&r.image)).collect();
+        let input = ImageTaskInput::from_arc_images(input_images);
         let orient = line_orientation_adapter.execute(input, None)?;
 
         for (idx, classifications) in orient
@@ -693,7 +716,8 @@ impl OAROCR {
             regions[idx].line_orientation_angle = Some(angle);
 
             if top_class.class_id == 1 {
-                regions[idx].image = image::imageops::rotate180(&regions[idx].image);
+                regions[idx].image =
+                    Arc::new(image::imageops::rotate180(regions[idx].image.as_ref()));
             }
         }
 
@@ -725,7 +749,9 @@ impl OAROCR {
                 .map(|r| r.wh_ratio)
                 .fold(base_rec_ratio, |acc, r| acc.max(r));
 
-            let rec_input = ImageTaskInput::new(chunk.iter().map(|r| r.image.clone()).collect());
+            let rec_input = ImageTaskInput::from_arc_images(
+                chunk.iter().map(|r| Arc::clone(&r.image)).collect(),
+            );
 
             let rec = self
                 .pipeline
@@ -1050,6 +1076,35 @@ mod tests {
 
         assert_eq!(builder.image_batch_size, Some(4));
         assert_eq!(builder.region_batch_size, Some(64));
+    }
+
+    #[test]
+    fn test_validate_batch_size_accepts_bounds() {
+        assert!(OAROCRBuilder::validate_batch_size("image_batch_size", 1).is_ok());
+        assert!(
+            OAROCRBuilder::validate_batch_size("region_batch_size", OAROCRBuilder::MAX_BATCH_SIZE,)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_batch_size_rejects_zero() {
+        let err = OAROCRBuilder::validate_batch_size("image_batch_size", 0).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("image_batch_size"));
+        assert!(msg.contains(&format!("1..={}", OAROCRBuilder::MAX_BATCH_SIZE)));
+    }
+
+    #[test]
+    fn test_validate_batch_size_rejects_values_above_max() {
+        let err = OAROCRBuilder::validate_batch_size(
+            "region_batch_size",
+            OAROCRBuilder::MAX_BATCH_SIZE + 1,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("region_batch_size"));
+        assert!(msg.contains(&format!("1..={}", OAROCRBuilder::MAX_BATCH_SIZE)));
     }
 
     #[test]

--- a/src/oarocr/stitching.rs
+++ b/src/oarocr/stitching.rs
@@ -1664,21 +1664,25 @@ impl ResultStitcher {
                     sorted_for_meta.append(&mut line);
                 }
 
-                // seg_start_x: first span's left edge (PaddleX: line[0].spans[0].box[0])
-                element.seg_start_x = Some(sorted_for_meta[0].0.bounding_box.x_min());
-                // seg_end_x: last span's right edge (PaddleX: line[-1].spans[-1].box[2])
-                element.seg_end_x = Some(sorted_for_meta.last().unwrap().0.bounding_box.x_max());
+                if let Some((first_region, _)) = sorted_for_meta.first() {
+                    // seg_start_x: first span's left edge (PaddleX: line[0].spans[0].box[0])
+                    element.seg_start_x = Some(first_region.bounding_box.x_min());
+                    // seg_end_x: last span's right edge (PaddleX: line[-1].spans[-1].box[2])
+                    element.seg_end_x = sorted_for_meta
+                        .last()
+                        .map(|(region, _)| region.bounding_box.x_max());
 
-                // Count distinct lines (Y-groups)
-                let mut num_lines = 1u32;
-                let mut prev_bbox = &sorted_for_meta[0].0.bounding_box;
-                for (region, _) in &sorted_for_meta[1..] {
-                    if !Self::is_same_text_line_bbox(prev_bbox, &region.bounding_box, cfg) {
-                        num_lines += 1;
-                        prev_bbox = &region.bounding_box;
+                    // Count distinct lines (Y-groups)
+                    let mut num_lines = 1u32;
+                    let mut prev_bbox = &first_region.bounding_box;
+                    for (region, _) in &sorted_for_meta[1..] {
+                        if !Self::is_same_text_line_bbox(prev_bbox, &region.bounding_box, cfg) {
+                            num_lines += 1;
+                            prev_bbox = &region.bounding_box;
+                        }
                     }
+                    element.num_lines = Some(num_lines);
                 }
-                element.num_lines = Some(num_lines);
             }
 
             Self::sort_and_join_texts(&mut element_texts, Some(&element.bbox), cfg, |joined| {

--- a/src/oarocr/table_analyzer.rs
+++ b/src/oarocr/table_analyzer.rs
@@ -116,6 +116,33 @@ fn nearest_index(positions: &[f32], value: f32) -> usize {
         .unwrap_or(0)
 }
 
+fn cell_bbox_from_coords(coords: &[f32]) -> BoundingBox {
+    if coords.len() >= 8 {
+        let points = [
+            (coords[0], coords[1]),
+            (coords[2], coords[3]),
+            (coords[4], coords[5]),
+            (coords[6], coords[7]),
+        ];
+        let x_min = points.iter().map(|(x, _)| *x).fold(f32::INFINITY, f32::min);
+        let y_min = points.iter().map(|(_, y)| *y).fold(f32::INFINITY, f32::min);
+        let x_max = points
+            .iter()
+            .map(|(x, _)| *x)
+            .fold(f32::NEG_INFINITY, f32::max);
+        let y_max = points
+            .iter()
+            .map(|(_, y)| *y)
+            .fold(f32::NEG_INFINITY, f32::max);
+
+        BoundingBox::from_coords(x_min, y_min, x_max, y_max)
+    } else if let [x_min, y_min, x_max, y_max, ..] = coords {
+        BoundingBox::from_coords(*x_min, *y_min, *x_max, *y_max)
+    } else {
+        BoundingBox::from_coords(0.0, 0.0, 0.0, 0.0)
+    }
+}
+
 /// Converts detected table cell boxes to PaddleX-like HTML structure tokens and
 /// returns the row-major cell ordering implied by those tokens.
 fn table_cells_to_html_structure(
@@ -542,34 +569,7 @@ impl<'a> TableAnalyzer<'a> {
                     .iter()
                     .enumerate()
                     .map(|(cell_idx, bbox_coords)| {
-                        let mut bbox_crop = if bbox_coords.len() >= 8 {
-                            let xs = [
-                                bbox_coords[0],
-                                bbox_coords[2],
-                                bbox_coords[4],
-                                bbox_coords[6],
-                            ];
-                            let ys = [
-                                bbox_coords[1],
-                                bbox_coords[3],
-                                bbox_coords[5],
-                                bbox_coords[7],
-                            ];
-                            let x_min = xs.iter().fold(f32::INFINITY, |acc, &x| acc.min(x));
-                            let y_min = ys.iter().fold(f32::INFINITY, |acc, &y| acc.min(y));
-                            let x_max = xs.iter().fold(f32::NEG_INFINITY, |acc, &x| acc.max(x));
-                            let y_max = ys.iter().fold(f32::NEG_INFINITY, |acc, &y| acc.max(y));
-                            BoundingBox::from_coords(x_min, y_min, x_max, y_max)
-                        } else if bbox_coords.len() >= 4 {
-                            BoundingBox::from_coords(
-                                bbox_coords[0],
-                                bbox_coords[1],
-                                bbox_coords[2],
-                                bbox_coords[3],
-                            )
-                        } else {
-                            BoundingBox::from_coords(0.0, 0.0, 0.0, 0.0)
-                        };
+                        let mut bbox_crop = cell_bbox_from_coords(bbox_coords);
 
                         if let Some(rot) = table_rotation
                             && rot.angle.abs() > 1.0
@@ -1200,27 +1200,12 @@ mod tests {
             10.0, 80.0, // bottom-left
         ];
 
-        let xs = [
-            bbox_coords[0],
-            bbox_coords[2],
-            bbox_coords[4],
-            bbox_coords[6],
-        ];
-        let ys = [
-            bbox_coords[1],
-            bbox_coords[3],
-            bbox_coords[5],
-            bbox_coords[7],
-        ];
-        let x_min = xs.iter().fold(f32::INFINITY, |acc, &x| acc.min(x));
-        let y_min = ys.iter().fold(f32::INFINITY, |acc, &y| acc.min(y));
-        let x_max = xs.iter().fold(f32::NEG_INFINITY, |acc, &x| acc.max(x));
-        let y_max = ys.iter().fold(f32::NEG_INFINITY, |acc, &y| acc.max(y));
+        let bbox = cell_bbox_from_coords(&bbox_coords);
 
-        assert_eq!(x_min, 10.0);
-        assert_eq!(y_min, 20.0);
-        assert_eq!(x_max, 90.0);
-        assert_eq!(y_max, 80.0);
+        assert_eq!(bbox.x_min(), 10.0);
+        assert_eq!(bbox.y_min(), 20.0);
+        assert_eq!(bbox.x_max(), 90.0);
+        assert_eq!(bbox.y_max(), 80.0);
     }
 
     #[test]
@@ -1228,16 +1213,7 @@ mod tests {
         // 4-value format: [x_min, y_min, x_max, y_max]
         let bbox_coords: Vec<f32> = vec![10.0, 20.0, 90.0, 80.0];
 
-        let bbox = if bbox_coords.len() >= 4 {
-            BoundingBox::from_coords(
-                bbox_coords[0],
-                bbox_coords[1],
-                bbox_coords[2],
-                bbox_coords[3],
-            )
-        } else {
-            BoundingBox::from_coords(0.0, 0.0, 0.0, 0.0)
-        };
+        let bbox = cell_bbox_from_coords(&bbox_coords);
 
         assert_eq!(bbox.x_min(), 10.0);
         assert_eq!(bbox.y_min(), 20.0);
@@ -1249,34 +1225,7 @@ mod tests {
     fn test_cell_bbox_fallback_for_empty_coords() {
         let bbox_coords: Vec<f32> = vec![];
 
-        let bbox = if bbox_coords.len() >= 8 {
-            let xs = [
-                bbox_coords[0],
-                bbox_coords[2],
-                bbox_coords[4],
-                bbox_coords[6],
-            ];
-            let ys = [
-                bbox_coords[1],
-                bbox_coords[3],
-                bbox_coords[5],
-                bbox_coords[7],
-            ];
-            let x_min = xs.iter().fold(f32::INFINITY, |acc, &x| acc.min(x));
-            let y_min = ys.iter().fold(f32::INFINITY, |acc, &y| acc.min(y));
-            let x_max = xs.iter().fold(f32::NEG_INFINITY, |acc, &x| acc.max(x));
-            let y_max = ys.iter().fold(f32::NEG_INFINITY, |acc, &y| acc.max(y));
-            BoundingBox::from_coords(x_min, y_min, x_max, y_max)
-        } else if bbox_coords.len() >= 4 {
-            BoundingBox::from_coords(
-                bbox_coords[0],
-                bbox_coords[1],
-                bbox_coords[2],
-                bbox_coords[3],
-            )
-        } else {
-            BoundingBox::from_coords(0.0, 0.0, 0.0, 0.0)
-        };
+        let bbox = cell_bbox_from_coords(&bbox_coords);
 
         // Fallback to zero-sized bbox
         assert_eq!(bbox.x_min(), 0.0);


### PR DESCRIPTION
 Use shared Arc-backed image inputs across OCR batching and adapter boundaries, only converting back to owned images when model APIs require ownership. Optimize normalization by avoiding redundant RGB8 conversions, reusing single-image paths, and gating Rayon parallelism by batch output size.

Also validate OCR batch-size options, centralize table cell bbox parsing, guard empty stitching metadata, wire VL download-binaries/CUDA features, and document the VL download-binaries feature.