### PR TITLE
fix(vl): avoid OOM in PaddleOCR-VL vision attention on low-VRAM GPUs

### DIFF
--- a/oar-ocr-vl/src/glmocr/model.rs
+++ b/oar-ocr-vl/src/glmocr/model.rs
@@ -123,7 +123,7 @@ impl GlmOcr {
                 .map(|tokens| self.decode_generated_tokens(&tokens))
                 .collect(),
             Err(e) => {
-                let msg = format!("generation failed: {e}");
+                let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
                         Err(OCRError::InvalidInput {
@@ -160,7 +160,7 @@ impl GlmOcr {
         match self.generate_tokens_internal(images, instructions, max_new_tokens) {
             Ok(results) => results.into_iter().map(Ok).collect(),
             Err(e) => {
-                let msg = format!("generation failed: {e}");
+                let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
                         Err(OCRError::InvalidInput {

--- a/oar-ocr-vl/src/hunyuanocr/model.rs
+++ b/oar-ocr-vl/src/hunyuanocr/model.rs
@@ -201,15 +201,7 @@ impl HunyuanOcr {
                 .map(|tokens| self.decode_generated_tokens(&tokens))
                 .collect(),
             Err(e) => {
-                // Walk the source chain so the underlying candle / CUDA
-                // failure isn't hidden behind the top-level OCRError.
-                let mut chain = format!("generation failed: {e}");
-                let mut cur: Option<&dyn std::error::Error> = std::error::Error::source(&e);
-                while let Some(s) = cur {
-                    chain.push_str(&format!("\n  caused by: {s}"));
-                    cur = s.source();
-                }
-                let msg = chain;
+                let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
                         Err(OCRError::InvalidInput {
@@ -246,13 +238,7 @@ impl HunyuanOcr {
         match self.generate_tokens_internal(images, instructions, max_new_tokens) {
             Ok(results) => results.into_iter().map(Ok).collect(),
             Err(e) => {
-                let mut chain = format!("generation failed: {e}");
-                let mut cur: Option<&dyn std::error::Error> = std::error::Error::source(&e);
-                while let Some(s) = cur {
-                    chain.push_str(&format!("\n  caused by: {s}"));
-                    cur = s.source();
-                }
-                let msg = chain;
+                let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
                         Err(OCRError::InvalidInput {

--- a/oar-ocr-vl/src/mineru/model.rs
+++ b/oar-ocr-vl/src/mineru/model.rs
@@ -305,7 +305,7 @@ impl MinerU {
                 .map(|tokens| self.decode_generated_tokens(&tokens))
                 .collect(),
             Err(e) => {
-                let msg = format!("generation failed: {e}");
+                let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
                         Err(OCRError::InvalidInput {
@@ -342,7 +342,7 @@ impl MinerU {
         match self.generate_tokens_internal(images, instructions, max_new_tokens) {
             Ok(results) => results.into_iter().map(Ok).collect(),
             Err(e) => {
-                let msg = format!("generation failed: {e}");
+                let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
                         Err(OCRError::InvalidInput {

--- a/oar-ocr-vl/src/paddleocr_vl/model.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/model.rs
@@ -193,7 +193,7 @@ impl PaddleOcrVl {
                 .map(|(i, tokens)| self.decode_generated_tokens(&tokens, tasks[i]))
                 .collect(),
             Err(e) => {
-                let msg = format!("generation failed: {e}");
+                let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
                         Err(OCRError::InvalidInput {
@@ -231,7 +231,7 @@ impl PaddleOcrVl {
         match self.generate_tokens_internal(images, tasks, max_new_tokens) {
             Ok(results) => results.into_iter().map(Ok).collect(),
             Err(e) => {
-                let msg = format!("generation failed: {e}");
+                let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
                         Err(OCRError::InvalidInput {

--- a/oar-ocr-vl/src/paddleocr_vl/vision.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/vision.rs
@@ -19,6 +19,66 @@ const ATTN_FULL_SEQ_THRESHOLD: usize = 8192;
 /// F32 softmax scratch at `chunk * seq_k * num_heads * 4 bytes` — about
 /// 110 MB at seq_k = 3600 / heads = 16, well within VRAM headroom.
 const ATTN_CHUNK_SIZE: usize = 512;
+/// Device memory to leave untouched when deciding whether the full-matrix
+/// attention path fits: later ops (attn @ v output, MLP activations) still
+/// need allocations after the softmax scratch peak.
+const ATTN_FREE_MEM_HEADROOM: usize = 256 * 1024 * 1024;
+
+/// The seq length above which vision attention always uses the chunked path.
+/// Defaults to [`ATTN_FULL_SEQ_THRESHOLD`]; the `OAR_VL_ATTN_FULL_SEQ_THRESHOLD`
+/// environment variable overrides it (e.g. `0` forces chunked attention).
+fn attn_full_seq_threshold() -> usize {
+    static THRESHOLD: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *THRESHOLD.get_or_init(|| {
+        match std::env::var("OAR_VL_ATTN_FULL_SEQ_THRESHOLD") {
+            Ok(v) => match v.trim().parse() {
+                Ok(t) => {
+                    tracing::info!(
+                        "vision attention full-seq threshold {t} from OAR_VL_ATTN_FULL_SEQ_THRESHOLD"
+                    );
+                    t
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "ignoring invalid OAR_VL_ATTN_FULL_SEQ_THRESHOLD value '{v}' (expected an integer)"
+                    );
+                    ATTN_FULL_SEQ_THRESHOLD
+                }
+            },
+            Err(_) => ATTN_FULL_SEQ_THRESHOLD,
+        }
+    })
+}
+
+/// Peak transient device memory (bytes) of the full-matrix attention path:
+/// the `[b, heads, seq, seq]` scores in the compute dtype, their F32 copy fed
+/// to the softmax, the F32 softmax output, and the cast back to the compute
+/// dtype are all live at once.
+fn eager_attn_scratch_bytes(b: usize, heads: usize, seq: usize, dtype: DType) -> usize {
+    b * heads * seq * seq * (2 * dtype.size_in_bytes() + 2 * DType::F32.size_in_bytes())
+}
+
+/// Whether the full-matrix attention path fits on `device` next to what is
+/// already allocated. Unknown free memory (CPU, Metal, query failure) keeps
+/// the pre-existing behavior of always taking the full path below the seq
+/// threshold.
+fn eager_attn_fits(device: &Device, scratch_bytes: usize) -> bool {
+    match crate::utils::free_device_memory(device) {
+        Some(free) => match scratch_bytes.checked_add(ATTN_FREE_MEM_HEADROOM) {
+            Some(needed) if needed <= free => true,
+            _ => {
+                tracing::debug!(
+                    "vision attention falling back to chunked path: needs ~{} MiB scratch \
+                     but only {} MiB device memory is free",
+                    scratch_bytes / (1024 * 1024),
+                    free / (1024 * 1024),
+                );
+                false
+            }
+        },
+        None => true,
+    }
+}
 
 /// SigLIP-style 2D rotary embedding for vision encoder
 #[derive(Debug, Clone)]
@@ -356,7 +416,15 @@ impl VisionAttention {
         // O(chunk * seq_k) F32 scratch for the softmax, instead of O(seq_q * seq_k) for the
         // full eager path. Numerically equivalent to the original code, and matches Python's
         // PaddleOCRAttention which auto-selects sdpa at runtime (modeling_paddleocr_vl.py:1298).
-        let attn_output = if seq <= ATTN_FULL_SEQ_THRESHOLD {
+        //
+        // Besides the seq threshold, the full path also requires its softmax scratch to fit
+        // in the device's currently-free memory: on small-VRAM GPUs (e.g. 4 GB GTX 1650 Ti)
+        // large images otherwise OOM inside the softmax (issue #147).
+        let attn_output = if seq <= attn_full_seq_threshold()
+            && eager_attn_fits(
+                hidden_states.device(),
+                eager_attn_scratch_bytes(b, self.num_heads, seq, q.dtype()),
+            ) {
             // Original eager attention path — kept byte-identical to the pre-fix
             // implementation so that small/medium seq inputs (incl. all v1.5
             // inputs) produce the exact same output. Removing the final

--- a/oar-ocr-vl/src/paddleocr_vl/vision.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/vision.rs
@@ -53,16 +53,24 @@ fn attn_full_seq_threshold() -> usize {
 /// Peak transient device memory (bytes) of the full-matrix attention path:
 /// the `[b, heads, seq, seq]` scores in the compute dtype, their F32 copy fed
 /// to the softmax, the F32 softmax output, and the cast back to the compute
-/// dtype are all live at once.
-fn eager_attn_scratch_bytes(b: usize, heads: usize, seq: usize, dtype: DType) -> usize {
-    b * heads * seq * seq * (2 * dtype.size_in_bytes() + 2 * DType::F32.size_in_bytes())
+/// dtype are all live at once. `None` means the product overflows `usize`
+/// (only possible on 32-bit targets), which certainly doesn't fit either.
+fn eager_attn_scratch_bytes(b: usize, heads: usize, seq: usize, dtype: DType) -> Option<usize> {
+    let per_element = 2 * dtype.size_in_bytes() + 2 * DType::F32.size_in_bytes();
+    b.checked_mul(heads)?
+        .checked_mul(seq)?
+        .checked_mul(seq)?
+        .checked_mul(per_element)
 }
 
 /// Whether the full-matrix attention path fits on `device` next to what is
 /// already allocated. Unknown free memory (CPU, Metal, query failure) keeps
 /// the pre-existing behavior of always taking the full path below the seq
-/// threshold.
-fn eager_attn_fits(device: &Device, scratch_bytes: usize) -> bool {
+/// threshold; an overflowing scratch estimate (`None`) never fits.
+fn eager_attn_fits(device: &Device, scratch_bytes: Option<usize>) -> bool {
+    let Some(scratch_bytes) = scratch_bytes else {
+        return false;
+    };
     match crate::utils::free_device_memory(device) {
         Some(free) => match scratch_bytes.checked_add(ATTN_FREE_MEM_HEADROOM) {
             Some(needed) if needed <= free => true,
@@ -1044,6 +1052,21 @@ fn interpolate_bilinear_align_corners_false(
 #[cfg(test)]
 mod tests {
     use super::interpolate_bilinear_align_corners_false;
+
+    #[test]
+    fn eager_attn_scratch_bytes_estimate_and_overflow() {
+        use candle_core::DType;
+        // f16 scores + f32 copy + f32 softmax output + f16 cast back = 12 B/elem.
+        assert_eq!(
+            super::eager_attn_scratch_bytes(1, 16, 5000, DType::F16),
+            Some(16 * 5000 * 5000 * 12)
+        );
+        // An overflowing product must report "doesn't fit", not wrap around.
+        assert_eq!(
+            super::eager_attn_scratch_bytes(1, 16, usize::MAX / 2, DType::F16),
+            None
+        );
+    }
 
     #[test]
     fn interpolate_same_size_is_identity() {

--- a/oar-ocr-vl/src/utils.rs
+++ b/oar-ocr-vl/src/utils.rs
@@ -237,6 +237,40 @@ pub fn candle_to_ocr_inference(
     }
 }
 
+/// Returns the free device memory in bytes when it can be queried.
+///
+/// Only CUDA devices can be queried (`cuMemGetInfo`); CPU and Metal return
+/// `None`, as does a CUDA query failure. Callers use `None` as "unknown, don't
+/// gate on memory".
+pub fn free_device_memory(device: &Device) -> Option<usize> {
+    #[cfg(feature = "cuda")]
+    if let Device::Cuda(dev) = device {
+        return match dev.cuda_stream().context().mem_get_info() {
+            Ok((free, _total)) => Some(free),
+            Err(e) => {
+                tracing::debug!("querying free CUDA memory failed: {e}");
+                None
+            }
+        };
+    }
+    let _ = device;
+    None
+}
+
+/// Formats an error together with its full `source()` chain, so underlying
+/// candle / CUDA failures (e.g. out-of-memory) aren't hidden behind the
+/// top-level error's Display output.
+pub fn error_chain_message(prefix: &str, e: &(dyn std::error::Error + 'static)) -> String {
+    use std::fmt::Write;
+    let mut chain = format!("{prefix}: {e}");
+    let mut cur = e.source();
+    while let Some(s) = cur {
+        let _ = write!(chain, "\n  caused by: {s}");
+        cur = s.source();
+    }
+    chain
+}
+
 /// Convert Candle error to OCRError for processing operations.
 pub fn candle_to_ocr_processing(
     kind: oar_ocr_core::core::errors::ProcessingStage,
@@ -913,6 +947,21 @@ mod tests {
     fn test_parse_device_cpu() {
         let device = parse_device("cpu").unwrap();
         assert!(matches!(device, Device::Cpu));
+    }
+
+    #[test]
+    fn test_error_chain_message_includes_sources() {
+        let root = std::io::Error::other("CUDA_ERROR_OUT_OF_MEMORY");
+        let err = OCRError::Inference {
+            model_name: "PaddleOCR-VL".to_string(),
+            context: "vision attn softmax".to_string(),
+            source: Box::new(root),
+        };
+        let msg = error_chain_message("generation failed", &err);
+        assert_eq!(
+            msg,
+            "generation failed: inference failed in model 'PaddleOCR-VL': vision attn softmax\n  caused by: CUDA_ERROR_OUT_OF_MEMORY"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #147.

## Problem

On small-VRAM GPUs (e.g. the reporter's 4 GB GTX 1650 Ti), PaddleOCR-VL fails on larger images with an opaque error:

```
InvalidInput { message: "generation failed: inference failed in model 'PaddleOCR-VL': vision attn softmax" }
```

Two issues compound here:

1. The full-matrix vision attention path materializes the `[b, heads, seq, seq]` scores in the compute dtype plus two F32 copies for the softmax — roughly `heads × seq² × 12` bytes, about 4 GB at seq ≈ 5000. Small images fit, large ones OOM inside the softmax, which is why the crash is image-dependent.
2. The `generation failed: {e}` formatting only printed the top-level `OCRError` Display and dropped the `source()` chain, hiding the underlying `CUDA_ERROR_OUT_OF_MEMORY`.

## Changes

- **VRAM-aware attention path selection** (`paddleocr_vl/vision.rs`): before taking the full-matrix path, estimate its softmax scratch and check it against the device's free memory (`cuMemGetInfo` via cudarc, 256 MiB headroom). If it doesn't fit, fall back to the numerically equivalent chunked path (~few hundred MB peak). CPU/Metal/query-failure keep the previous behavior.
- **`OAR_VL_ATTN_FULL_SEQ_THRESHOLD` env override** for the seq threshold (`0` forces chunked attention), mirroring `OAR_VL_DTYPE`.
- **Full error-chain reporting**: new `utils::error_chain_message()` walks the source chain (`caused by: ...`); applied to PaddleOCR-VL, MinerU, and GLM-OCR, and replaces the inline copy HunyuanOCR already had.

## Verification

- Eager vs forced-chunked (`OAR_VL_ATTN_FULL_SEQ_THRESHOLD=0`) output is byte-identical on `cuda:0` with `OAR_VL_DTYPE=f16` for text-line and full-page OCR images.
- Memory gate exercised for real: raising the threshold on the v1 chart image (seq ≈ 14200 → ~36 GB scratch estimate) triggers the fallback in all 27 layers ("needs ~36921 MiB scratch but only 20857 MiB device memory is free") and still produces correct output.
- `cargo test --workspace` green, including a new unit test asserting the chained OOM message; clippy clean with and without `--features cuda`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
