### PR TITLE
feat: support loading models from memory

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,6 +101,30 @@ let ocr = OAROCRBuilder::new(
 | `.image_batch_size(n)` | Set batch size for image processing |
 | `.region_batch_size(n)` | Set batch size for region processing |
 | `.ort_session(config)` | Apply ONNX Runtime configuration |
+| `.character_dict_content(text)` | Provide the character dictionary as an in-memory string |
+
+#### Loading Models from Memory
+
+Everywhere a builder accepts a model path it also accepts raw ONNX bytes
+(`Vec<u8>`, `&'static [u8]`, or `Arc<[u8]>`), so models can be embedded into
+the binary or decrypted at runtime without touching the filesystem:
+
+```rust
+use oar_ocr::oarocr::OAROCRBuilder;
+
+static DET_MODEL: &[u8] = include_bytes!("../models/pp-ocrv6_tiny_det.onnx");
+static REC_MODEL: &[u8] = include_bytes!("../models/pp-ocrv6_tiny_rec.onnx");
+static DICT: &str = include_str!("../models/ppocrv6_tiny_dict.txt");
+
+let ocr = OAROCRBuilder::new(DET_MODEL, REC_MODEL, "")
+    .character_dict_content(DICT)
+    .build()?;
+```
+
+In-memory sources skip auto-download resolution, and models that reference
+external-data sidecar files cannot be loaded this way. The same applies to
+the per-task predictors (`TextDetectionPredictorBuilder::build(...)` etc.),
+`OARStructureBuilder` model setters, and `AdapterBuilder::build(...)`.
 
 ### OARStructureBuilder - Document Structure Analysis
 

--- a/oar-ocr-core/src/core/inference/mod.rs
+++ b/oar-ocr-core/src/core/inference/mod.rs
@@ -7,6 +7,7 @@ use crate::core::errors::OCRError;
 use ort::{session::Session, value::ValueType};
 use std::sync::Mutex;
 
+mod model_source;
 pub mod session;
 mod tensor_output;
 
@@ -18,6 +19,7 @@ mod ort_infer_config;
 #[path = "ort_infer_execution.rs"]
 mod ort_infer_execution;
 
+pub use model_source::ModelSource;
 pub use ort_infer_builders::ensure_cuda_launch_blocking;
 pub use ort_infer_execution::TensorInput;
 pub use session::load_session;

--- a/oar-ocr-core/src/core/inference/model_source.rs
+++ b/oar-ocr-core/src/core/inference/model_source.rs
@@ -1,0 +1,148 @@
+//! Model source abstraction: filesystem path or in-memory bytes.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Where to load an ONNX model from.
+///
+/// Every model-accepting builder takes `impl Into<ModelSource>`, so existing
+/// path-based call sites keep working while callers can also pass raw model
+/// bytes (e.g. from `include_bytes!` or decrypted at runtime):
+///
+/// ```
+/// use oar_ocr_core::core::ModelSource;
+///
+/// let from_path: ModelSource = "models/det.onnx".into();
+/// let from_bytes: ModelSource = vec![0u8; 4].into();
+/// assert!(from_path.as_path().is_some());
+/// assert!(from_bytes.as_path().is_none());
+/// ```
+#[derive(Clone)]
+pub enum ModelSource {
+    /// Load from a file path (resolved through the auto-download cache where
+    /// that feature applies).
+    Path(PathBuf),
+    /// Load from in-memory ONNX bytes. `Arc` keeps clones cheap; models whose
+    /// weights live in external-data sidecar files cannot be loaded this way.
+    Memory(Arc<[u8]>),
+}
+
+impl ModelSource {
+    /// The path for `Path` sources, `None` for in-memory sources.
+    pub fn as_path(&self) -> Option<&Path> {
+        match self {
+            Self::Path(p) => Some(p),
+            Self::Memory(_) => None,
+        }
+    }
+
+    /// A path usable for logging and error messages.
+    pub fn display_path(&self) -> PathBuf {
+        match self {
+            Self::Path(p) => p.clone(),
+            Self::Memory(bytes) => PathBuf::from(format!("<in-memory: {} bytes>", bytes.len())),
+        }
+    }
+}
+
+impl std::fmt::Debug for ModelSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Path(p) => f.debug_tuple("Path").field(p).finish(),
+            Self::Memory(bytes) => f.debug_struct("Memory").field("len", &bytes.len()).finish(),
+        }
+    }
+}
+
+impl From<&ModelSource> for ModelSource {
+    fn from(source: &ModelSource) -> Self {
+        source.clone()
+    }
+}
+
+impl From<PathBuf> for ModelSource {
+    fn from(p: PathBuf) -> Self {
+        Self::Path(p)
+    }
+}
+
+impl From<&PathBuf> for ModelSource {
+    fn from(p: &PathBuf) -> Self {
+        Self::Path(p.clone())
+    }
+}
+
+impl From<&Path> for ModelSource {
+    fn from(p: &Path) -> Self {
+        Self::Path(p.to_path_buf())
+    }
+}
+
+impl From<String> for ModelSource {
+    fn from(p: String) -> Self {
+        Self::Path(PathBuf::from(p))
+    }
+}
+
+impl From<&str> for ModelSource {
+    fn from(p: &str) -> Self {
+        Self::Path(PathBuf::from(p))
+    }
+}
+
+impl From<Vec<u8>> for ModelSource {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self::Memory(bytes.into())
+    }
+}
+
+impl From<Arc<[u8]>> for ModelSource {
+    fn from(bytes: Arc<[u8]>) -> Self {
+        Self::Memory(bytes)
+    }
+}
+
+impl From<&'static [u8]> for ModelSource {
+    fn from(bytes: &'static [u8]) -> Self {
+        Self::Memory(bytes.into())
+    }
+}
+
+impl<const N: usize> From<&'static [u8; N]> for ModelSource {
+    fn from(bytes: &'static [u8; N]) -> Self {
+        Self::Memory(bytes.as_slice().into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_like_inputs_become_path_sources() {
+        for source in [
+            ModelSource::from("a/b.onnx"),
+            ModelSource::from(String::from("a/b.onnx")),
+            ModelSource::from(PathBuf::from("a/b.onnx")),
+            ModelSource::from(Path::new("a/b.onnx")),
+        ] {
+            assert_eq!(source.as_path(), Some(Path::new("a/b.onnx")));
+        }
+    }
+
+    #[test]
+    fn byte_inputs_become_memory_sources() {
+        static EMBEDDED: [u8; 4] = [1, 2, 3, 4];
+        for source in [
+            ModelSource::from(vec![1u8, 2, 3, 4]),
+            ModelSource::from(&EMBEDDED),
+            ModelSource::from(EMBEDDED.as_slice()),
+        ] {
+            assert!(source.as_path().is_none());
+            let ModelSource::Memory(bytes) = source else {
+                panic!("expected memory source");
+            };
+            assert_eq!(&bytes[..], &[1, 2, 3, 4]);
+        }
+    }
+}

--- a/oar-ocr-core/src/core/inference/ort_infer_builders.rs
+++ b/oar-ocr-core/src/core/inference/ort_infer_builders.rs
@@ -1,15 +1,18 @@
 use super::{session, *};
 use crate::core::config::ModelInferenceConfig;
+use crate::core::inference::ModelSource;
 use ort::logging::LogLevel;
-use std::path::Path;
 use std::sync::Mutex;
 
 impl OrtInfer {
     /// Creates a new OrtInfer instance with default ONNX Runtime settings and a single session.
-    pub fn new(model_path: impl AsRef<Path>, input_name: Option<&str>) -> Result<Self, OCRError> {
-        let path = model_path.as_ref();
+    pub fn new(
+        model_source: impl Into<ModelSource>,
+        input_name: Option<&str>,
+    ) -> Result<Self, OCRError> {
+        let source = model_source.into();
         let session = session::load_session_with(
-            path,
+            source.clone(),
             |builder| Ok(builder.with_log_level(LogLevel::Error)?),
             Some("verify model path and compatibility with selected execution providers"),
         )?;
@@ -19,7 +22,7 @@ impl OrtInfer {
             sessions: vec![Mutex::new(session)],
             next_idx: std::sync::atomic::AtomicUsize::new(0),
             input_name: input_name.unwrap_or("x").to_string(),
-            model_path: path.to_path_buf(),
+            model_path: source.display_path(),
             model_name,
         })
     }
@@ -28,10 +31,10 @@ impl OrtInfer {
     /// configuration.
     pub fn from_config(
         common: &ModelInferenceConfig,
-        model_path: impl AsRef<Path>,
+        model_source: impl Into<ModelSource>,
         input_name: Option<&str>,
     ) -> Result<Self, OCRError> {
-        let path = model_path.as_ref();
+        let source = model_source.into();
 
         // Workaround for a non-deterministic data race in ORT's CUDA EP that
         // corrupts arena buffers reused across `session.run()` calls.
@@ -41,7 +44,7 @@ impl OrtInfer {
         Self::ensure_cuda_launch_blocking_if_needed(common);
 
         let session = session::load_session_with(
-            path,
+            source.clone(),
             |builder| {
                 if let Some(cfg) = &common.ort_session {
                     Self::apply_ort_config(builder, cfg)
@@ -61,7 +64,7 @@ impl OrtInfer {
             sessions: vec![Mutex::new(session)],
             next_idx: std::sync::atomic::AtomicUsize::new(0),
             input_name: input_name.unwrap_or("x").to_string(),
-            model_path: path.to_path_buf(),
+            model_path: source.display_path(),
             model_name,
         })
     }

--- a/oar-ocr-core/src/core/inference/session.rs
+++ b/oar-ocr-core/src/core/inference/session.rs
@@ -1,6 +1,7 @@
 //! Helpers for working directly with ONNX Runtime sessions.
 
 use crate::core::errors::OCRError;
+use crate::core::inference::ModelSource;
 use ort::logging::LogLevel;
 use ort::session::{Session, builder::SessionBuilder};
 use std::path::Path;
@@ -8,9 +9,9 @@ use std::path::Path;
 const SESSION_CREATION_FAILURE: &str = "failed to create ONNX session";
 
 /// Loads a session with default logging configuration.
-pub fn load_session(model_path: impl AsRef<Path>) -> Result<Session, OCRError> {
+pub fn load_session(model_source: impl Into<ModelSource>) -> Result<Session, OCRError> {
     load_session_with(
-        model_path,
+        model_source,
         |builder| Ok(builder.with_log_level(LogLevel::Error)?),
         Some("verify model file exists and is readable"),
     )
@@ -18,18 +19,28 @@ pub fn load_session(model_path: impl AsRef<Path>) -> Result<Session, OCRError> {
 
 /// Builds a session using a caller-provided builder configuration.
 pub(crate) fn load_session_with<F>(
-    model_path: impl AsRef<Path>,
+    model_source: impl Into<ModelSource>,
     configure_builder: F,
     suggestion: Option<&str>,
 ) -> Result<Session, OCRError>
 where
     F: FnOnce(SessionBuilder) -> Result<SessionBuilder, ort::Error>,
 {
-    let path = model_path.as_ref();
+    let source = model_source.into();
     let builder = Session::builder()?;
     let mut builder = configure_builder(builder)?;
-    let session = builder.commit_from_file(path).map_err(|e| {
-        OCRError::model_load_error(path, SESSION_CREATION_FAILURE, suggestion, Some(e))
-    })?;
+    let session = match &source {
+        ModelSource::Path(path) => builder.commit_from_file(path).map_err(|e| {
+            OCRError::model_load_error(path, SESSION_CREATION_FAILURE, suggestion, Some(e))
+        })?,
+        ModelSource::Memory(bytes) => builder.commit_from_memory(bytes).map_err(|e| {
+            OCRError::model_load_error(
+                Path::new("<in-memory model>"),
+                SESSION_CREATION_FAILURE,
+                suggestion,
+                Some(e),
+            )
+        })?,
+    };
     Ok(session)
 }

--- a/oar-ocr-core/src/core/macros.rs
+++ b/oar-ocr-core/src/core/macros.rs
@@ -605,9 +605,12 @@ macro_rules! impl_adapter_builder {
             type Config = $Config;
             type Adapter = $Adapter;
 
-            fn build(self, model_path: &std::path::Path) -> Result<Self::Adapter, $crate::core::OCRError> {
-                let build_fn: fn(Self, &std::path::Path) -> Result<$Adapter, $crate::core::OCRError> = $build_closure;
-                build_fn(self, model_path)
+            fn build(
+                self,
+                model_source: impl Into<$crate::core::ModelSource>,
+            ) -> Result<Self::Adapter, $crate::core::OCRError> {
+                let build_fn: fn(Self, $crate::core::ModelSource) -> Result<$Adapter, $crate::core::OCRError> = $build_closure;
+                build_fn(self, model_source.into())
             }
 
             fn with_config(mut self, config: Self::Config) -> Self {
@@ -763,9 +766,12 @@ macro_rules! impl_adapter_builder {
             type Config = $Config;
             type Adapter = $Adapter;
 
-            fn build(self, model_path: &std::path::Path) -> Result<Self::Adapter, $crate::core::OCRError> {
-                let build_fn: fn(Self, &std::path::Path) -> Result<$Adapter, $crate::core::OCRError> = $build_closure;
-                build_fn(self, model_path)
+            fn build(
+                self,
+                model_source: impl Into<$crate::core::ModelSource>,
+            ) -> Result<Self::Adapter, $crate::core::OCRError> {
+                let build_fn: fn(Self, $crate::core::ModelSource) -> Result<$Adapter, $crate::core::OCRError> = $build_closure;
+                build_fn(self, model_source.into())
             }
 
             fn with_config(self, config: Self::Config) -> Self {
@@ -827,9 +833,12 @@ macro_rules! impl_adapter_builder {
             type Config = $Config;
             type Adapter = $Adapter;
 
-            fn build(self, model_path: &std::path::Path) -> Result<Self::Adapter, $crate::core::OCRError> {
-                let build_fn: fn(Self, &std::path::Path) -> Result<$Adapter, $crate::core::OCRError> = $build_closure;
-                build_fn(self, model_path)
+            fn build(
+                self,
+                model_source: impl Into<$crate::core::ModelSource>,
+            ) -> Result<Self::Adapter, $crate::core::OCRError> {
+                let build_fn: fn(Self, $crate::core::ModelSource) -> Result<$Adapter, $crate::core::OCRError> = $build_closure;
+                build_fn(self, model_source.into())
             }
 
             fn with_config(self, config: Self::Config) -> Self {

--- a/oar-ocr-core/src/core/mod.rs
+++ b/oar-ocr-core/src/core/mod.rs
@@ -43,7 +43,7 @@ pub use config::{
 pub use constants::*;
 pub use errors::{OCRError, OcrResult, OpaqueError, ProcessingStage};
 pub use image_reader::DefaultImageReader;
-pub use inference::{OrtInfer, TensorInput, TensorOutput, load_session};
+pub use inference::{ModelSource, OrtInfer, TensorInput, TensorOutput, load_session};
 pub use traits::{
     AdapterBuilder, AdapterInfo, AdapterTask, GranularImageReader, ImageReader, ImageTaskInput,
     ModelAdapter, Postprocessor, Preprocessor, Sampler, Task, TaskRunner, TaskSchema, TaskType,

--- a/oar-ocr-core/src/core/traits/adapter.rs
+++ b/oar-ocr-core/src/core/traits/adapter.rs
@@ -7,7 +7,6 @@
 use super::task::{Task, TaskSchema, TaskType};
 use crate::core::OCRError;
 use std::fmt::Debug;
-use std::path::Path;
 
 /// Information about a model adapter.
 #[derive(Debug, Clone)]
@@ -122,16 +121,19 @@ pub trait AdapterBuilder: Sized {
     /// The adapter type that this builder creates
     type Adapter: ModelAdapter;
 
-    /// Builds an adapter from a model file.
+    /// Builds an adapter from a model source.
     ///
     /// # Arguments
     ///
-    /// * `model_path` - Path to the model file (e.g., ONNX file)
+    /// * `model_source` - Model file path or in-memory model bytes
     ///
     /// # Returns
     ///
     /// The built adapter or an error
-    fn build(self, model_path: &Path) -> Result<Self::Adapter, OCRError>;
+    fn build(
+        self,
+        model_source: impl Into<crate::core::inference::ModelSource>,
+    ) -> Result<Self::Adapter, OCRError>;
 
     /// Configures the builder with the given configuration.
     ///

--- a/oar-ocr-core/src/domain/adapters/document_orientation_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/document_orientation_adapter.rs
@@ -153,7 +153,7 @@ impl_adapter_builder! {
         }
     }
 
-    build: |builder: DocumentOrientationAdapterBuilder, model_path: &std::path::Path| -> Result<DocumentOrientationAdapter, OCRError> {
+    build: |builder: DocumentOrientationAdapterBuilder, model_source: crate::core::ModelSource| -> Result<DocumentOrientationAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -167,7 +167,7 @@ impl_adapter_builder! {
             PPLCNetModelBuilder::new().preprocess_config(preprocess_config),
             ort_config
         )
-        .build(model_path)?;
+        .build(model_source)?;
 
         // Create postprocessing configuration
         let postprocess_config = PPLCNetPostprocessConfig {

--- a/oar-ocr-core/src/domain/adapters/document_rectification_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/document_rectification_adapter.rs
@@ -93,7 +93,7 @@ impl_adapter_builder! {
         },
     }
 
-    build: |builder: UVDocRectifierAdapterBuilder, model_path: &std::path::Path| -> Result<UVDocRectifierAdapter, OCRError> {
+    build: |builder: UVDocRectifierAdapterBuilder, model_source: crate::core::ModelSource| -> Result<UVDocRectifierAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -105,7 +105,7 @@ impl_adapter_builder! {
             UVDocModelBuilder::new().preprocess_config(builder.preprocess_config),
             ort_config
         )
-        .build(model_path)?;
+        .build(model_source)?;
 
         // Create adapter info using the helper
         let mut info = UVDocRectifierAdapterBuilder::base_adapter_info();

--- a/oar-ocr-core/src/domain/adapters/formula_recognition_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/formula_recognition_adapter.rs
@@ -13,7 +13,7 @@ use crate::models::recognition::{
     pp_formulanet::PPFormulaNetPostprocessConfig, unimernet::UniMERNetPostprocessConfig,
 };
 use crate::processors::normalize_latex;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Instant;
 use tokenizers::Tokenizer;
 
@@ -383,7 +383,7 @@ impl_adapter_builder! {
         }
     }
 
-    build: |builder: PPFormulaNetAdapterBuilder, model_path: &Path| -> Result<FormulaRecognitionAdapter, OCRError> {
+    build: |builder: PPFormulaNetAdapterBuilder, model_source: crate::core::ModelSource| -> Result<FormulaRecognitionAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -396,7 +396,7 @@ impl_adapter_builder! {
             model_builder = model_builder.target_size(width, height);
         }
         let model = FormulaModel::PPFormulaNet(
-            apply_ort_config!(model_builder, ort_config).build(model_path)?
+            apply_ort_config!(model_builder, ort_config).build(model_source)?
         );
 
         // Tokenizer path is required
@@ -486,7 +486,7 @@ impl_adapter_builder! {
         }
     }
 
-    build: |builder: UniMERNetAdapterBuilder, model_path: &Path| -> Result<FormulaRecognitionAdapter, OCRError> {
+    build: |builder: UniMERNetAdapterBuilder, model_source: crate::core::ModelSource| -> Result<FormulaRecognitionAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -499,7 +499,7 @@ impl_adapter_builder! {
             model_builder = model_builder.target_size(width, height);
         }
         let model = FormulaModel::UniMERNet(
-            apply_ort_config!(model_builder, ort_config).build(model_path)?
+            apply_ort_config!(model_builder, ort_config).build(model_source)?
         );
 
         // Tokenizer path is required

--- a/oar-ocr-core/src/domain/adapters/layout_detection_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/layout_detection_adapter.rs
@@ -20,7 +20,6 @@ use crate::models::detection::{
 use crate::processors::{ImageScaleInfo, LayoutPostProcess, apply_nms_with_merge, unclip_boxes};
 use ndarray::Axis;
 use std::collections::HashMap;
-use std::path::Path;
 
 /// Result data for layout detection box filtering and merging operations.
 ///
@@ -1231,7 +1230,7 @@ impl LayoutDetectionAdapterBuilder {
     /// Builds the adapter with the specified model configuration.
     fn build_with_config(
         self,
-        model_path: &Path,
+        model_source: crate::core::ModelSource,
         model_config: LayoutModelConfig,
     ) -> Result<LayoutDetectionAdapter, OCRError> {
         let (task_config, ort_config) =
@@ -1252,16 +1251,16 @@ impl LayoutDetectionAdapterBuilder {
                 ort_session: ort_config,
                 ..Default::default()
             };
-            OrtInfer::from_config(&common_config, model_path, input_name)?
+            OrtInfer::from_config(&common_config, model_source, input_name)?
         } else {
             match model_config.model_type.as_str() {
                 "pp-doclayout" => {
                     // PP-DocLayout models use "image" as the input name
-                    OrtInfer::new(model_path, Some("image"))?
+                    OrtInfer::new(model_source, Some("image"))?
                 }
                 _ => {
                     // Other models use default or auto-detect
-                    OrtInfer::new(model_path, None)?
+                    OrtInfer::new(model_source, None)?
                 }
             }
         };
@@ -1344,7 +1343,10 @@ impl AdapterBuilder for LayoutDetectionAdapterBuilder {
     type Config = LayoutDetectionConfig;
     type Adapter = LayoutDetectionAdapter;
 
-    fn build(self, model_path: &Path) -> Result<Self::Adapter, OCRError> {
+    fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<Self::Adapter, OCRError> {
         let model_config = self
             .model_config
             .clone()
@@ -1352,7 +1354,7 @@ impl AdapterBuilder for LayoutDetectionAdapterBuilder {
                 message: "Model configuration is required".to_string(),
             })?;
 
-        self.build_with_config(model_path, model_config)
+        self.build_with_config(model_source.into(), model_config)
     }
 
     fn with_config(mut self, config: Self::Config) -> Self {
@@ -1435,8 +1437,11 @@ impl AdapterBuilder for PicoDetLayoutAdapterBuilder {
     type Config = LayoutDetectionConfig;
     type Adapter = PicoDetLayoutAdapter;
 
-    fn build(self, model_path: &Path) -> Result<Self::Adapter, OCRError> {
-        self.inner.build(model_path)
+    fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<Self::Adapter, OCRError> {
+        self.inner.build(model_source)
     }
 
     fn with_config(mut self, config: Self::Config) -> Self {
@@ -1510,8 +1515,11 @@ impl AdapterBuilder for RTDetrLayoutAdapterBuilder {
     type Config = LayoutDetectionConfig;
     type Adapter = RTDetrLayoutAdapter;
 
-    fn build(self, model_path: &Path) -> Result<Self::Adapter, OCRError> {
-        self.inner.build(model_path)
+    fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<Self::Adapter, OCRError> {
+        self.inner.build(model_source)
     }
 
     fn with_config(mut self, config: Self::Config) -> Self {
@@ -1620,8 +1628,11 @@ impl AdapterBuilder for PPDocLayoutAdapterBuilder {
     type Config = LayoutDetectionConfig;
     type Adapter = PPDocLayoutAdapter;
 
-    fn build(self, model_path: &Path) -> Result<Self::Adapter, OCRError> {
-        self.inner.build(model_path)
+    fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<Self::Adapter, OCRError> {
+        self.inner.build(model_source)
     }
 
     fn with_config(mut self, config: Self::Config) -> Self {

--- a/oar-ocr-core/src/domain/adapters/seal_text_detection_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/seal_text_detection_adapter.rs
@@ -109,7 +109,7 @@ impl_adapter_builder! {
     fields: {},
     methods: {}
 
-    build: |builder: SealTextDetectionAdapterBuilder, model_path: &std::path::Path| -> Result<SealTextDetectionAdapter, OCRError> {
+    build: |builder: SealTextDetectionAdapterBuilder, model_source: crate::core::ModelSource| -> Result<SealTextDetectionAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -137,7 +137,7 @@ impl_adapter_builder! {
                 .postprocess_config(postprocess_config),
             ort_config
         )
-        .build(model_path)?;
+        .build(model_source)?;
 
         // Create adapter info using the helper
         let info = SealTextDetectionAdapterBuilder::base_adapter_info();

--- a/oar-ocr-core/src/domain/adapters/table_cell_detection_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/table_cell_detection_adapter.rs
@@ -14,7 +14,6 @@ use crate::impl_adapter_builder;
 use crate::models::detection::{RTDetrModel, RTDetrModelBuilder, RTDetrPostprocessConfig};
 use crate::processors::{ImageScaleInfo, LayoutPostProcess};
 use std::collections::HashMap;
-use std::path::Path;
 
 /// Configuration describing a table cell detection model.
 #[derive(Debug, Clone)]
@@ -210,7 +209,7 @@ impl_adapter_builder! {
         }
     }
 
-    build: |builder: TableCellDetectionAdapterBuilder, model_path: &Path| -> Result<TableCellDetectionAdapter, OCRError> {
+    build: |builder: TableCellDetectionAdapterBuilder, model_source: crate::core::ModelSource| -> Result<TableCellDetectionAdapter, OCRError> {
         let model_config = builder.model_config.ok_or_else(|| OCRError::InvalidInput {
             message: "Table cell model configuration is required".to_string(),
         })?;
@@ -221,13 +220,13 @@ impl_adapter_builder! {
                 message: err.to_string(),
             })?;
 
-        TableCellDetectionAdapterBuilder::build_with_config(model_path, model_config, task_config, ort_config)
+        TableCellDetectionAdapterBuilder::build_with_config(model_source, model_config, task_config, ort_config)
     },
 }
 
 impl TableCellDetectionAdapterBuilder {
     fn build_with_config(
-        model_path: &Path,
+        model_source: crate::core::ModelSource,
         model_config: TableCellModelConfig,
         task_config: TableCellDetectionConfig,
         ort_config: Option<crate::core::config::OrtSessionConfig>,
@@ -238,9 +237,9 @@ impl TableCellDetectionAdapterBuilder {
                 ort_session: ort_config,
                 ..Default::default()
             };
-            OrtInfer::from_config(&common_config, model_path, None)?
+            OrtInfer::from_config(&common_config, model_source, None)?
         } else {
-            OrtInfer::new(model_path, None)?
+            OrtInfer::new(model_source, None)?
         };
 
         let postprocessor = LayoutPostProcess::new(
@@ -341,8 +340,11 @@ impl AdapterBuilder for RTDetrTableCellAdapterBuilder {
     type Config = TableCellDetectionConfig;
     type Adapter = TableCellDetectionAdapter;
 
-    fn build(self, model_path: &Path) -> Result<Self::Adapter, OCRError> {
-        self.inner.build(model_path)
+    fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<Self::Adapter, OCRError> {
+        self.inner.build(model_source)
     }
 
     fn with_config(mut self, config: Self::Config) -> Self {

--- a/oar-ocr-core/src/domain/adapters/table_classification_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/table_classification_adapter.rs
@@ -13,7 +13,6 @@ use crate::domain::tasks::{
 };
 use crate::impl_adapter_builder;
 use crate::models::classification::{PPLCNetModel, PPLCNetModelBuilder, PPLCNetPostprocessConfig};
-use std::path::Path;
 
 /// Table classification adapter that uses the PP-LCNet model.
 #[derive(Debug)]
@@ -159,7 +158,7 @@ impl_adapter_builder! {
         }
     }
 
-    build: |builder: TableClassificationAdapterBuilder, model_path: &Path| -> Result<TableClassificationAdapter, OCRError> {
+    build: |builder: TableClassificationAdapterBuilder, model_source: crate::core::ModelSource| -> Result<TableClassificationAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -173,7 +172,7 @@ impl_adapter_builder! {
             PPLCNetModelBuilder::new().preprocess_config(preprocess_config),
             ort_config
         )
-        .build(model_path)?;
+        .build(model_source)?;
 
         // Create postprocessing configuration
         let postprocess_config = PPLCNetPostprocessConfig {

--- a/oar-ocr-core/src/domain/adapters/table_structure_recognition_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/table_structure_recognition_adapter.rs
@@ -12,7 +12,6 @@ use crate::domain::tasks::{TableStructureRecognitionConfig, TableStructureRecogn
 use crate::impl_adapter_builder;
 use crate::models::recognition::{SLANetModel, SLANetModelBuilder};
 use crate::processors::TableStructureDecode;
-use std::path::Path;
 
 /// Table structure recognition adapter that uses the SLANet model.
 #[derive(Debug)]
@@ -241,7 +240,7 @@ impl_adapter_builder! {
         }
     }
 
-    build: |builder: SLANetWiredAdapterBuilder, model_path: &Path| -> Result<TableStructureRecognitionAdapter, OCRError> {
+    build: |builder: SLANetWiredAdapterBuilder, model_source: crate::core::ModelSource| -> Result<TableStructureRecognitionAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -256,7 +255,7 @@ impl_adapter_builder! {
             model_builder = model_builder.input_size(input_shape);
         }
 
-        let model = apply_ort_config!(model_builder, ort_config).build(model_path)?;
+        let model = apply_ort_config!(model_builder, ort_config).build(model_source)?;
 
         // Dictionary path is required
         let dict_path = builder.dict_path.ok_or_else(|| OCRError::ConfigError {
@@ -318,7 +317,7 @@ impl_adapter_builder! {
         }
     }
 
-    build: |builder: SLANetWirelessAdapterBuilder, model_path: &Path| -> Result<TableStructureRecognitionAdapter, OCRError> {
+    build: |builder: SLANetWirelessAdapterBuilder, model_source: crate::core::ModelSource| -> Result<TableStructureRecognitionAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -333,7 +332,7 @@ impl_adapter_builder! {
             model_builder = model_builder.input_size(input_shape);
         }
 
-        let model = apply_ort_config!(model_builder, ort_config).build(model_path)?;
+        let model = apply_ort_config!(model_builder, ort_config).build(model_source)?;
 
         // Dictionary path is required
         let dict_path = builder.dict_path.ok_or_else(|| OCRError::ConfigError {

--- a/oar-ocr-core/src/domain/adapters/text_detection_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/text_detection_adapter.rs
@@ -122,7 +122,7 @@ impl_adapter_builder! {
         }
     }
 
-    build: |builder: TextDetectionAdapterBuilder, model_path: &std::path::Path| -> Result<TextDetectionAdapter, OCRError> {
+    build: |builder: TextDetectionAdapterBuilder, model_source: crate::core::ModelSource| -> Result<TextDetectionAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -179,7 +179,7 @@ impl_adapter_builder! {
                 .postprocess_config(postprocess_config),
             ort_config
         )
-        .build(model_path)?;
+        .build(model_source)?;
 
         // Create adapter info using the helper
         let mut info = TextDetectionAdapterBuilder::base_adapter_info();

--- a/oar-ocr-core/src/domain/adapters/text_line_orientation_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/text_line_orientation_adapter.rs
@@ -148,7 +148,7 @@ impl_adapter_builder! {
         }
     }
 
-    build: |builder: TextLineOrientationAdapterBuilder, model_path: &std::path::Path| -> Result<TextLineOrientationAdapter, OCRError> {
+    build: |builder: TextLineOrientationAdapterBuilder, model_source: crate::core::ModelSource| -> Result<TextLineOrientationAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -166,7 +166,7 @@ impl_adapter_builder! {
             PPLCNetModelBuilder::new().preprocess_config(preprocess_config),
             ort_config
         )
-        .build(model_path)?;
+        .build(model_source)?;
 
         // Create postprocessing configuration
         let postprocess_config = PPLCNetPostprocessConfig {

--- a/oar-ocr-core/src/domain/adapters/text_recognition_adapter.rs
+++ b/oar-ocr-core/src/domain/adapters/text_recognition_adapter.rs
@@ -181,7 +181,7 @@ impl_adapter_builder! {
         }
     }
 
-    build: |builder: TextRecognitionAdapterBuilder, model_path: &std::path::Path| -> Result<TextRecognitionAdapter, OCRError> {
+    build: |builder: TextRecognitionAdapterBuilder, model_source: crate::core::ModelSource| -> Result<TextRecognitionAdapter, OCRError> {
         let (task_config, ort_config) = builder.config
             .into_validated_parts()
             .map_err(|err| OCRError::ConfigError {
@@ -195,7 +195,7 @@ impl_adapter_builder! {
             model_builder = model_builder.character_dict(character_dict);
         }
 
-        let model = apply_ort_config!(model_builder, ort_config).build(model_path)?;
+        let model = apply_ort_config!(model_builder, ort_config).build(model_source)?;
 
         // Create adapter info using the helper
         let mut info = TextRecognitionAdapterBuilder::base_adapter_info();

--- a/oar-ocr-core/src/models/classification/pp_lcnet.rs
+++ b/oar-ocr-core/src/models/classification/pp_lcnet.rs
@@ -360,12 +360,15 @@ impl PPLCNetModelBuilder {
     ///
     /// # Arguments
     ///
-    /// * `model_path` - Path to the ONNX model file
+    /// * `model_source` - Path to the ONNX model file
     ///
     /// # Returns
     ///
     /// A configured PP-LCNet model instance
-    pub fn build(self, model_path: &std::path::Path) -> Result<PPLCNetModel, OCRError> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<PPLCNetModel, OCRError> {
         // Create ONNX inference engine
         let inference = if self.ort_config.is_some() {
             use crate::core::config::ModelInferenceConfig;
@@ -373,9 +376,9 @@ impl PPLCNetModelBuilder {
                 ort_session: self.ort_config,
                 ..Default::default()
             };
-            OrtInfer::from_config(&common_config, model_path, None)?
+            OrtInfer::from_config(&common_config, model_source, None)?
         } else {
-            OrtInfer::new(model_path, None)?
+            OrtInfer::new(model_source, None)?
         };
 
         // Create normalizer (ImageNet normalization).

--- a/oar-ocr-core/src/models/detection/db.rs
+++ b/oar-ocr-core/src/models/detection/db.rs
@@ -10,7 +10,6 @@ use crate::processors::{
     LimitType, NormalizeImage, ScoreMode, TensorLayout,
 };
 use image::{DynamicImage, GenericImageView, RgbImage};
-use std::path::Path;
 use tracing::debug;
 
 /// Configuration for DB model preprocessing.
@@ -375,7 +374,10 @@ impl DBModelBuilder {
     }
 
     /// Builds the DB model.
-    pub fn build(self, model_path: &Path) -> Result<DBModel, OCRError> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<DBModel, OCRError> {
         // Create ONNX inference engine
         let inference = if self.ort_config.is_some() {
             use crate::core::config::ModelInferenceConfig;
@@ -383,9 +385,9 @@ impl DBModelBuilder {
                 ort_session: self.ort_config,
                 ..Default::default()
             };
-            OrtInfer::from_config(&common_config, model_path, Some("x"))?
+            OrtInfer::from_config(&common_config, model_source, Some("x"))?
         } else {
-            OrtInfer::new(model_path, Some("x"))?
+            OrtInfer::new(model_source, Some("x"))?
         };
 
         // Create resizer

--- a/oar-ocr-core/src/models/recognition/crnn.rs
+++ b/oar-ocr-core/src/models/recognition/crnn.rs
@@ -8,7 +8,6 @@ use crate::core::inference::{OrtInfer, TensorInput};
 use crate::processors::{CTCLabelDecode, OCRResize};
 use image::RgbImage;
 use rayon::prelude::*;
-use std::path::Path;
 
 /// CRNN model output containing recognized text and confidence scores.
 #[derive(Debug, Clone)]
@@ -331,16 +330,19 @@ impl CRNNModelBuilder {
     }
 
     /// Builds the CRNN model.
-    pub fn build(self, model_path: &Path) -> Result<CRNNModel, OCRError> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<CRNNModel, OCRError> {
         // Create ONNX inference engine
         let inference = if self.ort_config.is_some() {
             let common = crate::core::config::ModelInferenceConfig {
                 ort_session: self.ort_config,
                 ..Default::default()
             };
-            OrtInfer::from_config(&common, model_path, None)?
+            OrtInfer::from_config(&common, model_source, None)?
         } else {
-            OrtInfer::new(model_path, None)?
+            OrtInfer::new(model_source, None)?
         };
 
         // Create resizer

--- a/oar-ocr-core/src/models/recognition/pp_formulanet.rs
+++ b/oar-ocr-core/src/models/recognition/pp_formulanet.rs
@@ -313,7 +313,10 @@ impl PPFormulaNetModelBuilder {
     }
 
     /// Builds the PP-FormulaNet model.
-    pub fn build(self, model_path: &std::path::Path) -> Result<PPFormulaNetModel, OCRError> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<PPFormulaNetModel, OCRError> {
         // Create ONNX inference engine
         let ort_config = self
             .ort_config
@@ -329,9 +332,9 @@ impl PPFormulaNetModelBuilder {
                 model_name: Some("PP-FormulaNet".to_string()),
                 ..Default::default()
             };
-            OrtInfer::from_config(&common_config, model_path, None)?
+            OrtInfer::from_config(&common_config, model_source, None)?
         } else {
-            OrtInfer::new(model_path, None)?
+            OrtInfer::new(model_source, None)?
         };
 
         // Determine target size

--- a/oar-ocr-core/src/models/recognition/slanet.rs
+++ b/oar-ocr-core/src/models/recognition/slanet.rs
@@ -21,7 +21,6 @@ use crate::core::inference::{OrtInfer, TensorInput};
 use crate::processors::NormalizeImage;
 use image::{DynamicImage, RgbImage};
 use ndarray::s;
-use std::path::Path;
 
 /// Output from SLANet model containing structure predictions and bounding boxes.
 #[derive(Debug, Clone)]
@@ -293,7 +292,10 @@ impl SLANetModelBuilder {
     /// 1. If explicitly set via `input_shape()` or `input_size()`, use that
     /// 2. Otherwise, parse from ONNX model metadata
     /// 3. If ONNX has dynamic spatial dimensions, use default 512x512
-    pub fn build(self, model_path: &Path) -> Result<SLANetModel, OCRError> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<SLANetModel, OCRError> {
         // Create ONNX inference engine
         let inference = if self.ort_config.is_some() {
             use crate::core::config::ModelInferenceConfig;
@@ -301,9 +303,9 @@ impl SLANetModelBuilder {
                 ort_session: self.ort_config,
                 ..Default::default()
             };
-            OrtInfer::from_config(&common_config, model_path, None)?
+            OrtInfer::from_config(&common_config, model_source, None)?
         } else {
-            OrtInfer::new(model_path, None)?
+            OrtInfer::new(model_source, None)?
         };
 
         // Determine input shape: user override > ONNX metadata > default

--- a/oar-ocr-core/src/models/recognition/unimernet.rs
+++ b/oar-ocr-core/src/models/recognition/unimernet.rs
@@ -252,7 +252,10 @@ impl UniMERNetModelBuilder {
     }
 
     /// Builds the UniMERNet model.
-    pub fn build(self, model_path: &std::path::Path) -> Result<UniMERNetModel, OCRError> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<UniMERNetModel, OCRError> {
         // Create ONNX inference engine
         let ort_config = self.ort_config.map(Self::configure_unimernet_ort_for_cuda);
 
@@ -265,9 +268,9 @@ impl UniMERNetModelBuilder {
                 model_name: Some("UniMERNet".to_string()),
                 ..Default::default()
             };
-            OrtInfer::from_config(&common_config, model_path, None)?
+            OrtInfer::from_config(&common_config, model_source, None)?
         } else {
-            OrtInfer::new(model_path, None)?
+            OrtInfer::new(model_source, None)?
         };
 
         // Determine target size

--- a/oar-ocr-core/src/models/rectification/uvdoc.rs
+++ b/oar-ocr-core/src/models/rectification/uvdoc.rs
@@ -261,12 +261,15 @@ impl UVDocModelBuilder {
     ///
     /// # Arguments
     ///
-    /// * `model_path` - Path to the ONNX model file
+    /// * `model_source` - Path to the ONNX model file
     ///
     /// # Returns
     ///
     /// A configured UVDoc model instance
-    pub fn build(self, model_path: &std::path::Path) -> Result<UVDocModel, OCRError> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> Result<UVDocModel, OCRError> {
         // Create ONNX inference engine
         let inference = if self.ort_config.is_some() {
             use crate::core::config::ModelInferenceConfig;
@@ -274,9 +277,9 @@ impl UVDocModelBuilder {
                 ort_session: self.ort_config,
                 ..Default::default()
             };
-            OrtInfer::from_config(&common_config, model_path, Some("image"))?
+            OrtInfer::from_config(&common_config, model_source, Some("image"))?
         } else {
-            OrtInfer::new(model_path, Some("image"))?
+            OrtInfer::new(model_source, Some("image"))?
         };
 
         // Create normalizer (scale to [0, 1] without mean shift).

--- a/oar-ocr-core/src/predictors/document_orientation.rs
+++ b/oar-ocr-core/src/predictors/document_orientation.rs
@@ -13,7 +13,6 @@ use crate::domain::tasks::document_orientation::{
 };
 use crate::predictors::TaskPredictorCore;
 use image::RgbImage;
-use std::path::Path;
 
 /// Document orientation prediction result
 #[derive(Debug, Clone)]
@@ -77,7 +76,10 @@ impl DocumentOrientationPredictorBuilder {
         self
     }
 
-    pub fn build<P: AsRef<Path>>(self, model_path: P) -> OcrResult<DocumentOrientationPredictor> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> OcrResult<DocumentOrientationPredictor> {
         let Self { state, input_shape } = self;
         let (config, ort_config) = state.into_parts();
         let mut adapter_builder = DocumentOrientationAdapterBuilder::new()
@@ -88,7 +90,7 @@ impl DocumentOrientationPredictorBuilder {
             adapter_builder = adapter_builder.with_ort_config(ort_cfg);
         }
 
-        let adapter = super::build_adapter(adapter_builder, model_path.as_ref())?;
+        let adapter = super::build_adapter(adapter_builder, model_source)?;
         let task = DocumentOrientationTask::new(config.clone());
         Ok(DocumentOrientationPredictor {
             core: TaskPredictorCore::new(adapter, task, config),

--- a/oar-ocr-core/src/predictors/document_rectification.rs
+++ b/oar-ocr-core/src/predictors/document_rectification.rs
@@ -14,7 +14,6 @@ use crate::domain::tasks::document_rectification::{
 };
 use crate::predictors::TaskPredictorCore;
 use image::RgbImage;
-use std::path::Path;
 
 /// Document rectification prediction result
 #[derive(Debug, Clone)]
@@ -58,7 +57,10 @@ impl DocumentRectificationPredictorBuilder {
         }
     }
 
-    pub fn build<P: AsRef<Path>>(self, model_path: P) -> OcrResult<DocumentRectificationPredictor> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> OcrResult<DocumentRectificationPredictor> {
         let (config, ort_config) = self.state.into_parts();
         let mut adapter_builder = UVDocRectifierAdapterBuilder::new().with_config(config.clone());
 
@@ -66,7 +68,7 @@ impl DocumentRectificationPredictorBuilder {
             adapter_builder = adapter_builder.with_ort_config(ort_cfg);
         }
 
-        let adapter = super::build_adapter(adapter_builder, model_path.as_ref())?;
+        let adapter = super::build_adapter(adapter_builder, model_source)?;
         let task = DocumentRectificationTask::new(config.clone());
         Ok(DocumentRectificationPredictor {
             core: TaskPredictorCore::new(adapter, task, config),

--- a/oar-ocr-core/src/predictors/formula_recognition.rs
+++ b/oar-ocr-core/src/predictors/formula_recognition.rs
@@ -150,7 +150,10 @@ impl FormulaRecognitionPredictorBuilder {
     }
 
     /// Build the formula recognition predictor
-    pub fn build<P: AsRef<Path>>(self, model_path: P) -> OcrResult<FormulaRecognitionPredictor> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> OcrResult<FormulaRecognitionPredictor> {
         let Self {
             state,
             model_name,
@@ -185,7 +188,7 @@ impl FormulaRecognitionPredictorBuilder {
                     builder = builder.with_ort_config(ort_cfg);
                 }
 
-                super::build_adapter(builder, model_path.as_ref())?
+                super::build_adapter(builder, model_source)?
             }
             FormulaModelKind::PPFormulaNet => {
                 let mut builder = PPFormulaNetAdapterBuilder::new()
@@ -201,7 +204,7 @@ impl FormulaRecognitionPredictorBuilder {
                     builder = builder.with_ort_config(ort_cfg);
                 }
 
-                super::build_adapter(builder, model_path.as_ref())?
+                super::build_adapter(builder, model_source)?
             }
         };
 

--- a/oar-ocr-core/src/predictors/layout_detection.rs
+++ b/oar-ocr-core/src/predictors/layout_detection.rs
@@ -12,7 +12,6 @@ use crate::domain::adapters::LayoutDetectionAdapterBuilder;
 use crate::domain::tasks::layout_detection::{LayoutDetectionConfig, LayoutDetectionTask};
 use crate::predictors::TaskPredictorCore;
 use image::RgbImage;
-use std::path::Path;
 
 /// Layout detection prediction result
 #[derive(Debug, Clone)]
@@ -82,7 +81,10 @@ impl LayoutDetectionPredictorBuilder {
         self
     }
 
-    pub fn build<P: AsRef<Path>>(self, model_path: P) -> OcrResult<LayoutDetectionPredictor> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> OcrResult<LayoutDetectionPredictor> {
         let (config, ort_config) = self.state.into_parts();
         let mut adapter_builder = LayoutDetectionAdapterBuilder::new().task_config(config.clone());
 
@@ -96,7 +98,7 @@ impl LayoutDetectionPredictorBuilder {
             adapter_builder = adapter_builder.with_ort_config(ort_cfg);
         }
 
-        let adapter = super::build_adapter(adapter_builder, model_path.as_ref())?;
+        let adapter = super::build_adapter(adapter_builder, model_source)?;
         let task = LayoutDetectionTask::new(config.clone());
         Ok(LayoutDetectionPredictor {
             core: TaskPredictorCore::new(adapter, task, config),

--- a/oar-ocr-core/src/predictors/mod.rs
+++ b/oar-ocr-core/src/predictors/mod.rs
@@ -10,6 +10,7 @@ mod core;
 
 use std::path::{Path, PathBuf};
 
+use crate::core::ModelSource;
 use crate::core::traits::adapter::{AdapterBuilder, ModelAdapter};
 
 pub use core::TaskPredictorCore;
@@ -25,16 +26,25 @@ pub(crate) fn resolve_asset_path(path: &Path) -> crate::core::OcrResult<PathBuf>
     }
 }
 
+/// Resolves `Path` sources through the auto-download cache; in-memory
+/// sources pass through untouched.
+pub(crate) fn resolve_model_source(source: ModelSource) -> crate::core::OcrResult<ModelSource> {
+    match source {
+        ModelSource::Path(path) => Ok(ModelSource::Path(resolve_asset_path(&path)?)),
+        memory @ ModelSource::Memory(_) => Ok(memory),
+    }
+}
+
 pub(crate) fn build_adapter<B>(
     builder: B,
-    model_path: &Path,
+    model_source: impl Into<ModelSource>,
 ) -> crate::core::OcrResult<Box<B::Adapter>>
 where
     B: AdapterBuilder,
     B::Adapter: ModelAdapter + 'static,
 {
-    let model_path = resolve_asset_path(model_path)?;
-    Ok(Box::new(builder.build(&model_path)?))
+    let model_source = resolve_model_source(model_source.into())?;
+    Ok(Box::new(builder.build(model_source)?))
 }
 
 pub mod document_orientation;

--- a/oar-ocr-core/src/predictors/seal_text_detection.rs
+++ b/oar-ocr-core/src/predictors/seal_text_detection.rs
@@ -11,7 +11,6 @@ use crate::domain::adapters::SealTextDetectionAdapterBuilder;
 use crate::domain::tasks::seal_text_detection::{SealTextDetectionConfig, SealTextDetectionTask};
 use crate::predictors::TaskPredictorCore;
 use image::RgbImage;
-use std::path::Path;
 
 /// Seal text detection prediction result
 #[derive(Debug, Clone)]
@@ -63,7 +62,10 @@ impl SealTextDetectionPredictorBuilder {
         self
     }
 
-    pub fn build<P: AsRef<Path>>(self, model_path: P) -> OcrResult<SealTextDetectionPredictor> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> OcrResult<SealTextDetectionPredictor> {
         let (config, ort_config) = self.state.into_parts();
         let mut adapter_builder =
             SealTextDetectionAdapterBuilder::new().with_config(config.clone());
@@ -72,7 +74,7 @@ impl SealTextDetectionPredictorBuilder {
             adapter_builder = adapter_builder.with_ort_config(ort_cfg);
         }
 
-        let adapter = super::build_adapter(adapter_builder, model_path.as_ref())?;
+        let adapter = super::build_adapter(adapter_builder, model_source)?;
         let task = SealTextDetectionTask::with_config(config.clone());
         Ok(SealTextDetectionPredictor {
             core: TaskPredictorCore::new(adapter, task, config),

--- a/oar-ocr-core/src/predictors/table_cell_detection.rs
+++ b/oar-ocr-core/src/predictors/table_cell_detection.rs
@@ -124,18 +124,25 @@ impl TableCellDetectionPredictorBuilder {
         self
     }
 
-    pub fn build<P: AsRef<Path>>(self, model_path: P) -> OcrResult<TableCellDetectionPredictor> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> OcrResult<TableCellDetectionPredictor> {
         let (config, ort_config) = self.state.into_parts();
-        let path_ref = model_path.as_ref();
+        let model_source = model_source.into();
         let variant = self
             .model_variant
-            .or_else(|| TableCellModelVariant::detect_from_path(path_ref))
+            .or_else(|| {
+                model_source
+                    .as_path()
+                    .and_then(TableCellModelVariant::detect_from_path)
+            })
             .ok_or_else(|| OCRError::ConfigError {
                 message: format!(
                     "Unable to determine table cell model variant from '{}'. \
                          Provide `model_variant(...)` on the builder or use a filename \
                          containing 'wired_table_cell' or 'wireless_table_cell'.",
-                    path_ref.display()
+                    model_source.display_path().display()
                 ),
             })?;
 
@@ -147,7 +154,7 @@ impl TableCellDetectionPredictorBuilder {
             adapter_builder = adapter_builder.with_ort_config(ort_cfg);
         }
 
-        let adapter = super::build_adapter(adapter_builder, path_ref)?;
+        let adapter = super::build_adapter(adapter_builder, model_source)?;
         let task = TableCellDetectionTask::new(config.clone());
         Ok(TableCellDetectionPredictor {
             core: TaskPredictorCore::new(adapter, task, config),

--- a/oar-ocr-core/src/predictors/table_classification.rs
+++ b/oar-ocr-core/src/predictors/table_classification.rs
@@ -14,7 +14,6 @@ use crate::domain::tasks::table_classification::{
 };
 use crate::predictors::TaskPredictorCore;
 use image::RgbImage;
-use std::path::Path;
 
 /// Table classification prediction result
 #[derive(Debug, Clone)]
@@ -83,7 +82,10 @@ impl TableClassificationPredictorBuilder {
     }
 
     /// Build the table classification predictor
-    pub fn build<P: AsRef<Path>>(self, model_path: P) -> OcrResult<TableClassificationPredictor> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> OcrResult<TableClassificationPredictor> {
         let Self { state, input_shape } = self;
         let (config, ort_config) = state.into_parts();
         let mut adapter_builder = TableClassificationAdapterBuilder::new()
@@ -94,7 +96,7 @@ impl TableClassificationPredictorBuilder {
             adapter_builder = adapter_builder.with_ort_config(ort_cfg);
         }
 
-        let adapter = super::build_adapter(adapter_builder, model_path.as_ref())?;
+        let adapter = super::build_adapter(adapter_builder, model_source)?;
         let task = TableClassificationTask::new(config.clone());
 
         Ok(TableClassificationPredictor {

--- a/oar-ocr-core/src/predictors/table_structure_recognition.rs
+++ b/oar-ocr-core/src/predictors/table_structure_recognition.rs
@@ -134,9 +134,9 @@ impl TableStructureRecognitionPredictorBuilder {
         self
     }
 
-    pub fn build<P: AsRef<Path>>(
+    pub fn build(
         self,
-        model_path: P,
+        model_source: impl Into<crate::core::ModelSource>,
     ) -> OcrResult<TableStructureRecognitionPredictor> {
         let Self {
             state,
@@ -148,7 +148,7 @@ impl TableStructureRecognitionPredictorBuilder {
         let dict_path = dict_path.ok_or_else(|| {
             OCRError::missing_field("dict_path", "TableStructureRecognitionPredictor")
         })?;
-        let model_path_ref = model_path.as_ref();
+        let model_source = model_source.into();
 
         let model_family = if let Some(name) = model_name.as_deref() {
             TableStructureModelFamily::from_model_name(name).ok_or_else(|| {
@@ -161,7 +161,9 @@ impl TableStructureRecognitionPredictorBuilder {
                 }
             })?
         } else {
-            TableStructureModelFamily::detect_from_path(model_path_ref)
+            model_source
+                .as_path()
+                .and_then(TableStructureModelFamily::detect_from_path)
                 .unwrap_or(TableStructureModelFamily::Wired)
         };
 
@@ -185,7 +187,7 @@ impl TableStructureRecognitionPredictorBuilder {
                     adapter_builder = adapter_builder.with_ort_config(ort_cfg);
                 }
 
-                super::build_adapter(adapter_builder, model_path_ref)?
+                super::build_adapter(adapter_builder, model_source)?
             }
             TableStructureModelFamily::Wireless => {
                 let mut adapter_builder = SLANetWirelessAdapterBuilder::new()
@@ -204,7 +206,7 @@ impl TableStructureRecognitionPredictorBuilder {
                     adapter_builder = adapter_builder.with_ort_config(ort_cfg);
                 }
 
-                super::build_adapter(adapter_builder, model_path_ref)?
+                super::build_adapter(adapter_builder, model_source)?
             }
         };
         let task = TableStructureRecognitionTask::new(config.clone());

--- a/oar-ocr-core/src/predictors/text_detection.rs
+++ b/oar-ocr-core/src/predictors/text_detection.rs
@@ -11,7 +11,6 @@ use crate::domain::adapters::TextDetectionAdapterBuilder;
 use crate::domain::tasks::text_detection::{TextDetectionConfig, TextDetectionTask};
 use crate::predictors::TaskPredictorCore;
 use image::RgbImage;
-use std::path::Path;
 
 /// Text detection prediction result
 #[derive(Debug, Clone)]
@@ -93,7 +92,10 @@ impl TextDetectionPredictorBuilder {
     }
 
     /// Build the text detection predictor
-    pub fn build<P: AsRef<Path>>(self, model_path: P) -> OcrResult<TextDetectionPredictor> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> OcrResult<TextDetectionPredictor> {
         let (config, ort_config) = self.state.into_parts();
         let mut adapter_builder = TextDetectionAdapterBuilder::new().with_config(config.clone());
 
@@ -101,7 +103,7 @@ impl TextDetectionPredictorBuilder {
             adapter_builder = adapter_builder.with_ort_config(ort_cfg);
         }
 
-        let adapter = super::build_adapter(adapter_builder, model_path.as_ref())?;
+        let adapter = super::build_adapter(adapter_builder, model_source)?;
         let task = TextDetectionTask::new(config.clone());
 
         Ok(TextDetectionPredictor {

--- a/oar-ocr-core/src/predictors/text_line_orientation.rs
+++ b/oar-ocr-core/src/predictors/text_line_orientation.rs
@@ -14,7 +14,6 @@ use crate::domain::tasks::text_line_orientation::{
 };
 use crate::predictors::TaskPredictorCore;
 use image::RgbImage;
-use std::path::Path;
 
 /// Text line orientation prediction result
 #[derive(Debug, Clone)]
@@ -76,7 +75,10 @@ impl TextLineOrientationPredictorBuilder {
         self
     }
 
-    pub fn build<P: AsRef<Path>>(self, model_path: P) -> OcrResult<TextLineOrientationPredictor> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> OcrResult<TextLineOrientationPredictor> {
         let Self { state, input_shape } = self;
         let (config, ort_config) = state.into_parts();
         let mut adapter_builder = TextLineOrientationAdapterBuilder::new()
@@ -87,7 +89,7 @@ impl TextLineOrientationPredictorBuilder {
             adapter_builder = adapter_builder.with_ort_config(ort_cfg);
         }
 
-        let adapter = super::build_adapter(adapter_builder, model_path.as_ref())?;
+        let adapter = super::build_adapter(adapter_builder, model_source)?;
         let task = TextLineOrientationTask::new(config.clone());
         Ok(TextLineOrientationPredictor {
             core: TaskPredictorCore::new(adapter, task, config),

--- a/oar-ocr-core/src/predictors/text_recognition.rs
+++ b/oar-ocr-core/src/predictors/text_recognition.rs
@@ -73,7 +73,10 @@ impl TextRecognitionPredictorBuilder {
         self
     }
 
-    pub fn build<P: AsRef<Path>>(self, model_path: P) -> OcrResult<TextRecognitionPredictor> {
+    pub fn build(
+        self,
+        model_source: impl Into<crate::core::ModelSource>,
+    ) -> OcrResult<TextRecognitionPredictor> {
         let Self { state, dict_path } = self;
         let (config, ort_config) = state.into_parts();
 
@@ -95,7 +98,7 @@ impl TextRecognitionPredictorBuilder {
             adapter_builder = adapter_builder.with_ort_config(ort_cfg);
         }
 
-        let adapter = super::build_adapter(adapter_builder, model_path.as_ref())?;
+        let adapter = super::build_adapter(adapter_builder, model_source)?;
         let task = TextRecognitionTask::new(config.clone());
         Ok(TextRecognitionPredictor {
             core: TaskPredictorCore::new(adapter, task, config),

--- a/src/oarocr/builder_utils.rs
+++ b/src/oarocr/builder_utils.rs
@@ -1,9 +1,9 @@
 //! Shared utilities for builder patterns in oarocr module.
 
-use oar_ocr_core::core::OCRError;
 use oar_ocr_core::core::config::OrtSessionConfig;
 use oar_ocr_core::core::traits::OrtConfigurable;
 use oar_ocr_core::core::traits::adapter::AdapterBuilder;
+use oar_ocr_core::core::{ModelSource, OCRError};
 use std::path::{Path, PathBuf};
 
 /// Resolves a model path through the auto-download cache when the
@@ -28,6 +28,15 @@ pub fn resolve_model_path(path: &Path) -> Result<PathBuf, OCRError> {
     }
 }
 
+/// Resolves `Path` sources through the auto-download cache; in-memory
+/// sources pass through untouched.
+pub fn resolve_model_source(source: &ModelSource) -> Result<ModelSource, OCRError> {
+    match source {
+        ModelSource::Path(path) => Ok(ModelSource::Path(resolve_model_path(path)?)),
+        memory @ ModelSource::Memory(_) => Ok(memory.clone()),
+    }
+}
+
 /// Builds an optional adapter from a model path using a builder factory.
 ///
 /// This helper reduces boilerplate when building adapters that only need
@@ -49,22 +58,22 @@ pub fn resolve_model_path(path: &Path) -> Result<PathBuf, OCRError> {
 /// * `Ok(None)` if model_path is None
 /// * `Err(...)` if build fails
 pub fn build_optional_adapter<B>(
-    model_path: Option<&PathBuf>,
+    model_source: Option<&ModelSource>,
     ort_config: Option<&OrtSessionConfig>,
     create_builder: impl FnOnce() -> B,
 ) -> Result<Option<B::Adapter>, OCRError>
 where
     B: AdapterBuilder + OrtConfigurable,
 {
-    let Some(model) = model_path else {
+    let Some(source) = model_source else {
         return Ok(None);
     };
-    let resolved = resolve_model_path(model)?;
+    let resolved = resolve_model_source(source)?;
 
     let mut builder = create_builder();
     if let Some(config) = ort_config {
         builder = builder.with_ort_config(config.clone());
     }
 
-    Ok(Some(builder.build(&resolved)?))
+    Ok(Some(builder.build(resolved)?))
 }

--- a/src/oarocr/ocr.rs
+++ b/src/oarocr/ocr.rs
@@ -4,7 +4,8 @@
 //! It simplifies the process of configuring text detection, recognition, and optional
 //! preprocessing components.
 
-use super::builder_utils::{build_optional_adapter, resolve_model_path};
+use super::builder_utils::{build_optional_adapter, resolve_model_path, resolve_model_source};
+use oar_ocr_core::core::ModelSource;
 use oar_ocr_core::core::config::OrtSessionConfig;
 use oar_ocr_core::core::constants::DEFAULT_REC_IMAGE_SHAPE;
 use oar_ocr_core::core::errors::OCRError;
@@ -61,14 +62,15 @@ struct OCRPipeline {
 #[derive(Debug)]
 pub struct OAROCRBuilder {
     // Required fields
-    text_detection_model: PathBuf,
-    text_recognition_model: PathBuf,
+    text_detection_model: ModelSource,
+    text_recognition_model: ModelSource,
     character_dict_path: PathBuf,
+    character_dict_content: Option<String>,
 
     // Optional components
-    document_orientation_model: Option<PathBuf>,
-    text_line_orientation_model: Option<PathBuf>,
-    document_rectification_model: Option<PathBuf>,
+    document_orientation_model: Option<ModelSource>,
+    text_line_orientation_model: Option<ModelSource>,
+    document_rectification_model: Option<ModelSource>,
 
     // Configuration
     ort_session_config: Option<OrtSessionConfig>,
@@ -91,18 +93,22 @@ impl OAROCRBuilder {
     ///
     /// # Arguments
     ///
-    /// * `text_detection_model` - Path to the text detection ONNX model
-    /// * `text_recognition_model` - Path to the text recognition ONNX model
-    /// * `character_dict_path` - Path to the character dictionary file
+    /// * `text_detection_model` - Text detection ONNX model: a path, or raw
+    ///   model bytes (e.g. from `include_bytes!`)
+    /// * `text_recognition_model` - Text recognition ONNX model: a path or
+    ///   raw model bytes
+    /// * `character_dict_path` - Path to the character dictionary file (see
+    ///   [`Self::character_dict_content`] for the in-memory alternative)
     pub fn new(
-        text_detection_model: impl Into<PathBuf>,
-        text_recognition_model: impl Into<PathBuf>,
+        text_detection_model: impl Into<ModelSource>,
+        text_recognition_model: impl Into<ModelSource>,
         character_dict_path: impl Into<PathBuf>,
     ) -> Self {
         Self {
             text_detection_model: text_detection_model.into(),
             text_recognition_model: text_recognition_model.into(),
             character_dict_path: character_dict_path.into(),
+            character_dict_content: None,
             document_orientation_model: None,
             text_line_orientation_model: None,
             document_rectification_model: None,
@@ -114,6 +120,13 @@ impl OAROCRBuilder {
             text_type: None,
             return_word_box: false,
         }
+    }
+
+    /// Sets the character dictionary from an in-memory string (e.g. from
+    /// `include_str!`). When set, `character_dict_path` is ignored.
+    pub fn character_dict_content(mut self, content: impl Into<String>) -> Self {
+        self.character_dict_content = Some(content.into());
+        self
     }
 
     /// Sets the ONNX Runtime session configuration.
@@ -166,9 +179,9 @@ impl OAROCRBuilder {
     /// This component detects and corrects document orientation before text detection.
     pub fn with_document_image_orientation_classification(
         mut self,
-        model_path: impl Into<PathBuf>,
+        model_source: impl Into<ModelSource>,
     ) -> Self {
-        self.document_orientation_model = Some(model_path.into());
+        self.document_orientation_model = Some(model_source.into());
         self
     }
 
@@ -177,17 +190,20 @@ impl OAROCRBuilder {
     /// This component detects and corrects text line orientation after text detection.
     pub fn with_text_line_orientation_classification(
         mut self,
-        model_path: impl Into<PathBuf>,
+        model_source: impl Into<ModelSource>,
     ) -> Self {
-        self.text_line_orientation_model = Some(model_path.into());
+        self.text_line_orientation_model = Some(model_source.into());
         self
     }
 
     /// Adds document image rectification to the pipeline.
     ///
     /// This component corrects document distortion before text detection.
-    pub fn with_document_image_rectification(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.document_rectification_model = Some(model_path.into());
+    pub fn with_document_image_rectification(
+        mut self,
+        model_source: impl Into<ModelSource>,
+    ) -> Self {
+        self.document_rectification_model = Some(model_source.into());
         self
     }
 
@@ -234,19 +250,25 @@ impl OAROCRBuilder {
 
         // Resolve required model paths through the auto-download cache when
         // the feature is enabled. With the feature off these are no-ops.
-        let text_detection_model = resolve_model_path(&self.text_detection_model)?;
-        let text_recognition_model = resolve_model_path(&self.text_recognition_model)?;
-        let character_dict_path = resolve_model_path(&self.character_dict_path)?;
+        let text_detection_model = resolve_model_source(&self.text_detection_model)?;
+        let text_recognition_model = resolve_model_source(&self.text_recognition_model)?;
 
         // Load character dictionary for text recognition
-        let char_dict =
-            std::fs::read_to_string(&character_dict_path).map_err(|e| OCRError::InvalidInput {
-                message: format!(
-                    "Failed to read character dictionary from '{}': {}",
-                    character_dict_path.display(),
-                    e
-                ),
-            })?;
+        let char_dict = match &self.character_dict_content {
+            Some(content) => content.clone(),
+            None => {
+                let character_dict_path = resolve_model_path(&self.character_dict_path)?;
+                std::fs::read_to_string(&character_dict_path).map_err(|e| {
+                    OCRError::InvalidInput {
+                        message: format!(
+                            "Failed to read character dictionary from '{}': {}",
+                            character_dict_path.display(),
+                            e
+                        ),
+                    }
+                })?
+            }
+        };
 
         // Build document rectification adapter if enabled
         let rectification_adapter = build_optional_adapter(
@@ -330,7 +352,7 @@ impl OAROCRBuilder {
             detection_builder = detection_builder.text_type(text_type.clone());
         }
 
-        let text_detection_adapter = detection_builder.build(&text_detection_model)?;
+        let text_detection_adapter = detection_builder.build(text_detection_model)?;
 
         // Build text line orientation adapter if enabled
         let text_line_orientation_adapter = build_optional_adapter(
@@ -355,7 +377,7 @@ impl OAROCRBuilder {
             recognition_builder = recognition_builder.with_config(rec_config.clone());
         }
 
-        let text_recognition_adapter = recognition_builder.build(&text_recognition_model)?;
+        let text_recognition_adapter = recognition_builder.build(text_recognition_model)?;
 
         let pipeline = OCRPipeline {
             rectification_adapter,
@@ -1048,12 +1070,12 @@ mod tests {
         let builder = OAROCRBuilder::new("models/det.onnx", "models/rec.onnx", "models/dict.txt");
 
         assert_eq!(
-            builder.text_detection_model,
-            PathBuf::from("models/det.onnx")
+            builder.text_detection_model.as_path(),
+            Some(std::path::Path::new("models/det.onnx"))
         );
         assert_eq!(
-            builder.text_recognition_model,
-            PathBuf::from("models/rec.onnx")
+            builder.text_recognition_model.as_path(),
+            Some(std::path::Path::new("models/rec.onnx"))
         );
         assert_eq!(
             builder.character_dict_path,
@@ -1071,18 +1093,27 @@ mod tests {
             .with_text_line_orientation_classification("models/line_orient.onnx")
             .with_document_image_rectification("models/rectify.onnx");
 
-        let Some(path) = builder.document_orientation_model.as_ref() else {
+        let Some(source) = builder.document_orientation_model.as_ref() else {
             panic!("expected document_orientation_model to be Some");
         };
-        assert_eq!(path, &PathBuf::from("models/doc_orient.onnx"));
-        let Some(path) = builder.text_line_orientation_model.as_ref() else {
+        assert_eq!(
+            source.as_path(),
+            Some(std::path::Path::new("models/doc_orient.onnx"))
+        );
+        let Some(source) = builder.text_line_orientation_model.as_ref() else {
             panic!("expected text_line_orientation_model to be Some");
         };
-        assert_eq!(path, &PathBuf::from("models/line_orient.onnx"));
-        let Some(path) = builder.document_rectification_model.as_ref() else {
+        assert_eq!(
+            source.as_path(),
+            Some(std::path::Path::new("models/line_orient.onnx"))
+        );
+        let Some(source) = builder.document_rectification_model.as_ref() else {
             panic!("expected document_rectification_model to be Some");
         };
-        assert_eq!(path, &PathBuf::from("models/rectify.onnx"));
+        assert_eq!(
+            source.as_path(),
+            Some(std::path::Path::new("models/rectify.onnx"))
+        );
     }
 
     #[test]

--- a/src/oarocr/structure.rs
+++ b/src/oarocr/structure.rs
@@ -4,11 +4,11 @@
 //! analysis pipelines that can detect layout elements, recognize tables, extract formulas,
 //! and optionally integrate OCR for text extraction.
 
-use super::builder_utils::{build_optional_adapter, resolve_model_path};
-use oar_ocr_core::core::OCRError;
+use super::builder_utils::{build_optional_adapter, resolve_model_path, resolve_model_source};
 use oar_ocr_core::core::config::OrtSessionConfig;
 use oar_ocr_core::core::traits::OrtConfigurable;
 use oar_ocr_core::core::traits::adapter::{AdapterBuilder, ModelAdapter};
+use oar_ocr_core::core::{ModelSource, OCRError};
 use oar_ocr_core::domain::adapters::{
     DocumentOrientationAdapter, DocumentOrientationAdapterBuilder, FormulaRecognitionAdapter,
     LayoutDetectionAdapter, LayoutDetectionAdapterBuilder, PPFormulaNetAdapterBuilder,
@@ -124,29 +124,29 @@ struct StructurePipeline {
 #[derive(Debug, Clone)]
 pub struct OARStructureBuilder {
     // Required models
-    layout_detection_model: PathBuf,
+    layout_detection_model: ModelSource,
     layout_model_name: Option<String>,
 
     // Optional document preprocessing
-    document_orientation_model: Option<PathBuf>,
-    document_rectification_model: Option<PathBuf>,
+    document_orientation_model: Option<ModelSource>,
+    document_rectification_model: Option<ModelSource>,
 
     // Optional region detection for hierarchical ordering (PP-DocBlockLayout)
-    region_detection_model: Option<PathBuf>,
+    region_detection_model: Option<ModelSource>,
 
     // Optional table analysis models
-    table_classification_model: Option<PathBuf>,
-    table_orientation_model: Option<PathBuf>, // Reuses doc orientation model for rotated tables
-    table_cell_detection_model: Option<PathBuf>,
+    table_classification_model: Option<ModelSource>,
+    table_orientation_model: Option<ModelSource>, // Reuses doc orientation model for rotated tables
+    table_cell_detection_model: Option<ModelSource>,
     table_cell_detection_type: Option<String>, // "wired" or "wireless"
-    table_structure_recognition_model: Option<PathBuf>,
+    table_structure_recognition_model: Option<ModelSource>,
     table_structure_recognition_type: Option<String>, // "wired" or "wireless"
     table_structure_dict_path: Option<PathBuf>,
 
-    wired_table_structure_model: Option<PathBuf>,
-    wireless_table_structure_model: Option<PathBuf>,
-    wired_table_cell_model: Option<PathBuf>,
-    wireless_table_cell_model: Option<PathBuf>,
+    wired_table_structure_model: Option<ModelSource>,
+    wireless_table_structure_model: Option<ModelSource>,
+    wired_table_cell_model: Option<ModelSource>,
+    wireless_table_cell_model: Option<ModelSource>,
     // E2E mode: when true, skip cell detection and use only structure model output
     // Defaults: wired=false, wireless=true
     use_e2e_wired_table_rec: bool,
@@ -157,18 +157,18 @@ pub struct OARStructureBuilder {
     use_wireless_table_cells_trans_to_html: bool,
 
     // Optional formula recognition
-    formula_recognition_model: Option<PathBuf>,
+    formula_recognition_model: Option<ModelSource>,
     formula_recognition_type: Option<String>, // "pp_formulanet" or "unimernet"
     formula_tokenizer_path: Option<PathBuf>,
     formula_ort_session_config: Option<OrtSessionConfig>,
 
     // Optional seal text detection
-    seal_text_detection_model: Option<PathBuf>,
+    seal_text_detection_model: Option<ModelSource>,
 
     // Optional OCR integration
-    text_detection_model: Option<PathBuf>,
-    text_line_orientation_model: Option<PathBuf>,
-    text_recognition_model: Option<PathBuf>,
+    text_detection_model: Option<ModelSource>,
+    text_line_orientation_model: Option<ModelSource>,
+    text_recognition_model: Option<ModelSource>,
     character_dict_path: Option<PathBuf>,
 
     // Model name presets for loading correct pre/post processors
@@ -203,7 +203,7 @@ impl OARStructureBuilder {
     /// # Arguments
     ///
     /// * `layout_detection_model` - Path to the layout detection model file
-    pub fn new(layout_detection_model: impl Into<PathBuf>) -> Self {
+    pub fn new(layout_detection_model: impl Into<ModelSource>) -> Self {
         Self {
             layout_detection_model: layout_detection_model.into(),
             layout_model_name: None,
@@ -369,8 +369,8 @@ impl OARStructureBuilder {
     ///
     /// This component detects and corrects document rotation (0°, 90°, 180°, 270°).
     /// Should be run before other processing for best results.
-    pub fn with_document_orientation(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.document_orientation_model = Some(model_path.into());
+    pub fn with_document_orientation(mut self, model_source: impl Into<ModelSource>) -> Self {
+        self.document_orientation_model = Some(model_source.into());
         self
     }
 
@@ -378,8 +378,8 @@ impl OARStructureBuilder {
     ///
     /// This component corrects document distortion and perspective issues.
     /// Should be run after orientation detection if both are enabled.
-    pub fn with_document_rectification(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.document_rectification_model = Some(model_path.into());
+    pub fn with_document_rectification(mut self, model_source: impl Into<ModelSource>) -> Self {
+        self.document_rectification_model = Some(model_source.into());
         self
     }
 
@@ -395,8 +395,8 @@ impl OARStructureBuilder {
     /// 1. Group layout elements by their parent regions
     /// 2. Apply XY-cut ordering within each region
     /// 3. Order regions based on their relative positions
-    pub fn with_region_detection(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.region_detection_model = Some(model_path.into());
+    pub fn with_region_detection(mut self, model_source: impl Into<ModelSource>) -> Self {
+        self.region_detection_model = Some(model_source.into());
         self
     }
 
@@ -404,16 +404,16 @@ impl OARStructureBuilder {
     ///
     /// This component detects circular/curved seal and stamp text regions.
     /// Seal regions will be included in the layout elements.
-    pub fn with_seal_text_detection(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.seal_text_detection_model = Some(model_path.into());
+    pub fn with_seal_text_detection(mut self, model_source: impl Into<ModelSource>) -> Self {
+        self.seal_text_detection_model = Some(model_source.into());
         self
     }
 
     /// Adds table classification to the pipeline.
     ///
     /// This component classifies tables as wired or wireless.
-    pub fn with_table_classification(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.table_classification_model = Some(model_path.into());
+    pub fn with_table_classification(mut self, model_source: impl Into<ModelSource>) -> Self {
+        self.table_classification_model = Some(model_source.into());
         self
     }
 
@@ -432,8 +432,8 @@ impl OARStructureBuilder {
     /// # Arguments
     ///
     /// * `model_path` - Path to the orientation classification model (same as document orientation)
-    pub fn with_table_orientation(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.table_orientation_model = Some(model_path.into());
+    pub fn with_table_orientation(mut self, model_source: impl Into<ModelSource>) -> Self {
+        self.table_orientation_model = Some(model_source.into());
         self
     }
 
@@ -487,10 +487,10 @@ impl OARStructureBuilder {
     /// * `cell_type` - Type of cells to detect: "wired" or "wireless"
     pub fn with_table_cell_detection(
         mut self,
-        model_path: impl Into<PathBuf>,
+        model_source: impl Into<ModelSource>,
         cell_type: impl Into<String>,
     ) -> Self {
-        self.table_cell_detection_model = Some(model_path.into());
+        self.table_cell_detection_model = Some(model_source.into());
         self.table_cell_detection_type = Some(cell_type.into());
         self
     }
@@ -511,10 +511,10 @@ impl OARStructureBuilder {
     /// This component recognizes the structure of tables and outputs HTML.
     pub fn with_table_structure_recognition(
         mut self,
-        model_path: impl Into<PathBuf>,
+        model_source: impl Into<ModelSource>,
         table_type: impl Into<String>,
     ) -> Self {
-        self.table_structure_recognition_model = Some(model_path.into());
+        self.table_structure_recognition_model = Some(model_source.into());
         self.table_structure_recognition_type = Some(table_type.into());
         self
     }
@@ -543,8 +543,8 @@ impl OARStructureBuilder {
     ///
     /// When both wired and wireless models are configured along with table classification,
     /// the system automatically selects the appropriate model based on classification results.
-    pub fn with_wired_table_structure(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.wired_table_structure_model = Some(model_path.into());
+    pub fn with_wired_table_structure(mut self, model_source: impl Into<ModelSource>) -> Self {
+        self.wired_table_structure_model = Some(model_source.into());
         self
     }
 
@@ -552,8 +552,8 @@ impl OARStructureBuilder {
     ///
     /// When both wired and wireless models are configured along with table classification,
     /// the system automatically selects the appropriate model based on classification results.
-    pub fn with_wireless_table_structure(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.wireless_table_structure_model = Some(model_path.into());
+    pub fn with_wireless_table_structure(mut self, model_source: impl Into<ModelSource>) -> Self {
+        self.wireless_table_structure_model = Some(model_source.into());
         self
     }
 
@@ -561,8 +561,8 @@ impl OARStructureBuilder {
     ///
     /// When both wired and wireless models are configured along with table classification,
     /// the system automatically selects the appropriate model based on classification results.
-    pub fn with_wired_table_cell_detection(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.wired_table_cell_model = Some(model_path.into());
+    pub fn with_wired_table_cell_detection(mut self, model_source: impl Into<ModelSource>) -> Self {
+        self.wired_table_cell_model = Some(model_source.into());
         self
     }
 
@@ -570,8 +570,11 @@ impl OARStructureBuilder {
     ///
     /// When both wired and wireless models are configured along with table classification,
     /// the system automatically selects the appropriate model based on classification results.
-    pub fn with_wireless_table_cell_detection(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.wireless_table_cell_model = Some(model_path.into());
+    pub fn with_wireless_table_cell_detection(
+        mut self,
+        model_source: impl Into<ModelSource>,
+    ) -> Self {
+        self.wireless_table_cell_model = Some(model_source.into());
         self
     }
 
@@ -586,11 +589,11 @@ impl OARStructureBuilder {
     /// This component recognizes mathematical formulas and outputs LaTeX.
     pub fn with_formula_recognition(
         mut self,
-        model_path: impl Into<PathBuf>,
+        model_source: impl Into<ModelSource>,
         tokenizer_path: impl Into<PathBuf>,
         model_type: impl Into<String>,
     ) -> Self {
-        self.formula_recognition_model = Some(model_path.into());
+        self.formula_recognition_model = Some(model_source.into());
         self.formula_tokenizer_path = Some(tokenizer_path.into());
         self.formula_recognition_type = Some(model_type.into());
         self
@@ -612,13 +615,13 @@ impl OARStructureBuilder {
     ///
     /// # Arguments
     ///
-    /// * `text_detection_model` - Path to the text detection model
-    /// * `text_recognition_model` - Path to the text recognition model
+    /// * `text_detection_model` - Text detection model: a path or raw model bytes
+    /// * `text_recognition_model` - Text recognition model: a path or raw model bytes
     /// * `character_dict_path` - Path to the character dictionary file
     pub fn with_ocr(
         mut self,
-        text_detection_model: impl Into<PathBuf>,
-        text_recognition_model: impl Into<PathBuf>,
+        text_detection_model: impl Into<ModelSource>,
+        text_recognition_model: impl Into<ModelSource>,
         character_dict_path: impl Into<PathBuf>,
     ) -> Self {
         self.text_detection_model = Some(text_detection_model.into());
@@ -637,8 +640,8 @@ impl OARStructureBuilder {
     /// When enabled, detected text lines are classified before recognition:
     /// - Lines classified as 180° rotated are flipped before OCR
     /// - This improves accuracy for documents scanned upside-down or with mixed orientations
-    pub fn with_text_line_orientation(mut self, model_path: impl Into<PathBuf>) -> Self {
-        self.text_line_orientation_model = Some(model_path.into());
+    pub fn with_text_line_orientation(mut self, model_source: impl Into<ModelSource>) -> Self {
+        self.text_line_orientation_model = Some(model_source.into());
         self
     }
 
@@ -695,31 +698,37 @@ impl OARStructureBuilder {
         // Resolve every model/dict/tokenizer path through the auto-download
         // cache when the `auto-download` feature is enabled. With the feature
         // off these calls are infallible no-ops.
-        self.layout_detection_model = resolve_model_path(&self.layout_detection_model)?;
+        self.layout_detection_model = resolve_model_source(&self.layout_detection_model)?;
         fn resolve_opt_path(p: &mut Option<PathBuf>) -> Result<(), OCRError> {
             if let Some(path) = p {
                 *path = resolve_model_path(path)?;
             }
             Ok(())
         }
-        resolve_opt_path(&mut self.document_orientation_model)?;
-        resolve_opt_path(&mut self.document_rectification_model)?;
-        resolve_opt_path(&mut self.region_detection_model)?;
-        resolve_opt_path(&mut self.table_classification_model)?;
-        resolve_opt_path(&mut self.table_orientation_model)?;
-        resolve_opt_path(&mut self.table_cell_detection_model)?;
-        resolve_opt_path(&mut self.table_structure_recognition_model)?;
+        fn resolve_opt_source(s: &mut Option<ModelSource>) -> Result<(), OCRError> {
+            if let Some(source) = s {
+                *source = resolve_model_source(source)?;
+            }
+            Ok(())
+        }
+        resolve_opt_source(&mut self.document_orientation_model)?;
+        resolve_opt_source(&mut self.document_rectification_model)?;
+        resolve_opt_source(&mut self.region_detection_model)?;
+        resolve_opt_source(&mut self.table_classification_model)?;
+        resolve_opt_source(&mut self.table_orientation_model)?;
+        resolve_opt_source(&mut self.table_cell_detection_model)?;
+        resolve_opt_source(&mut self.table_structure_recognition_model)?;
         resolve_opt_path(&mut self.table_structure_dict_path)?;
-        resolve_opt_path(&mut self.wired_table_structure_model)?;
-        resolve_opt_path(&mut self.wireless_table_structure_model)?;
-        resolve_opt_path(&mut self.wired_table_cell_model)?;
-        resolve_opt_path(&mut self.wireless_table_cell_model)?;
-        resolve_opt_path(&mut self.formula_recognition_model)?;
+        resolve_opt_source(&mut self.wired_table_structure_model)?;
+        resolve_opt_source(&mut self.wireless_table_structure_model)?;
+        resolve_opt_source(&mut self.wired_table_cell_model)?;
+        resolve_opt_source(&mut self.wireless_table_cell_model)?;
+        resolve_opt_source(&mut self.formula_recognition_model)?;
         resolve_opt_path(&mut self.formula_tokenizer_path)?;
-        resolve_opt_path(&mut self.seal_text_detection_model)?;
-        resolve_opt_path(&mut self.text_detection_model)?;
-        resolve_opt_path(&mut self.text_line_orientation_model)?;
-        resolve_opt_path(&mut self.text_recognition_model)?;
+        resolve_opt_source(&mut self.seal_text_detection_model)?;
+        resolve_opt_source(&mut self.text_detection_model)?;
+        resolve_opt_source(&mut self.text_line_orientation_model)?;
+        resolve_opt_source(&mut self.text_recognition_model)?;
         resolve_opt_path(&mut self.character_dict_path)?;
 
         // Load character dictionary if OCR is enabled
@@ -3453,8 +3462,8 @@ mod tests {
     fn test_structure_builder_new() {
         let builder = OARStructureBuilder::new("models/layout.onnx");
         assert_eq!(
-            builder.layout_detection_model,
-            PathBuf::from("models/layout.onnx")
+            builder.layout_detection_model.as_path(),
+            Some(std::path::Path::new("models/layout.onnx"))
         );
         assert!(builder.table_classification_model.is_none());
         assert!(builder.formula_recognition_model.is_none());


### PR DESCRIPTION
## Summary

Implements #37: models can now be loaded from memory (e.g. `include_bytes!` for single-binary deployments, or buffers decrypted at runtime) instead of only from file paths.

- Adds `ModelSource` (`Path(PathBuf) | Memory(Arc<[u8]>)`) in `oar-ocr-core` with `From` conversions for paths, strings, `Vec<u8>`, `&'static [u8]`/arrays, and `Arc<[u8]>`.
- `AdapterBuilder::build`, every model builder (`DBModelBuilder`, `CRNNModelBuilder`, ...), every adapter builder, every task predictor `build()`, and the `OAROCRBuilder`/`OARStructureBuilder` model setters now take `impl Into<ModelSource>` — **existing path-based call sites compile unchanged**.
- `Memory` sources go through ort's `commit_from_memory`; `Path` sources keep the exact previous behavior, including auto-download resolution (in-memory sources skip it).
- The character dictionary can be supplied in-memory via `OAROCRBuilder::character_dict_content(...)` (e.g. `include_str!`).
- Model-family detection that relied on file names (table structure / table cell) falls back to defaults or the explicit `model_name`/`model_variant` setters for in-memory sources.

Usage:

```rust
static DET: &[u8] = include_bytes!("../models/pp-ocrv6_tiny_det.onnx");
static REC: &[u8] = include_bytes!("../models/pp-ocrv6_tiny_rec.onnx");
static DICT: &str = include_str!("../models/ppocrv6_tiny_dict.txt");

let ocr = OAROCRBuilder::new(DET, REC, "")
    .character_dict_content(DICT)
    .build()?;
```

Documented in `docs/usage.md` ("Loading Models from Memory"). Models with external-data sidecar files cannot be loaded from memory (ONNX Runtime limitation); PP-OCR models are single-file and unaffected.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets` (no warnings), `cargo test --workspace` — 594 tests + doctests pass.
- Unit tests for `ModelSource` conversions.
- Local E2E: built the OCR pipeline twice on PP-OCRv6 tiny — once from paths, once from `Vec<u8>` model bytes + in-memory dict — and verified byte-identical recognition output on a real image; also re-ran the path-based `ocr` example as a regression check.

Closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
