### PR TITLE
ci: pin macOS runner to macos-26 to avoid image drift breaking cached builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,9 @@ jobs:
         include:
           - os: ubuntu-latest
             vl_feature_check: ""
-          - os: macos-latest
+          # Pinned: macos-latest drifts between images, breaking cached
+          # ort-sys linker paths (see #145).
+          - os: macos-26
             vl_feature_check: "--features metal"
           - os: windows-latest
             vl_feature_check: ""


### PR DESCRIPTION
## Problem

The macOS CI job on #144 failed at the link step:

```
ld: library 'clang_rt.osx' not found
ld: warning: search path '/Applications/Xcode_26.5.app/.../usr/lib/clang/21/lib/darwin' not found
```

## Root cause

- The `macos-latest` label currently drifts between the `macos-15-arm64` and `macos-26-arm64` runner images (gradual rollout).
- `Swatinem/rust-cache` keys do not distinguish the runner image, so both images share the same cache.
- The ort-sys build script records **absolute** Xcode toolchain paths (the directory containing `clang_rt.osx`) in its linker arguments, which get cached. When a cache built on macos-26 is restored on a macos-15 runner, cargo skips re-running the build script and replays the stale Xcode 26.5 paths, and linking fails.

## Fix

Pin the macOS runner to `macos-26` (the image recent green runs used) so the cache and runner always match. The four existing Darwin cache entries have been deleted.

Optional further hardening (not included): add an `ImageVersion` dimension to the rust-cache `prefix-key` to guard against Xcode changes within an image label, at the cost of a full cache rebuild on every image update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
