### PR TITLE
chore: bump version to 0.7.4, document environment variables, trim verbose comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "oar-ocr-derive", "oar-ocr-core", "oar-ocr-vl"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ repository = "https://github.com/greatv/oar-ocr"
 homepage = "https://github.com/greatv/oar-ocr"
 
 [workspace.dependencies]
-oar-ocr-core = { version = "0.7.3", path = "oar-ocr-core", default-features = false }
-oar-ocr-derive = { version = "0.7.3", path = "oar-ocr-derive", default-features = false }
+oar-ocr-core = { version = "0.7.4", path = "oar-ocr-core", default-features = false }
+oar-ocr-derive = { version = "0.7.4", path = "oar-ocr-derive", default-features = false }
 
 # Shared third-party dependencies (kept in sync via workspace inheritance).
 clap = { version = "4.5.42", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ For advanced document understanding using Vision-Language Models (like PaddleOCR
 
 - [**Usage Guide**](docs/usage.md) - Detailed API usage, builder patterns, GPU configuration
 - [**Pre-trained Models**](docs/models.md) - Model download links and recommended configurations
+- [**Environment Variables**](docs/environment-variables.md) - Runtime configuration via `OAR_*` variables
 
 ## Examples
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,75 @@
+# Environment Variables
+
+Runtime environment variables read by the oar-ocr crates. Project-specific
+variables use the `OAR_` prefix (`OAR_VL_` for the Vision-Language crate).
+
+## Summary
+
+| Variable | Crate | Default | Purpose |
+|---|---|---|---|
+| [`OAR_HOME`](#oar_home) | `oar-ocr-core` | `~/.oar` | Model cache directory for auto-download |
+| [`OAR_VL_DTYPE`](#oar_vl_dtype) | `oar-ocr-vl` | auto | Compute dtype for VL models |
+| [`OAR_VL_ATTN_FULL_SEQ_THRESHOLD`](#oar_vl_attn_full_seq_threshold) | `oar-ocr-vl` | `8192` | PaddleOCR-VL vision attention path selection |
+| [`CUDA_LAUNCH_BLOCKING`](#cuda_launch_blocking) | `oar-ocr-core` | set to `1` if unset | ONNX Runtime CUDA workaround |
+| [`RUST_LOG`](#rust_log) | examples | `info` | Log filter |
+
+## `OAR_HOME`
+
+Directory where the `auto-download` feature caches model files
+(default `~/.oar`). Bare model file names passed to the builders are
+downloaded here and verified against their expected SHA-256. See
+[models.md](models.md#auto-download-via-the-auto-download-feature) for the
+exact path resolution rules.
+
+```bash
+OAR_HOME=/data/oar-models cargo run --release --example ocr -- doc.jpg
+```
+
+## `OAR_VL_DTYPE`
+
+Overrides the automatic weight/compute dtype selection for Vision-Language
+models (PaddleOCR-VL, GLM-OCR, HunyuanOCR, MinerU2.5).
+
+Accepted values (case-insensitive):
+
+- `bf16` (alias `bfloat16`)
+- `f16` (aliases `fp16`, `float16`, `half`)
+- `f32` (aliases `fp32`, `float32`)
+
+Without the override, GPUs use BF16 when a runtime probe confirms kernel
+support (CUDA compute capability >= 8.0), falling back to F16 otherwise
+(e.g. GTX 10xx/16xx, RTX 20xx); CPU always uses F32.
+
+```bash
+OAR_VL_DTYPE=f16 cargo run --release --features cuda -p oar-ocr-vl --example paddleocr_vl -- ...
+```
+
+## `OAR_VL_ATTN_FULL_SEQ_THRESHOLD`
+
+Maximum sequence length (in vision patches) for which PaddleOCR-VL's vision
+attention may use the single-shot full-matrix path; longer sequences use the
+numerically equivalent chunked path, which needs far less peak memory.
+Default `8192`; set `0` to force chunked attention.
+
+Independently of this threshold, the full path is skipped automatically
+whenever its softmax scratch would not fit in the free device memory, so
+low-VRAM GPUs normally don't need this variable.
+
+```bash
+OAR_VL_ATTN_FULL_SEQ_THRESHOLD=0 cargo run --release --features cuda -p oar-ocr-vl --example paddleocr_vl -- ...
+```
+
+## `CUDA_LAUNCH_BLOCKING`
+
+Standard CUDA variable, listed here because the classic (ONNX Runtime)
+pipeline sets it to `1` at startup when it is not already set, to work around
+[onnxruntime#4829](https://github.com/microsoft/onnxruntime/issues/4829)
+(PP-FormulaNet's autoregressive `Loop` corrupting CUDA-EP arena buffers).
+Preset any value (e.g. `0`) to keep your own setting. Note this serializes
+CUDA kernel launches process-wide.
+
+## `RUST_LOG`
+
+Standard [`tracing_subscriber::EnvFilter`](https://docs.rs/tracing-subscriber)
+filter used by the examples, e.g. `RUST_LOG=oar_ocr_vl=debug` to see why the
+vision attention picked the chunked path.

--- a/oar-ocr-vl/src/hunyuanocr/model.rs
+++ b/oar-ocr-vl/src/hunyuanocr/model.rs
@@ -581,16 +581,11 @@ fn expand_image_tokens_in_place(
     image_inputs: &HunyuanOcrImageInputs,
 ) -> Result<(), OCRError> {
     let (_, hm, wm) = image_inputs.grid_thw_merged;
-    // Match the upstream HuggingFace processor:
-    //   transformers/models/hunyuan_vl/processing_hunyuan_vl.py:62
-    //   num_image_tokens = patch_h * (patch_w + 1) + 2
-    // The `+ 2` accounts for the begin/end markers that the vit's perceive
-    // step prepends/appends to the spatial sequence — those positions also
-    // get replaced by image embeddings (rather than carrying separate
-    // `image_start` / `image_end` text embeddings, which is the scheme an
-    // earlier internal Tencent variant used and which this Rust port
-    // originally followed). The placeholder run is contiguous and uses
-    // `image_token_id` exclusively — no `image_newline_token_id` interleaving.
+    // Upstream processor: num_image_tokens = patch_h * (patch_w + 1) + 2
+    // (processing_hunyuan_vl.py:62). The `+ 2` covers the perceive step's
+    // begin/end markers, whose positions are also replaced by image
+    // embeddings. The placeholder run is contiguous `image_token_id` only —
+    // no `image_newline_token_id` interleaving.
     let expected_tokens = hm.saturating_mul(wm.saturating_add(1)).saturating_add(2);
     if expected_tokens == 0 {
         return Err(OCRError::InvalidInput {
@@ -657,15 +652,10 @@ fn build_position_ids(
     //   - h is `[h]*(patch_w+1)` for `h` in `0..patch_h`,
     //   - t is 0 across the run.
     // The run starts at `first_image_token + 1` and spans `(patch_w+1)*patch_h`
-    // tokens — i.e. the *middle* of the expanded `patch_h*(patch_w+1) + 2`
-    // image-token block. The first and last image_tokens (perceive begin/end
-    // markers) keep their default arange position.
-    //
-    // Earlier this port used pure-sequential position ids for all four axes,
-    // which made the model produce hallucinated text (e.g. "The text in the
-    // image is not complete.") instead of OCR output: the trained weights
-    // expect the spatial xdrope rotation to encode 2-D image structure, and
-    // collapsing to 1-D destroys the geometry.
+    // tokens — the *middle* of the expanded `patch_h*(patch_w+1) + 2` block;
+    // the perceive begin/end markers keep their default arange position.
+    // Collapsing the spatial axes to plain 1-D sequence ids destroys the 2-D
+    // geometry the trained weights expect and yields hallucinated text.
     let mut pos: Vec<i64> = vec![0; 4 * seq_len];
     for i in 0..seq_len {
         let p = i as i64;

--- a/oar-ocr-vl/src/hunyuanocr/vision.rs
+++ b/oar-ocr-vl/src/hunyuanocr/vision.rs
@@ -674,20 +674,12 @@ impl VisionPerceive {
         //   2. cat([image_begin, mlp_out, image_end])
         //   3. after_rms(cat)
         //
-        // We previously (a) applied `after_rms` to the mlp output BEFORE
-        // concatenating the begin/end markers and (b) broadcast-added an
-        // unused `image_sep` parameter to every token. Both wrong:
-        // upstream's `after_rms` runs once over the full begin+tokens+end
-        // sequence, which lifts the image_begin / image_end embedding
-        // magnitudes from their stored norm (~0.9) up to the post-RMSNorm
-        // scale (~22), matching the surrounding patch tokens. Our pre-fix
-        // perceive output had image_begin / image_end at norm ~0.9 — 25×
-        // smaller than upstream — so the LLM saw those marker positions as
-        // near-zero vectors and the prefill's last-position logits diverged
-        // (cos 0.69 vs upstream → wrong argmax → hallucinated
-        // continuations like "The presence of factors…" instead of OCR text).
-        // The `image_sep` Parameter is declared in upstream weights but
-        // *never used in the forward path*; we now drop it on the floor too.
+        // `after_rms` must run over the full begin+tokens+end sequence: it
+        // lifts the image_begin / image_end embeddings from their stored norm
+        // (~0.9) to the post-RMSNorm scale (~22). Normalizing before the cat
+        // leaves the markers as near-zero vectors and the prefill logits
+        // diverge into hallucinated text. The `image_sep` parameter exists in
+        // the upstream weights but is never used in the forward path.
         let begin = self.image_begin.reshape((1usize, 1024usize)).map_err(|e| {
             candle_to_ocr_processing(
                 oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
@@ -832,17 +824,11 @@ impl HunyuanVisionModel {
             )
         })?;
 
-        // No extra/cls token. The upstream HunYuanVisionPatchEmbed
-        // (`transformers/models/hunyuan_vl/modeling_hunyuan_vl.py`) declares
-        // `num_positions = max_num_patches + 1` but the runtime path uses
-        // `position_embedding.weight[1:, :]` and feeds only the patch tokens
-        // through the encoder — the slot-0 entry is a vestigial cls token
-        // present in the trained weights for compatibility but never
-        // propagated. An earlier internal Tencent variant (which this Rust
-        // port originally followed) prepended a mean-pooled extra token plus
-        // a learned `extra_pos`, which contributed unwanted attention scores
-        // to every patch and accumulated noise across 27 encoder layers.
-        // Removing that prepend halves the residual vit_out drift vs upstream.
+        // No extra/cls token: upstream HunYuanVisionPatchEmbed declares
+        // `num_positions = max_num_patches + 1` but uses
+        // `position_embedding.weight[1:, :]` and feeds only patch tokens —
+        // slot 0 is a vestigial cls token in the trained weights, never
+        // propagated. Prepending one adds attention noise across all layers.
         let hidden = patch_tokens.unsqueeze(0).map_err(|e| {
             candle_to_ocr_processing(
                 oar_ocr_core::core::errors::ProcessingStage::TensorOperation,

--- a/oar-ocr-vl/src/paddleocr_vl/vision.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/vision.rs
@@ -5,28 +5,19 @@ use candle_nn::Module;
 use oar_ocr_core::core::OCRError;
 use rayon::prelude::*;
 
-/// Above this seq length vision attention computes softmax in chunks along the
-/// query dim instead of allocating the full `[seq, seq]` F32 buffer (mirroring
-/// PyTorch SDPA's memory profile).
-///
-/// Set above PaddleOCR-VL-1.5's worst-case seq (≈5040 at max_pixels=1_003_520)
-/// so v1.5 always takes the single-shot full-matrix path: chunked matmul shifts
-/// cuBLAS tiling and a few low-confidence argmax tokens, so the full path keeps
-/// v1.5 byte-stable. v1 (seq≈14200) crosses the threshold, where the full buffer
-/// would otherwise OOM (12+ GB on chart_01.jpg).
+/// Above this seq length vision attention runs chunked along the query dim
+/// instead of materializing the full `[seq, seq]` buffer. Kept above v1.5's
+/// worst-case seq (≈5040) because chunking shifts cuBLAS tiling and a few
+/// low-confidence argmax tokens; the full path keeps v1.5 byte-stable.
 const ATTN_FULL_SEQ_THRESHOLD: usize = 8192;
-/// Query chunk size when chunked attention kicks in. 512 keeps each chunk's
-/// F32 softmax scratch at `chunk * seq_k * num_heads * 4 bytes` — about
-/// 110 MB at seq_k = 3600 / heads = 16, well within VRAM headroom.
+/// Query chunk size for chunked attention (~110 MB F32 softmax scratch at
+/// seq_k = 3600, heads = 16).
 const ATTN_CHUNK_SIZE: usize = 512;
-/// Device memory to leave untouched when deciding whether the full-matrix
-/// attention path fits: later ops (attn @ v output, MLP activations) still
-/// need allocations after the softmax scratch peak.
+/// Free-memory headroom for allocations after the softmax scratch peak.
 const ATTN_FREE_MEM_HEADROOM: usize = 256 * 1024 * 1024;
 
-/// The seq length above which vision attention always uses the chunked path.
-/// Defaults to [`ATTN_FULL_SEQ_THRESHOLD`]; the `OAR_VL_ATTN_FULL_SEQ_THRESHOLD`
-/// environment variable overrides it (e.g. `0` forces chunked attention).
+/// [`ATTN_FULL_SEQ_THRESHOLD`], overridable via the
+/// `OAR_VL_ATTN_FULL_SEQ_THRESHOLD` env var (`0` forces chunked attention).
 fn attn_full_seq_threshold() -> usize {
     static THRESHOLD: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *THRESHOLD.get_or_init(|| {
@@ -50,11 +41,9 @@ fn attn_full_seq_threshold() -> usize {
     })
 }
 
-/// Peak transient device memory (bytes) of the full-matrix attention path:
-/// the `[b, heads, seq, seq]` scores in the compute dtype, their F32 copy fed
-/// to the softmax, the F32 softmax output, and the cast back to the compute
-/// dtype are all live at once. `None` means the product overflows `usize`
-/// (only possible on 32-bit targets), which certainly doesn't fit either.
+/// Peak transient bytes of the full-matrix path: the `[b, heads, seq, seq]`
+/// scores in the compute dtype, their F32 copy, the F32 softmax output, and
+/// the cast back are all live at once. `None` on `usize` overflow.
 fn eager_attn_scratch_bytes(b: usize, heads: usize, seq: usize, dtype: DType) -> Option<usize> {
     let per_element = 2 * dtype.size_in_bytes() + 2 * DType::F32.size_in_bytes();
     b.checked_mul(heads)?
@@ -63,10 +52,9 @@ fn eager_attn_scratch_bytes(b: usize, heads: usize, seq: usize, dtype: DType) ->
         .checked_mul(per_element)
 }
 
-/// Whether the full-matrix attention path fits on `device` next to what is
-/// already allocated. Unknown free memory (CPU, Metal, query failure) keeps
-/// the pre-existing behavior of always taking the full path below the seq
-/// threshold; an overflowing scratch estimate (`None`) never fits.
+/// Whether the full-matrix path fits in free device memory. Unknown free
+/// memory (CPU, Metal, query failure) keeps the full path; an overflowed
+/// scratch estimate (`None`) never fits.
 fn eager_attn_fits(device: &Device, scratch_bytes: Option<usize>) -> bool {
     let Some(scratch_bytes) = scratch_bytes else {
         return false;
@@ -419,25 +407,18 @@ impl VisionAttention {
             .contiguous()
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "vision k t23 contiguous", e))?;
 
-        // Chunked attention over the query dim to mirror PyTorch's `sdpa_attention_forward`
-        // memory profile (no full [seq, seq] materialization). Each iteration only allocates
-        // O(chunk * seq_k) F32 scratch for the softmax, instead of O(seq_q * seq_k) for the
-        // full eager path. Numerically equivalent to the original code, and matches Python's
-        // PaddleOCRAttention which auto-selects sdpa at runtime (modeling_paddleocr_vl.py:1298).
-        //
-        // Besides the seq threshold, the full path also requires its softmax scratch to fit
-        // in the device's currently-free memory: on small-VRAM GPUs (e.g. 4 GB GTX 1650 Ti)
-        // large images otherwise OOM inside the softmax (issue #147).
+        // Full-matrix path only when seq is below the threshold AND its softmax
+        // scratch fits in free device memory — large images otherwise OOM on
+        // small-VRAM GPUs (issue #147). The chunked fallback is numerically
+        // equivalent (mirrors PyTorch SDPA's memory profile).
         let attn_output = if seq <= attn_full_seq_threshold()
             && eager_attn_fits(
                 hidden_states.device(),
                 eager_attn_scratch_bytes(b, self.num_heads, seq, q.dtype()),
             ) {
-            // Original eager attention path — kept byte-identical to the pre-fix
-            // implementation so that small/medium seq inputs (incl. all v1.5
-            // inputs) produce the exact same output. Removing the final
-            // `.contiguous()` here changes cuBLAS' matmul-shape selection and
-            // shifts low-confidence argmax tokens, so we preserve it.
+            // Kept byte-identical to the original implementation: removing the
+            // final `.contiguous()` changes cuBLAS' matmul-shape selection and
+            // shifts low-confidence argmax tokens.
             let scores = q
                 .matmul(&kt)
                 .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "vision qk matmul", e))?

--- a/oar-ocr-vl/src/utils.rs
+++ b/oar-ocr-vl/src/utils.rs
@@ -237,11 +237,8 @@ pub fn candle_to_ocr_inference(
     }
 }
 
-/// Returns the free device memory in bytes when it can be queried.
-///
-/// Only CUDA devices can be queried (`cuMemGetInfo`); CPU and Metal return
-/// `None`, as does a CUDA query failure. Callers use `None` as "unknown, don't
-/// gate on memory".
+/// Free device memory in bytes; `None` when it can't be queried
+/// (CPU, Metal, or a CUDA `cuMemGetInfo` failure).
 pub fn free_device_memory(device: &Device) -> Option<usize> {
     #[cfg(feature = "cuda")]
     if let Device::Cuda(dev) = device {
@@ -257,9 +254,8 @@ pub fn free_device_memory(device: &Device) -> Option<usize> {
     None
 }
 
-/// Formats an error together with its full `source()` chain, so underlying
-/// candle / CUDA failures (e.g. out-of-memory) aren't hidden behind the
-/// top-level error's Display output.
+/// Formats an error with its full `source()` chain, so underlying candle /
+/// CUDA failures (e.g. out-of-memory) aren't hidden by the top-level Display.
 pub fn error_chain_message(prefix: &str, e: &(dyn std::error::Error + 'static)) -> String {
     use std::fmt::Write;
     let mut chain = format!("{prefix}: {e}");


### PR DESCRIPTION
## Changes

1. **Bump workspace version 0.7.3 → 0.7.4** (root `Cargo.toml`, including the `oar-ocr-core` / `oar-ocr-derive` workspace dependency versions).
2. **New [`docs/environment-variables.md`](../blob/chore-0.7.4-env-docs/docs/environment-variables.md)** — single reference for all runtime environment variables, linked from the README:
   - `OAR_HOME` — model cache directory for auto-download
   - `OAR_VL_DTYPE` — VL compute dtype override
   - `OAR_VL_ATTN_FULL_SEQ_THRESHOLD` — PaddleOCR-VL attention path selection (new in #148)
   - `CUDA_LAUNCH_BLOCKING` — set by the classic pipeline unless preset (ort#4829 workaround)
   - `RUST_LOG` — log filtering
3. **Comment cleanup in `oar-ocr-vl`** — condensed overlong comments to constraint-only wording, dropping historical narration ("we previously did X", "an earlier variant did Y"). Touched: the PaddleOCR-VL attention constants/helpers from #148 and four HunyuanOCR upstream-alignment blocks. Comments only, no code changes.

## Verification

`cargo test --workspace` green (all suites); Cargo.lock is untracked so the bump is Cargo.toml-only, matching the 0.7.3 bump (#146).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
