### PR TITLE
Fix link to ModelScope in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ With auto-download of model files from ModelScope:
 cargo add oar-ocr --features auto-download
 ```
 
-Bare file names passed to the builders are then fetched from [`greatv/oar-ocr` on ModelScope](https://www.modelscope.cn/models/greatv/oar-ocr) into `$OAR_HOME` (default `~/.oar`) and verified against their expected SHA-256. See [docs/models.md](docs/models.md#auto-download-via-the-auto-download-feature) for the exact path resolution rules.
+Bare file names passed to the builders are then fetched from [ModelScope](https://www.modelscope.cn/models/greatv/oar-ocr) into `$OAR_HOME` (default `~/.oar`) and verified against their expected SHA-256. See [docs/models.md](docs/models.md#auto-download-via-the-auto-download-feature) for the exact path resolution rules.
 
 ### Basic Usage
 


### PR DESCRIPTION
Updated the link to ModelScope in the README.