### PR TITLE
docs: refresh project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@
 [![dependency status](https://deps.rs/repo/github/GreatV/oar-ocr/status.svg)](https://deps.rs/repo/github/GreatV/oar-ocr)
 ![GitHub License](https://img.shields.io/github/license/GreatV/oar-ocr)
 
-An Optical Character Recognition (OCR) and Document Layout Analysis library written in Rust.
+A native Rust toolkit for OCR, document layout analysis, and vision-language document understanding.
+
+## Highlights
+
+- End-to-end text detection and recognition with PP-OCR models, including PP-OCRv6.
+- Document structure analysis for layout, tables, formulas, seals, orientation, and rectification.
+- Native Candle inference for compact document VLMs through the `oar-ocr-vl` crate.
+- CPU and GPU execution, model auto-download, and in-memory ONNX model loading.
 
 ## Quick Start
 
@@ -15,81 +22,38 @@ An Optical Character Recognition (OCR) and Document Layout Analysis library writ
 cargo add oar-ocr
 ```
 
-With GPU support:
+The default build enables ONNX Runtime binary downloads and SIMD acceleration. Add only the optional capabilities needed by your application. For example:
 
 ```bash
-cargo add oar-ocr --features cuda
+cargo add oar-ocr --features cuda,auto-download
 ```
 
-With auto-download of model files from ModelScope:
+This keeps the default `download-binaries` and `simd` features enabled, makes the ONNX Runtime CUDA execution provider available for selection, and downloads missing registered model files from ModelScope into `$OAR_HOME` when they are first used.
 
-```bash
-cargo add oar-ocr --features auto-download
-```
+See the [Cargo feature guide](docs/features.md) for all available features and the [model guide](docs/models.md#auto-download-via-the-auto-download-feature) for model download and cache behavior.
 
-Bare file names passed to the builders are then fetched from [ModelScope](https://www.modelscope.cn/models/greatv/oar-ocr) into `$OAR_HOME` (default `~/.oar`) and verified against their expected SHA-256. See [docs/models.md](docs/models.md#auto-download-via-the-auto-download-feature) for the exact path resolution rules.
+Builders also accept raw ONNX bytes such as `include_bytes!`, allowing models to be embedded in a single binary. See [Loading Models from Memory](docs/usage.md#loading-models-from-memory).
 
-Everywhere a builder accepts a model path it also accepts raw ONNX bytes (e.g. `include_bytes!`), so models can be embedded into a single binary — see [Loading Models from Memory](docs/usage.md#loading-models-from-memory).
+### OCR Pipeline
 
-### Basic Usage
+With `auto-download`, pass registered model names directly. Otherwise, replace them with local paths.
 
 ```rust
-use oar_ocr::prelude::*;
-use std::path::Path;
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize the OCR pipeline
-    let ocr = OAROCRBuilder::new(
-        "pp-ocrv5_mobile_det.onnx",
-        "pp-ocrv5_mobile_rec.onnx",
-        "ppocrv5_dict.txt",
-    )
-    .build()?;
-
-    // Load an image
-    let image = load_image(Path::new("document.jpg"))?;
-    
-    // Run prediction
-    let results = ocr.predict(vec![image])?;
-
-    // Process results
-    for text_region in &results[0].text_regions {
-        if let Some((text, confidence)) = text_region.text_with_confidence() {
-            println!("Text: {} ({:.2})", text, confidence);
-        }
-    }
-
-    Ok(())
-}
-```
-
-### PP-OCRv6
-
-PP-OCRv6 ships in three sizes. Pass the bare file names below and enable the `auto-download` feature to fetch them automatically or point to local paths:
-
-Size | Detection | Recognition | Dictionary
------|-----|-----|-----
-tiny | `pp-ocrv6_tiny_det.onnx` | `pp-ocrv6_tiny_rec.onnx` | `ppocrv6_tiny_dict.txt`
-small | `pp-ocrv6_small_det.onnx` | `pp-ocrv6_small_rec.onnx` | `ppocrv6_dict.txt`
-medium | `pp-ocrv6_medium_det.onnx` | `pp-ocrv6_medium_rec.onnx` | `ppocrv6_dict.txt`
-
-```rust
-use oar_ocr::prelude::*;
 use oar_ocr::domain::tasks::TextDetectionConfig;
+use oar_ocr::prelude::*;
 use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // PP-OCRv6 "tiny" — swap in small/medium (with ppocrv6_dict.txt) for higher accuracy.
     let ocr = OAROCRBuilder::new(
         "pp-ocrv6_tiny_det.onnx",
         "pp-ocrv6_tiny_rec.onnx",
         "ppocrv6_tiny_dict.txt",
     )
-    // Official PP-OCRv6 detection defaults.
     .text_detection_config(TextDetectionConfig {
         score_threshold: 0.2,
         box_threshold: 0.45,
         unclip_ratio: 1.4,
+        max_candidates: 3000,
         ..Default::default()
     })
     .build()?;
@@ -99,7 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for region in &results[0].text_regions {
         if let Some((text, confidence)) = region.text_with_confidence() {
-            println!("{text}  ({confidence:.2})");
+            println!("{text} ({confidence:.2})");
         }
     }
 
@@ -111,59 +75,74 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ```rust
 use oar_ocr::prelude::*;
-use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize structure analysis pipeline
     let structure = OARStructureBuilder::new("pp-doclayout_plus-l.onnx")
         .with_table_classification("pp-lcnet_x1_0_table_cls.onnx")
         .with_table_structure_recognition("slanet_plus.onnx", "wireless")
         .table_structure_dict_path("table_structure_dict_ch.txt")
         .with_ocr(
-            "pp-ocrv5_mobile_det.onnx", 
-            "pp-ocrv5_mobile_rec.onnx", 
-            "ppocrv5_dict.txt"
+            "pp-ocrv5_mobile_det.onnx",
+            "pp-ocrv5_mobile_rec.onnx",
+            "ppocrv5_dict.txt",
         )
         .build()?;
-        
-    // Analyze document
+
     let result = structure.predict("document.jpg")?;
-    
-    // Output Markdown
     println!("{}", result.to_markdown());
-    
+
     Ok(())
 }
 ```
 
-## Vision-Language Models (VLM)
+## Supported Models
 
-For advanced document understanding using Vision-Language Models (like PaddleOCR-VL, PaddleOCR-VL-1.5, **PaddleOCR-VL-1.6**, GLM-OCR, HunyuanOCR, and MinerU2.5), check out the [`oar-ocr-vl`](oar-ocr-vl/README.md) crate.
+The classic pipeline runs ONNX models through ONNX Runtime and supports the following model families. See the [pre-trained model guide](docs/models.md) for exact checkpoints, dictionaries, download links, and auto-download names.
+
+### Classic ONNX Models
+
+| Task | Supported model families |
+|---|---|
+| Text detection | PP-OCRv4, PP-OCRv5, and PP-OCRv6 DB detectors |
+| Text recognition | PP-OCRv3, PP-OCRv4, PP-OCRv5, PP-OCRv6, SVTRv2, and RepSVTR CTC recognizers |
+| Document preprocessing | PP-LCNet document orientation, PP-LCNet text-line orientation, and UVDoc rectification |
+| Layout detection | PicoDet, RT-DETR-H, PP-DocLayout S/M/L, PP-DocLayout Plus-L, PP-DocLayoutV2/V3, and PP-DocBlockLayout |
+| Table analysis | PP-LCNet table classification, RT-DETR-L cell detection, and SLANet, SLANet+, and SLANeXt structure recognition |
+| Formula recognition | PP-FormulaNet, PP-FormulaNet Plus, and UniMERNet |
+| Seal text detection | PP-OCRv4 mobile and server seal detectors |
+
+Available text-recognition checkpoints cover Chinese, Traditional Chinese, English, Arabic, Cyrillic, Devanagari, Greek, Eastern Slavic, Japanese, Georgian, Korean, Latin, Tamil, Telugu, and Thai scripts or languages.
+
+### Vision-Language Models (VLM)
+
+The [`oar-ocr-vl`](oar-ocr-vl/README.md) crate provides native [Candle](https://github.com/huggingface/candle) inference for compact document VLMs on CPU, CUDA, and Metal.
+
+| Model | Parameters | Capabilities |
+|---|---:|---|
+| [PaddleOCR-VL](https://huggingface.co/PaddlePaddle/PaddleOCR-VL) | 0.9B | Page parsing, text, table, formula, and chart recognition |
+| [PaddleOCR-VL-1.5](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5) | 0.9B | PaddleOCR-VL tasks plus text spotting and seal recognition |
+| [PaddleOCR-VL-1.6](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6) | 0.9B | Region-aware page parsing and task-specific recognition |
+| [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) | 0.9B | Page parsing, text, table, and formula recognition |
+| [HunyuanOCR 1.5 / 1.0](https://huggingface.co/tencent/HunyuanOCR) | 1B | Prompt-driven full-page parsing, text spotting, table, formula, and chart recognition, with optional DFlash decoding for 1.5 |
+| [MinerU2.5-2509](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) | 1.2B | Model-native two-step layout detection and content extraction |
+| [MinerU2.5-Pro-2605](https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B) | 1.2B | Newer MinerU2.5 checkpoint using the same two-step pipeline |
+| [MinerU-Diffusion-V1-0320](https://huggingface.co/opendatalab/MinerU-Diffusion-V1-0320-2.5B) | 2.5B | Block-diffusion OCR with structured two-step extraction or single-pass text recognition |
+
+PaddleOCR-VL variants and GLM-OCR integrate with the external-layout [`DocParser`](oar-ocr-vl/README.md#document-parsing-pipeline). HunyuanOCR and the MinerU models use their model-native parsing pipelines.
+
+See the [`oar-ocr-vl` guide](oar-ocr-vl/README.md) for setup and [`oar-ocr-vl/examples`](oar-ocr-vl/examples) for runnable examples.
 
 ## Documentation
 
-- [**Usage Guide**](docs/usage.md) - Detailed API usage, builder patterns, GPU configuration
-- [**Pre-trained Models**](docs/models.md) - Model download links and recommended configurations
-- [**Environment Variables**](docs/environment-variables.md) - Runtime configuration via `OAR_*` variables
-- [**FAQ**](docs/FAQ.md) - Common build and runtime questions
+- [Usage guide](docs/usage.md) — APIs, builder patterns, accelerators, and model loading
+- [Cargo features](docs/features.md) — defaults, execution providers, and feature combinations
+- [Pre-trained models](docs/models.md) — model files, dictionaries, and auto-download behavior
+- [Environment variables](docs/environment-variables.md) — runtime and performance overrides
+- [FAQ](docs/FAQ.md) — common build and runtime issues
 
 ## Examples
 
-The `examples/` directory contains complete examples for various tasks:
-
-```bash
-# General OCR
-cargo run --example ocr -- --help
-
-# Document Structure Analysis
-cargo run --example structure -- --help
-
-# Layout Detection
-cargo run --example layout_detection -- --help
-
-# Table Structure Recognition
-cargo run --example table_structure_recognition -- --help
-```
+See the [usage guide](docs/usage.md) for other pipeline configurations and APIs. Complete classic-pipeline examples live in [`examples`](examples), while VLM examples live in [`oar-ocr-vl/examples`](oar-ocr-vl/examples).
 
 ## Acknowledgments
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,7 +1,6 @@
 # Environment Variables
 
-Runtime environment variables read by the oar-ocr crates. Project-specific
-variables use the `OAR_` prefix (`OAR_VL_` for the Vision-Language crate).
+Runtime environment variables read by the oar-ocr crates. Project-specific variables use the `OAR_` prefix (`OAR_VL_` for the Vision-Language crate).
 
 ## Summary
 
@@ -10,16 +9,26 @@ variables use the `OAR_` prefix (`OAR_VL_` for the Vision-Language crate).
 | [`OAR_HOME`](#oar_home) | `oar-ocr-core` | `~/.oar` | Model cache directory for auto-download |
 | [`OAR_VL_DTYPE`](#oar_vl_dtype) | `oar-ocr-vl` | auto | Compute dtype for VL models |
 | [`OAR_VL_ATTN_FULL_SEQ_THRESHOLD`](#oar_vl_attn_full_seq_threshold) | `oar-ocr-vl` | `8192` | PaddleOCR-VL vision attention path selection |
+| [`OAR_VL_DISABLE_FLASH_ATTN`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable CUDA FlashAttention |
+| [`OAR_VL_DISABLE_GQA`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Use expanded-K/V GQA fallback |
+| [`OAR_VL_DISABLE_CUDA_GRAPH`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable shared decoder CUDA graphs |
+| [`OAR_VL_DISABLE_SPECULATIVE`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable GLM-OCR speculative decoding |
+| [`OAR_PADDLEOCR_VL_DISABLE_CUDA_GRAPH`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable PaddleOCR-VL CUDA graphs |
+| [`OAR_GLMOCR_DISABLE_MTP`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable GLM-OCR MTP |
+| [`OAR_GLMOCR_DISABLE_CUDA_GRAPH`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable GLM-OCR CUDA graphs |
+| [`OAR_HUNYUAN_DISABLE_CUDA_GRAPH`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable HunyuanOCR CUDA graphs |
+| [`OAR_HUNYUAN_DISABLE_AR_CUDA_GRAPH`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable HunyuanOCR AR CUDA graph |
+| [`OAR_MINERU_DISABLE_CUDA_GRAPH`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable MinerU CUDA graphs |
+| [`OAR_MINERU_DISABLE_GPU_SAMPLING`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable MinerU GPU sampling |
+| [`OAR_MINERU_DIFFUSION_DISABLE_GPU_SAMPLING`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable MinerU-Diffusion GPU sampling |
+| [`CUDA_COMPUTE_CAP`](#cuda-build-overrides) | `oar-ocr-vl` build | auto | CUDA PTX target architecture |
+| [`NVCC`](#cuda-build-overrides) | `oar-ocr-vl` build | `nvcc` | CUDA compiler path |
 | [`CUDA_LAUNCH_BLOCKING`](#cuda_launch_blocking) | `oar-ocr-core` | set to `1` if unset | ONNX Runtime CUDA workaround |
 | [`RUST_LOG`](#rust_log) | examples | `info` | Log filter |
 
 ## `OAR_HOME`
 
-Directory where the `auto-download` feature caches model files
-(default `~/.oar`). Bare model file names passed to the builders are
-downloaded here and verified against their expected SHA-256. See
-[models.md](models.md#auto-download-via-the-auto-download-feature) for the
-exact path resolution rules.
+Directory where the `auto-download` feature caches model files (default `~/.oar`). Bare model file names passed to the builders are downloaded here and verified against their expected SHA-256. See [models.md](models.md#auto-download-via-the-auto-download-feature) for the exact path resolution rules.
 
 ```bash
 OAR_HOME=/data/oar-models cargo run --release --example ocr -- doc.jpg
@@ -27,8 +36,7 @@ OAR_HOME=/data/oar-models cargo run --release --example ocr -- doc.jpg
 
 ## `OAR_VL_DTYPE`
 
-Overrides the automatic weight/compute dtype selection for Vision-Language
-models (PaddleOCR-VL, GLM-OCR, HunyuanOCR, MinerU2.5).
+Overrides the automatic weight/compute dtype selection for Vision-Language models (PaddleOCR-VL, GLM-OCR, HunyuanOCR, MinerU2.5/Pro, and MinerU-Diffusion).
 
 Accepted values (case-insensitive):
 
@@ -36,40 +44,56 @@ Accepted values (case-insensitive):
 - `f16` (aliases `fp16`, `float16`, `half`)
 - `f32` (aliases `fp32`, `float32`)
 
-Without the override, GPUs use BF16 when a runtime probe confirms kernel
-support (CUDA compute capability >= 8.0), falling back to F16 otherwise
-(e.g. GTX 10xx/16xx, RTX 20xx); CPU always uses F32.
+Without the override, devices that advertise BF16 support use it after a runtime kernel probe. If the probe fails (for example on pre-Ampere CUDA GPUs), inference falls back to F16. CPU and devices without advertised BF16 support use F32.
 
 ```bash
-OAR_VL_DTYPE=f16 cargo run --release --features cuda -p oar-ocr-vl --example paddleocr_vl -- ...
+OAR_VL_DTYPE=f16 cargo run --release --features cuda,download-binaries -p oar-ocr-vl --example paddleocr_vl -- ...
 ```
 
 ## `OAR_VL_ATTN_FULL_SEQ_THRESHOLD`
 
-Maximum sequence length (in vision patches) for which PaddleOCR-VL's vision
-attention may use the single-shot full-matrix path; longer sequences use the
-numerically equivalent chunked path, which needs far less peak memory.
-Default `8192`; set `0` to force chunked attention.
+Maximum sequence length (in vision patches) for which PaddleOCR-VL's vision attention may use the single-shot full-matrix path. Longer sequences use the numerically equivalent chunked path, which needs far less peak memory. Default `8192`. Set `0` to force chunked attention.
 
-Independently of this threshold, the full path is skipped automatically
-whenever its softmax scratch would not fit in the free device memory, so
-low-VRAM GPUs normally don't need this variable.
+Independently of this threshold, the full path is skipped automatically whenever its softmax scratch would not fit in the free device memory, so low-VRAM GPUs normally don't need this variable.
 
 ```bash
-OAR_VL_ATTN_FULL_SEQ_THRESHOLD=0 cargo run --release --features cuda -p oar-ocr-vl --example paddleocr_vl -- ...
+OAR_VL_ATTN_FULL_SEQ_THRESHOLD=0 cargo run --release --features cuda,download-binaries -p oar-ocr-vl --example paddleocr_vl -- ...
+```
+
+## VL Performance and Debug Overrides
+
+The following presence-based switches select portable fallbacks or disable optional accelerations. Setting a variable to any value enables the switch.
+
+| Variable | Scope | Effect |
+|---|---|---|
+| `OAR_VL_DISABLE_FLASH_ATTN` | All CUDA VLM backends | Use the eager attention fallback instead of FlashAttention |
+| `OAR_VL_DISABLE_GQA` | Backends using grouped-query attention | Expand K/V heads before eager attention instead of using the grouped implementation |
+| `OAR_VL_DISABLE_CUDA_GRAPH` | PaddleOCR-VL, GLM-OCR, MinerU2.5/Pro | Disable decoder CUDA graph capture and replay |
+| `OAR_VL_DISABLE_SPECULATIVE` | GLM-OCR | Disable MTP speculative decoding |
+| `OAR_PADDLEOCR_VL_DISABLE_CUDA_GRAPH` | PaddleOCR-VL variants | Disable decoder CUDA graphs only for PaddleOCR-VL |
+| `OAR_GLMOCR_DISABLE_MTP` | GLM-OCR | Do not load or use the MTP predictor |
+| `OAR_GLMOCR_DISABLE_CUDA_GRAPH` | GLM-OCR | Disable autoregressive and MTP CUDA graphs |
+| `OAR_HUNYUAN_DISABLE_CUDA_GRAPH` | HunyuanOCR | Disable target, autoregressive, and DFlash CUDA graphs |
+| `OAR_HUNYUAN_DISABLE_AR_CUDA_GRAPH` | HunyuanOCR | Disable only the single-token autoregressive CUDA graph |
+| `OAR_MINERU_DISABLE_CUDA_GRAPH` | MinerU2.5/Pro | Disable decoder CUDA graphs |
+| `OAR_MINERU_DISABLE_GPU_SAMPLING` | MinerU2.5/Pro | Use the host sampling fallback instead of the CUDA greedy sampler |
+| `OAR_MINERU_DIFFUSION_DISABLE_GPU_SAMPLING` | MinerU-Diffusion | Use the host sampling fallback instead of the CUDA sampler |
+
+These switches are primarily useful for compatibility checks, debugging, and numerical comparisons. The accelerated paths remain enabled by default when the active device and dtype support them.
+
+## CUDA Build Overrides
+
+With the `cuda` feature enabled, `oar-ocr-vl` compiles its custom kernels to PTX. `CUDA_COMPUTE_CAP` overrides automatic GPU detection and accepts values such as `89`, `8.9`, `sm_89`, or `compute_89`. Compute capability 8.0 or newer is required. `NVCC` overrides the CUDA compiler executable.
+
+```bash
+CUDA_COMPUTE_CAP=89 NVCC=/usr/local/cuda/bin/nvcc \
+    cargo build -p oar-ocr-vl --features cuda,download-binaries
 ```
 
 ## `CUDA_LAUNCH_BLOCKING`
 
-Standard CUDA variable, listed here because the classic (ONNX Runtime)
-pipeline sets it to `1` at startup when it is not already set, to work around
-[onnxruntime#4829](https://github.com/microsoft/onnxruntime/issues/4829)
-(PP-FormulaNet's autoregressive `Loop` corrupting CUDA-EP arena buffers).
-Preset any value (e.g. `0`) to keep your own setting. Note this serializes
-CUDA kernel launches process-wide.
+Standard CUDA variable, listed here because the classic (ONNX Runtime) pipeline sets it to `1` at startup when it is not already set, to work around [onnxruntime#4829](https://github.com/microsoft/onnxruntime/issues/4829) (PP-FormulaNet's autoregressive `Loop` corrupting CUDA-EP arena buffers). Preset any value (e.g. `0`) to keep your own setting. Note this serializes CUDA kernel launches process-wide.
 
 ## `RUST_LOG`
 
-Standard [`tracing_subscriber::EnvFilter`](https://docs.rs/tracing-subscriber)
-filter used by the examples, e.g. `RUST_LOG=oar_ocr_vl=debug` to see why the
-vision attention picked the chunked path.
+Standard [`tracing_subscriber::EnvFilter`](https://docs.rs/tracing-subscriber) filter used by the examples, e.g. `RUST_LOG=oar_ocr_vl=debug` to see why the vision attention picked the chunked path.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,195 @@
+# Cargo Features
+
+The root `oar-ocr` crate exposes optional Cargo features. Each feature is forwarded to `oar-ocr-core` under the same name.
+
+The Cargo feature named `default` is not an additional capability. It is a feature set that enables `download-binaries` and `simd`.
+
+## At a Glance
+
+| Feature | Enabled by default | Category | Purpose |
+|---|:---:|---|---|
+| `simd` | Yes | CPU optimization | Accelerates CHW image normalization and CTC argmax decoding |
+| `cuda` | No | Execution provider | Enables the ONNX Runtime CUDA provider for NVIDIA GPUs |
+| `tensorrt` | No | Execution provider | Enables the ONNX Runtime TensorRT provider |
+| `directml` | No | Execution provider | Enables the DirectML provider on Windows |
+| `coreml` | No | Execution provider | Enables the Core ML provider on macOS and iOS |
+| `webgpu` | No | Execution provider | Enables the WebGPU provider on supported ONNX Runtime targets |
+| `openvino` | No | Execution provider | Enables the Intel OpenVINO provider |
+| `download-binaries` | Yes | Build setup | Downloads a compatible ONNX Runtime distribution during the build |
+| `auto-download` | No | Model management | Downloads registered OCR model files from ModelScope when first used |
+
+## Default Configuration
+
+The standard dependency declaration enables `download-binaries` and `simd`:
+
+```bash
+cargo add oar-ocr
+```
+
+This configuration uses the CPU execution provider unless an accelerator is enabled and selected through `OrtSessionConfig`. It also downloads the ONNX Runtime binaries required for linking and enables the optimized CPU preprocessing kernels.
+
+Disable both defaults with:
+
+```bash
+cargo add oar-ocr --no-default-features
+```
+
+With default features disabled, CPU preprocessing uses scalar fallbacks. An ONNX Runtime installation must also be supplied before linking. See [`download-binaries`](#download-binaries) for the system-runtime setup.
+
+## CPU Optimization
+
+### `simd`
+
+`simd` accelerates two hot CPU paths in `oar-ocr-core`:
+
+- Per-pixel CHW image normalization
+- Per-timestep CTC argmax decoding
+
+The implementation uses `wide` and `multiversion` to select an available instruction set at runtime. Supported targets can use AVX2, SSE4.2, or NEON without compiling with `target-cpu=native`. The SIMD and scalar paths are tested for identical output.
+
+This feature improves CPU pre-processing and post-processing only. It does not change the ONNX Runtime execution provider.
+
+To keep automatic ONNX Runtime setup while disabling SIMD:
+
+```bash
+cargo add oar-ocr --no-default-features --features download-binaries
+```
+
+## Execution Provider Features
+
+The execution provider features make their corresponding ONNX Runtime providers available to the crate. Enabling a feature does not select that provider automatically. Configure the provider explicitly and place the CPU provider last when a fallback is desired.
+
+```rust
+use oar_ocr::core::config::{OrtExecutionProvider, OrtSessionConfig};
+
+let ort_config = OrtSessionConfig::new().with_execution_providers(vec![
+    OrtExecutionProvider::CUDA {
+        device_id: Some(0),
+        gpu_mem_limit: None,
+        arena_extend_strategy: None,
+        cudnn_conv_algo_search: None,
+        cudnn_conv_use_max_workspace: None,
+    },
+    OrtExecutionProvider::CPU,
+]);
+```
+
+Pass the configuration to `OAROCRBuilder::ort_session` or `OARStructureBuilder::ort_session`. Requesting a provider without its matching Cargo feature returns a configuration error.
+
+### `cuda`
+
+Enables the NVIDIA CUDA execution provider. It is intended for supported Linux and Windows targets and requires a compatible NVIDIA driver, CUDA runtime, and cuDNN installation.
+
+```bash
+cargo add oar-ocr --features cuda
+```
+
+The CUDA provider supports device selection, a GPU memory limit, arena growth strategy, cuDNN convolution algorithm selection, and maximum-workspace control through `OrtExecutionProvider::CUDA`.
+
+### `tensorrt`
+
+Enables the NVIDIA TensorRT execution provider on supported Linux and Windows targets. The host must provide compatible TensorRT and CUDA runtimes.
+
+TensorRT can fall back directly to CPU. For the usual TensorRT to CUDA to CPU provider chain, enable both accelerator features:
+
+```bash
+cargo add oar-ocr --features tensorrt,cuda
+```
+
+`OrtExecutionProvider::TensorRT` exposes workspace, FP16, timing-cache, engine-cache, and embedded-engine context options.
+
+### `directml`
+
+Enables the DirectML execution provider for Windows devices supported by DirectX 12. Select a device with the `device_id` field on `OrtExecutionProvider::DirectML`.
+
+```bash
+cargo add oar-ocr --features directml
+```
+
+### `coreml`
+
+Enables the Core ML execution provider on macOS and iOS. Its configuration can prefer the Apple Neural Engine and can enable subgraph execution.
+
+```bash
+cargo add oar-ocr --features coreml
+```
+
+This feature controls the ONNX Runtime Core ML provider used by the classic pipeline. The `metal` feature in `oar-ocr-vl` is separate.
+
+### `webgpu`
+
+Enables the ONNX Runtime WebGPU execution provider. Target and binary support depends on the ONNX Runtime distribution used for the build.
+
+```bash
+cargo add oar-ocr --features webgpu
+```
+
+Select it with `OrtExecutionProvider::WebGPU`.
+
+### `openvino`
+
+Enables the Intel OpenVINO execution provider on supported Linux and Windows targets. `OrtExecutionProvider::OpenVINO` accepts a device type and an optional thread count.
+
+```bash
+cargo add oar-ocr --features openvino
+```
+
+## Runtime and Model Downloads
+
+### `download-binaries`
+
+`download-binaries` asks the pinned `ort` dependency to fetch a compatible ONNX Runtime distribution during the build. It is enabled by default and uses the platform certificate store for TLS.
+
+This feature supplies the inference runtime. It does not download OCR model files.
+
+For offline, enterprise, or custom ONNX Runtime builds, disable the default features and point `ORT_LIB_LOCATION` at the directory containing the ONNX Runtime libraries:
+
+```bash
+ORT_LIB_LOCATION=/opt/onnxruntime/lib \
+    cargo build --no-default-features --features simd
+```
+
+If an execution provider feature is enabled, the supplied ONNX Runtime build must contain that provider and its runtime dependencies. Prebuilt availability also varies by target and provider combination.
+
+### `auto-download`
+
+`auto-download` fetches registered OCR model files from [`greatv/oar-ocr` on ModelScope](https://www.modelscope.cn/models/greatv/oar-ocr) when a builder receives a missing bare model name. Files are cached under `$OAR_HOME`, which defaults to `~/.oar`, and are verified against the bundled size and SHA-256 registry.
+
+```bash
+cargo add oar-ocr --features auto-download
+```
+
+Existing files and explicit paths remain under caller control. In-memory ONNX sources also bypass the download resolver. See the [model guide](models.md#auto-download-via-the-auto-download-feature) for the complete path-resolution and cache rules.
+
+`auto-download` supplies model files at runtime. It does not install ONNX Runtime or any accelerator dependencies.
+
+## Recommended Combinations
+
+| Use case | Features |
+|---|---|
+| Standard CPU inference | Defaults only |
+| CPU inference with automatic model downloads | `auto-download` |
+| NVIDIA CUDA | `cuda` |
+| NVIDIA CUDA with automatic model downloads | `cuda,auto-download` |
+| NVIDIA TensorRT with CUDA and CPU fallbacks | `tensorrt,cuda` |
+| Windows DirectML | `directml` |
+| Apple Core ML | `coreml` |
+| Intel OpenVINO | `openvino` |
+| WebGPU on a supported target | `webgpu` |
+
+Features listed in this table are added to the two default features unless `--no-default-features` is supplied.
+
+## Selection Rules and Common Pitfalls
+
+- Cargo features are additive. Another dependency in the graph can re-enable a feature that was disabled locally.
+- CPU execution is always available and does not have a dedicated feature.
+- Execution provider order matters. ONNX Runtime tries providers in the order supplied to `OrtSessionConfig`.
+- Feature flags compile provider support but do not install GPU drivers, TensorRT, DirectML, Core ML, OpenVINO, or other system runtimes.
+- Avoid `--all-features` for normal builds. Several providers are platform-specific and some provider combinations have no matching prebuilt ONNX Runtime distribution.
+- The `oar-ocr-vl` crate has its own `cuda`, `metal`, and `download-binaries` features. They are independent of the root-crate features documented here.
+
+Inspect the resolved feature graph with:
+
+```bash
+cargo tree -e features -i oar-ocr
+```

--- a/docs/models.md
+++ b/docs/models.md
@@ -11,10 +11,10 @@ Choose between mobile and server variants based on your needs:
 
 | Version  | Category | Model File | Size | Description |
 |----------|----------|------------|------|-------------|
-| PP-OCRv4 | Mobile | [`pp-ocrv4_mobile_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_mobile_det.onnx) | 4.6MB | Mobile variant for real-time applications |
-| PP-OCRv4 | Server | [`pp-ocrv4_server_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_server_det.onnx) | 108.2MB | Server variant for high-precision |
-| PP-OCRv5 | Mobile | [`pp-ocrv5_mobile_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv5_mobile_det.onnx) | 4.6MB | Mobile variant for real-time applications |
-| PP-OCRv5 | Server | [`pp-ocrv5_server_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv5_server_det.onnx) | 84.0MB | Server variant for high-precision |
+| PP-OCRv4 | Mobile | [`pp-ocrv4_mobile_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_mobile_det.onnx) | 4.6 MiB | Mobile variant for real-time applications |
+| PP-OCRv4 | Server | [`pp-ocrv4_server_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_server_det.onnx) | 108.2 MiB | Server variant for high-precision |
+| PP-OCRv5 | Mobile | [`pp-ocrv5_mobile_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv5_mobile_det.onnx) | 4.6 MiB | Mobile variant for real-time applications |
+| PP-OCRv5 | Server | [`pp-ocrv5_server_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv5_server_det.onnx) | 84.0 MiB | Server variant for high-precision |
 
 ## Text Recognition Models
 
@@ -22,42 +22,42 @@ Choose between mobile and server variants based on your needs:
 
 | Version  | Category | Model File | Size | Description |
 |----------|----------|------------|------|-------------|
-| PP-OCRv3 | Mobile | [`pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv3_mobile_rec.onnx) | 10.2MB | Legacy mobile variant |
-| PP-OCRv4 | Mobile | [`pp-ocrv4_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_mobile_rec.onnx) | 10.4MB | Mobile variant |
-| PP-OCRv4 | Server | [`pp-ocrv4_server_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_server_rec.onnx) | 86.3MB | Server variant |
-| PP-OCRv4 | Document | [`pp-ocrv4_server_rec_doc.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_server_rec_doc.onnx) | 90.5MB | Optimized for documents |
-| PP-OCRv5 | Mobile | [`pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv5_mobile_rec.onnx) | 15.8MB | Mobile variant |
-| PP-OCRv5 | Server | [`pp-ocrv5_server_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv5_server_rec.onnx) | 80.6MB | Server variant |
-| SVTRv2 | Server | [`ch_svtrv2_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ch_svtrv2_rec.onnx) | 80.3MB | High accuracy variant |
-| RepSVTR | Server | [`ch_repsvtr_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ch_repsvtr_rec.onnx) | 24.2MB | Balanced accuracy/speed |
+| PP-OCRv3 | Mobile | [`pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv3_mobile_rec.onnx) | 10.2 MiB | Legacy mobile variant |
+| PP-OCRv4 | Mobile | [`pp-ocrv4_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_mobile_rec.onnx) | 10.4 MiB | Mobile variant |
+| PP-OCRv4 | Server | [`pp-ocrv4_server_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_server_rec.onnx) | 86.3 MiB | Server variant |
+| PP-OCRv4 | Document | [`pp-ocrv4_server_rec_doc.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_server_rec_doc.onnx) | 90.5 MiB | Optimized for documents |
+| PP-OCRv5 | Mobile | [`pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv5_mobile_rec.onnx) | 15.8 MiB | Mobile variant |
+| PP-OCRv5 | Server | [`pp-ocrv5_server_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv5_server_rec.onnx) | 80.6 MiB | Server variant |
+| SVTRv2 | Server | [`ch_svtrv2_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ch_svtrv2_rec.onnx) | 80.3 MiB | High accuracy variant |
+| RepSVTR | Server | [`ch_repsvtr_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ch_repsvtr_rec.onnx) | 24.2 MiB | Balanced accuracy/speed |
 
 ### Language-Specific Models
 
 | Version  | Language | Model File | Size | Description |
 |----------|----------|------------|------|-------------|
-| PP-OCRv3 | Arabic | [`arabic_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/arabic_pp-ocrv3_mobile_rec.onnx) | 8.6MB | Arabic text recognition |
-| PP-OCRv5 | Arabic | [`arabic_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/arabic_pp-ocrv5_mobile_rec.onnx) | 7.7MB | Arabic text recognition |
-| PP-OCRv3 | Chinese Traditional | [`chinese_cht_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/chinese_cht_pp-ocrv3_mobile_rec.onnx) | 10.6MB | Traditional Chinese text recognition |
-| PP-OCRv3 | Cyrillic | [`cyrillic_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/cyrillic_pp-ocrv3_mobile_rec.onnx) | 8.6MB | Cyrillic script recognition |
-| PP-OCRv5 | Cyrillic | [`cyrillic_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/cyrillic_pp-ocrv5_mobile_rec.onnx) | 7.7MB | Cyrillic script recognition |
-| PP-OCRv3 | Devanagari | [`devanagari_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/devanagari_pp-ocrv3_mobile_rec.onnx) | 8.6MB | Devanagari script recognition |
-| PP-OCRv5 | Devanagari | [`devanagari_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/devanagari_pp-ocrv5_mobile_rec.onnx) | 7.6MB | Devanagari script recognition |
-| PP-OCRv5 | Greek | [`el_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/el_pp-ocrv5_mobile_rec.onnx) | 7.5MB | Greek text recognition |
-| PP-OCRv3 | English | [`en_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/en_pp-ocrv3_mobile_rec.onnx) | 8.6MB | English text recognition |
-| PP-OCRv4 | English | [`en_pp-ocrv4_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/en_pp-ocrv4_mobile_rec.onnx) | 7.4MB | English text recognition |
-| PP-OCRv5 | English | [`en_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/en_pp-ocrv5_mobile_rec.onnx) | 7.5MB | English text recognition |
-| PP-OCRv5 | Eastern Slavic | [`eslav_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/eslav_pp-ocrv5_mobile_rec.onnx) | 7.5MB | Eastern Slavic languages |
-| PP-OCRv3 | Japanese | [`japan_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/japan_pp-ocrv3_mobile_rec.onnx) | 9.6MB | Japanese text recognition |
-| PP-OCRv3 | Georgian | [`ka_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ka_pp-ocrv3_mobile_rec.onnx) | 8.6MB | Georgian text recognition |
-| PP-OCRv3 | Korean | [`korean_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/korean_pp-ocrv3_mobile_rec.onnx) | 9.5MB | Korean text recognition |
-| PP-OCRv5 | Korean | [`korean_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/korean_pp-ocrv5_mobile_rec.onnx) | 12.8MB | Korean text recognition |
-| PP-OCRv3 | Latin | [`latin_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/latin_pp-ocrv3_mobile_rec.onnx) | 8.6MB | Latin script recognition |
-| PP-OCRv5 | Latin | [`latin_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/latin_pp-ocrv5_mobile_rec.onnx) | 7.7MB | Latin script recognition |
-| PP-OCRv3 | Tamil | [`ta_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ta_pp-ocrv3_mobile_rec.onnx) | 8.6MB | Tamil text recognition |
-| PP-OCRv5 | Tamil | [`ta_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ta_pp-ocrv5_mobile_rec.onnx) | 7.5MB | Tamil text recognition |
-| PP-OCRv3 | Telugu | [`te_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/te_pp-ocrv3_mobile_rec.onnx) | 8.6MB | Telugu text recognition |
-| PP-OCRv5 | Telugu | [`te_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/te_pp-ocrv5_mobile_rec.onnx) | 7.6MB | Telugu text recognition |
-| PP-OCRv5 | Thai | [`th_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/th_pp-ocrv5_mobile_rec.onnx) | 7.6MB | Thai text recognition |
+| PP-OCRv3 | Arabic | [`arabic_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/arabic_pp-ocrv3_mobile_rec.onnx) | 8.6 MiB | Arabic text recognition |
+| PP-OCRv5 | Arabic | [`arabic_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/arabic_pp-ocrv5_mobile_rec.onnx) | 7.7 MiB | Arabic text recognition |
+| PP-OCRv3 | Chinese Traditional | [`chinese_cht_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/chinese_cht_pp-ocrv3_mobile_rec.onnx) | 10.6 MiB | Traditional Chinese text recognition |
+| PP-OCRv3 | Cyrillic | [`cyrillic_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/cyrillic_pp-ocrv3_mobile_rec.onnx) | 8.6 MiB | Cyrillic script recognition |
+| PP-OCRv5 | Cyrillic | [`cyrillic_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/cyrillic_pp-ocrv5_mobile_rec.onnx) | 7.7 MiB | Cyrillic script recognition |
+| PP-OCRv3 | Devanagari | [`devanagari_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/devanagari_pp-ocrv3_mobile_rec.onnx) | 8.6 MiB | Devanagari script recognition |
+| PP-OCRv5 | Devanagari | [`devanagari_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/devanagari_pp-ocrv5_mobile_rec.onnx) | 7.6 MiB | Devanagari script recognition |
+| PP-OCRv5 | Greek | [`el_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/el_pp-ocrv5_mobile_rec.onnx) | 7.5 MiB | Greek text recognition |
+| PP-OCRv3 | English | [`en_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/en_pp-ocrv3_mobile_rec.onnx) | 8.6 MiB | English text recognition |
+| PP-OCRv4 | English | [`en_pp-ocrv4_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/en_pp-ocrv4_mobile_rec.onnx) | 7.4 MiB | English text recognition |
+| PP-OCRv5 | English | [`en_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/en_pp-ocrv5_mobile_rec.onnx) | 7.5 MiB | English text recognition |
+| PP-OCRv5 | Eastern Slavic | [`eslav_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/eslav_pp-ocrv5_mobile_rec.onnx) | 7.5 MiB | Eastern Slavic languages |
+| PP-OCRv3 | Japanese | [`japan_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/japan_pp-ocrv3_mobile_rec.onnx) | 9.6 MiB | Japanese text recognition |
+| PP-OCRv3 | Georgian | [`ka_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ka_pp-ocrv3_mobile_rec.onnx) | 8.6 MiB | Georgian text recognition |
+| PP-OCRv3 | Korean | [`korean_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/korean_pp-ocrv3_mobile_rec.onnx) | 9.5 MiB | Korean text recognition |
+| PP-OCRv5 | Korean | [`korean_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/korean_pp-ocrv5_mobile_rec.onnx) | 12.8 MiB | Korean text recognition |
+| PP-OCRv3 | Latin | [`latin_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/latin_pp-ocrv3_mobile_rec.onnx) | 8.6 MiB | Latin script recognition |
+| PP-OCRv5 | Latin | [`latin_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/latin_pp-ocrv5_mobile_rec.onnx) | 7.7 MiB | Latin script recognition |
+| PP-OCRv3 | Tamil | [`ta_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ta_pp-ocrv3_mobile_rec.onnx) | 8.6 MiB | Tamil text recognition |
+| PP-OCRv5 | Tamil | [`ta_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ta_pp-ocrv5_mobile_rec.onnx) | 7.5 MiB | Tamil text recognition |
+| PP-OCRv3 | Telugu | [`te_pp-ocrv3_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/te_pp-ocrv3_mobile_rec.onnx) | 8.6 MiB | Telugu text recognition |
+| PP-OCRv5 | Telugu | [`te_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/te_pp-ocrv5_mobile_rec.onnx) | 7.6 MiB | Telugu text recognition |
+| PP-OCRv5 | Thai | [`th_pp-ocrv5_mobile_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/th_pp-ocrv5_mobile_rec.onnx) | 7.6 MiB | Thai text recognition |
 
 ## PP-OCRv6
 
@@ -67,20 +67,19 @@ PP-OCRv6 is the newest PP-OCR generation. Unlike the older models mirrored on th
 
 ### Detection
 
-| Size | ONNX | BOS |
-|------|------|--------------|
-| tiny | 1.7MB | [`PP-OCRv6_tiny_det_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_tiny_det_onnx_infer.tar) |
-| small | 9.4MB | [`PP-OCRv6_small_det_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_small_det_onnx_infer.tar) |
-| medium | 59.2MB | [`PP-OCRv6_medium_det_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_medium_det_onnx_infer.tar) |
+| Size | Auto-download ONNX | File size | Official bundle |
+|------|--------------------|-----------|-----------------|
+| tiny | `pp-ocrv6_tiny_det.onnx` | 1.7 MiB | [`PP-OCRv6_tiny_det_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_tiny_det_onnx_infer.tar) |
+| small | `pp-ocrv6_small_det.onnx` | 9.4 MiB | [`PP-OCRv6_small_det_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_small_det_onnx_infer.tar) |
+| medium | `pp-ocrv6_medium_det.onnx` | 59.2 MiB | [`PP-OCRv6_medium_det_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_medium_det_onnx_infer.tar) |
 
 ### Recognition
 
-| Size | ONNX | Dict size | BOS |
-|------|------|-----------|--------------|
-| tiny | 4.3MB | 6904 chars | [`PP-OCRv6_tiny_rec_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_tiny_rec_onnx_infer.tar) |
-| small | 20.2MB | 18708 chars | [`PP-OCRv6_small_rec_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_small_rec_onnx_infer.tar) |
-| medium | 73.0MB | 18708 chars | [`PP-OCRv6_medium_rec_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_medium_rec_onnx_infer.tar) |
-
+| Size | Auto-download ONNX | Dictionary | File size | Official bundle |
+|------|--------------------|------------|-----------|-----------------|
+| tiny | `pp-ocrv6_tiny_rec.onnx` | `ppocrv6_tiny_dict.txt` (6904 characters) | 4.3 MiB | [`PP-OCRv6_tiny_rec_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_tiny_rec_onnx_infer.tar) |
+| small | `pp-ocrv6_small_rec.onnx` | `ppocrv6_dict.txt` (18708 characters) | 20.2 MiB | [`PP-OCRv6_small_rec_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_small_rec_onnx_infer.tar) |
+| medium | `pp-ocrv6_medium_rec.onnx` | `ppocrv6_dict.txt` (18708 characters) | 73.0 MiB | [`PP-OCRv6_medium_rec_onnx_infer.tar`](https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_medium_rec_onnx_infer.tar) |
 
 ## Character Dictionaries
 
@@ -92,9 +91,11 @@ Character dictionaries are required for text recognition. Choose the appropriate
 |---------|------|-------------|
 | PP-OCRv4 Document | [`ppocrv4_doc_dict.txt`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ppocrv4_doc_dict.txt) | For PP-OCRv4 document models |
 | PP-OCRv5 | [`ppocrv5_dict.txt`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ppocrv5_dict.txt) | For PP-OCRv5 models |
-| PP-OCR Keys v1 | [`ppocr_keys_v1.txt`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ppocr_keys_v1.txt) | For older PP-OCR models |
+| PP-OCRv6 Tiny | `ppocrv6_tiny_dict.txt` | For PP-OCRv6 tiny recognition |
+| PP-OCRv6 Small/Medium | `ppocrv6_dict.txt` | For PP-OCRv6 small and medium recognition |
+| PP-OCR Keys v1 | [`ppocr_keys_v1.txt`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ppocr_keys_v1.txt) | For PP-OCRv3 general and PP-OCRv4 general models |
 
-### Language-Specific Dictionaries
+### PP-OCRv5 Language-Specific Dictionaries
 
 | Language | File | Model Compatibility |
 |----------|------|---------------------|
@@ -110,16 +111,35 @@ Character dictionaries are required for text recognition. Choose the appropriate
 | Telugu | [`ppocrv5_te_dict.txt`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ppocrv5_te_dict.txt) | PP-OCRv5 Telugu |
 | Thai | [`ppocrv5_th_dict.txt`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/ppocrv5_th_dict.txt) | PP-OCRv5 Thai |
 
+### PP-OCRv3 and PP-OCRv4 Language-Specific Dictionaries
+
+The language-specific PP-OCRv3 dictionaries are different from the PP-OCRv5 dictionaries and are not part of the auto-download registry. Download them from PaddleOCR and pass the local path to the recognition builder. The PP-OCRv4 English checkpoint uses the same `en_dict.txt` file as PP-OCRv3 English.
+
+| Language | Official dictionary | Model compatibility |
+|----------|---------------------|---------------------|
+| Arabic | [`arabic_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/arabic_dict.txt) | PP-OCRv3 Arabic |
+| Traditional Chinese | [`chinese_cht_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/chinese_cht_dict.txt) | PP-OCRv3 Traditional Chinese |
+| Cyrillic | [`cyrillic_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/cyrillic_dict.txt) | PP-OCRv3 Cyrillic |
+| Devanagari | [`devanagari_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/devanagari_dict.txt) | PP-OCRv3 Devanagari |
+| English | [`en_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/en_dict.txt) | PP-OCRv3 and PP-OCRv4 English |
+| Japanese | [`japan_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/japan_dict.txt) | PP-OCRv3 Japanese |
+| Georgian | [`ka_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/ka_dict.txt) | PP-OCRv3 Georgian |
+| Korean | [`korean_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/korean_dict.txt) | PP-OCRv3 Korean |
+| Latin | [`latin_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/latin_dict.txt) | PP-OCRv3 Latin script |
+| Tamil | [`ta_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/ta_dict.txt) | PP-OCRv3 Tamil |
+| Telugu | [`te_dict.txt`](https://github.com/PaddlePaddle/PaddleOCR/blob/main/ppocr/utils/dict/te_dict.txt) | PP-OCRv3 Telugu |
+
 ## Preprocessing Models
 
 Models for document preprocessing and orientation detection:
 
 | Type | Model File | Size | Description |
 |------|------------|------|-------------|
-| Document Orientation | [`pp-lcnet_x1_0_doc_ori.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-lcnet_x1_0_doc_ori.onnx) | 6.5MB | Detect document rotation |
-| Text Line Orientation (Light) | [`pp-lcnet_x0_25_textline_ori.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-lcnet_x0_25_textline_ori.onnx) | 995KB | Fast text line orientation |
-| Text Line Orientation | [`pp-lcnet_x1_0_textline_ori.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-lcnet_x1_0_textline_ori.onnx) | 6.5MB | Accurate text line orientation |
-| Document Rectification | [`uvdoc.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/uvdoc.onnx) | 30.2MB | Fix perspective distortion |
+| Document Orientation | [`pp-lcnet_x1_0_doc_ori.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-lcnet_x1_0_doc_ori.onnx) | 6.5 MiB | Detect document rotation |
+| Text Line Orientation (Light) | [`pp-lcnet_x0_25_textline_ori.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-lcnet_x0_25_textline_ori.onnx) | 995 KiB | Fast text line orientation |
+| Text Line Orientation (Paddle2ONNX) | `p2o_pp-lcnet_x0_25_textline_ori.onnx` | 977 KiB | Compatibility export available through auto-download |
+| Text Line Orientation | [`pp-lcnet_x1_0_textline_ori.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-lcnet_x1_0_textline_ori.onnx) | 6.5 MiB | Accurate text line orientation |
+| Document Rectification | [`uvdoc.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/uvdoc.onnx) | 30.2 MiB | Fix perspective distortion |
 
 ## Document Structure Models
 
@@ -129,54 +149,64 @@ Models for document structure analysis with `OARStructureBuilder`:
 
 | Model | Model File | Size | Description |
 |-------|------------|------|-------------|
-| PicoDet-L 17cls | [`picodet-l_layout_17cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet-l_layout_17cls.onnx) | 22.4MB | 17-class layout detection |
-| PicoDet-L 3cls | [`picodet-l_layout_3cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet-l_layout_3cls.onnx) | 22.4MB | 3-class layout detection |
-| PicoDet-S 17cls | [`picodet-s_layout_17cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet-s_layout_17cls.onnx) | 4.7MB | Fast 17-class layout |
-| PicoDet-S 3cls | [`picodet-s_layout_3cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet-s_layout_3cls.onnx) | 4.7MB | Fast 3-class layout |
-| PicoDet 1x | [`picodet_layout_1x.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet_layout_1x.onnx) | 7.2MB | Legacy layout model |
-| PicoDet 1x Table | [`picodet_layout_1x_table.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet_layout_1x_table.onnx) | 7.2MB | Table-focused layout |
-| PP-DocLayout-S | [`pp-doclayout-s.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-doclayout-s.onnx) | 4.7MB | Small variant |
-| PP-DocLayout-M | [`pp-doclayout-m.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-doclayout-m.onnx) | 22.4MB | Medium variant |
-| PP-DocLayout-L | [`pp-doclayout-l.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-doclayout-l.onnx) | 123.4MB | Large variant |
-| PP-DocLayout_plus-L | [`pp-doclayout_plus-l.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-doclayout_plus-l.onnx) | 123.7MB | Enhanced large variant |
-| PP-DocLayoutV2 | [`pp-doclayoutv2.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-doclayoutv2.onnx) | 204.0MB | V2 with reading order (col, row) |
-| PP-DocLayoutV3 | [`pp-doclayoutv3.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.6.0/pp-doclayoutv3.onnx) | 124.0MB | V3 with single order key |
-| PP-DocBlockLayout | [`pp-docblocklayout.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-docblocklayout.onnx) | 123.4MB | Hierarchical ordering |
-| RT-DETR-H 17cls | [`rt-detr-h_layout_17cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/rt-detr-h_layout_17cls.onnx) | 469.2MB | High accuracy 17-class |
-| RT-DETR-H 3cls | [`rt-detr-h_layout_3cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/rt-detr-h_layout_3cls.onnx) | 469.2MB | High accuracy 3-class |
+| PicoDet-L 17cls | [`picodet-l_layout_17cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet-l_layout_17cls.onnx) | 22.4 MiB | 17-class layout detection |
+| PicoDet-L 3cls | [`picodet-l_layout_3cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet-l_layout_3cls.onnx) | 22.4 MiB | 3-class layout detection |
+| PicoDet-S 17cls | [`picodet-s_layout_17cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet-s_layout_17cls.onnx) | 4.7 MiB | Fast 17-class layout |
+| PicoDet-S 3cls | [`picodet-s_layout_3cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet-s_layout_3cls.onnx) | 4.7 MiB | Fast 3-class layout |
+| PicoDet 1x | [`picodet_layout_1x.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet_layout_1x.onnx) | 7.2 MiB | Legacy layout model |
+| PicoDet 1x Table | [`picodet_layout_1x_table.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/picodet_layout_1x_table.onnx) | 7.2 MiB | Table-focused layout |
+| PP-DocLayout-S | [`pp-doclayout-s.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-doclayout-s.onnx) | 4.7 MiB | Small variant |
+| PP-DocLayout-M | [`pp-doclayout-m.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-doclayout-m.onnx) | 22.4 MiB | Medium variant |
+| PP-DocLayout-L | [`pp-doclayout-l.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-doclayout-l.onnx) | 123.4 MiB | Large variant |
+| PP-DocLayout_plus-L | [`pp-doclayout_plus-l.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-doclayout_plus-l.onnx) | 123.7 MiB | Enhanced large variant |
+| PP-DocLayoutV2 | [`pp-doclayoutv2.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-doclayoutv2.onnx) | 204.1 MiB | V2 with reading order (col, row) |
+| PP-DocLayoutV3 | [`pp-doclayoutv3.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.6.0/pp-doclayoutv3.onnx) | 123.9 MiB | V3 with single order key |
+| PP-DocBlockLayout | [`pp-docblocklayout.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-docblocklayout.onnx) | 123.3 MiB | Hierarchical ordering |
+| RT-DETR-H 17cls | [`rt-detr-h_layout_17cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/rt-detr-h_layout_17cls.onnx) | 469.3 MiB | High accuracy 17-class |
+| RT-DETR-H 3cls | [`rt-detr-h_layout_3cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/rt-detr-h_layout_3cls.onnx) | 469.2 MiB | High accuracy 3-class |
 
 ### Table Recognition
 
 | Component | Model File | Size | Description |
 |-----------|------------|------|-------------|
-| Table Classification | [`pp-lcnet_x1_0_table_cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-lcnet_x1_0_table_cls.onnx) | 6.5MB | Wired vs wireless |
-| Cell Detection (Wired) | [`rt-detr-l_wired_table_cell_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/rt-detr-l_wired_table_cell_det.onnx) | 123.4MB | RT-DETR for wired tables |
-| Cell Detection (Wireless) | [`rt-detr-l_wireless_table_cell_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/rt-detr-l_wireless_table_cell_det.onnx) | 123.4MB | RT-DETR for wireless tables |
-| Structure (SLANet) | [`slanet.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/slanet.onnx) | 7.4MB | Basic structure recognition |
-| Structure (SLANet+) | [`slanet_plus.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/slanet_plus.onnx) | 7.4MB | Wireless table structure |
-| Structure (SLANeXt Wired) | [`slanext_wired.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/slanext_wired.onnx) | 350.7MB | High accuracy wired structure |
-| Structure (SLANeXt Wireless) | [`slanext_wireless.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/slanext_wireless.onnx) | 350.7MB | High accuracy wireless structure |
+| Table Classification | [`pp-lcnet_x1_0_table_cls.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-lcnet_x1_0_table_cls.onnx) | 6.5 MiB | Wired vs wireless |
+| Cell Detection (Wired) | [`rt-detr-l_wired_table_cell_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/rt-detr-l_wired_table_cell_det.onnx) | 123.3 MiB | RT-DETR for wired tables |
+| Cell Detection (Wireless) | [`rt-detr-l_wireless_table_cell_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/rt-detr-l_wireless_table_cell_det.onnx) | 123.3 MiB | RT-DETR for wireless tables |
+| Structure (SLANet) | [`slanet.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/slanet.onnx) | 7.4 MiB | Basic structure recognition |
+| Structure (SLANet+) | [`slanet_plus.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/slanet_plus.onnx) | 7.4 MiB | Wireless table structure |
+| Structure (SLANet+ V2) | `slanet_plus_v2.onnx` | 7.4 MiB | Newer compatibility export available through auto-download |
+| Structure (SLANeXt Wired) | [`slanext_wired.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/slanext_wired.onnx) | 350.7 MiB | High accuracy wired structure |
+| Structure (SLANeXt Wireless) | [`slanext_wireless.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/slanext_wireless.onnx) | 350.7 MiB | High accuracy wireless structure |
 | Structure Dictionary | [`table_structure_dict_ch.txt`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/table_structure_dict_ch.txt) | - | Required for structure recognition |
 
 ### Formula Recognition
 
 | Model | Model File | Size | Description |
 |-------|------------|------|-------------|
-| PP-FormulaNet-S | [`pp-formulanet-s.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-formulanet-s.onnx) | 221.1MB | Small variant |
-| PP-FormulaNet-L | [`pp-formulanet-l.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-formulanet-l.onnx) | 696.7MB | Large variant |
-| PP-FormulaNet_plus-S | [`pp-formulanet_plus-s.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-formulanet_plus-s.onnx) | 221.1MB | Enhanced small variant |
-| PP-FormulaNet_plus-M | [`pp-formulanet_plus-m.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-formulanet_plus-m.onnx) | 565.0MB | Enhanced medium variant |
-| PP-FormulaNet_plus-L | [`pp-formulanet_plus-l.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-formulanet_plus-l.onnx) | 699.7MB | Enhanced large variant |
-| UniMERNet | [`unimernet.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/unimernet.onnx) | 1.7GB | Unified Math Expression Recognition |
-| UniMERNet Tokenizer | [`unimernet_tokenizer.json`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/unimernet_tokenizer.json) | 2.0MB | Required for UniMERNet |
-| LaTeX OCR | [`latex_ocr_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/latex_ocr_rec.onnx) | 97.8MB | LaTeX formula recognition |
+| PP-FormulaNet-S | [`pp-formulanet-s.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-formulanet-s.onnx) | 221.1 MiB | Small variant |
+| PP-FormulaNet-L | [`pp-formulanet-l.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-formulanet-l.onnx) | 696.5 MiB | Large variant |
+| PP-FormulaNet_plus-S | [`pp-formulanet_plus-s.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-formulanet_plus-s.onnx) | 221.1 MiB | Enhanced small variant |
+| PP-FormulaNet_plus-M | [`pp-formulanet_plus-m.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-formulanet_plus-m.onnx) | 564.9 MiB | Enhanced medium variant |
+| PP-FormulaNet_plus-L | [`pp-formulanet_plus-l.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-formulanet_plus-l.onnx) | 699.5 MiB | Enhanced large variant |
+| PP-FormulaNet Tokenizer | `pp-formulanet-tokenizer.json` | 2.0 MiB | Required for PP-FormulaNet variants |
+| UniMERNet | [`unimernet.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/unimernet.onnx) | 1.7 GiB | Unified Math Expression Recognition |
+| UniMERNet Tokenizer | [`unimernet_tokenizer.json`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/unimernet_tokenizer.json) | 2.0 MiB | Required for UniMERNet |
+
+The current formula predictor supports PP-FormulaNet and UniMERNet. `latex_ocr_rec.onnx` remains registered as a legacy download artifact, but it is not wired into `FormulaRecognitionPredictor` and its tokenizer is not mirrored by this project.
+
+### Auxiliary and Legacy Registered Assets
+
+| Asset | Size | Status |
+|-------|------|--------|
+| [`latex_ocr_rec.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/latex_ocr_rec.onnx) | 97.8 MiB | Legacy checkpoint, not supported by the current formula predictor |
+| `unimernet_tokenizer_config.json` | 4.4 KiB | Optional tokenizer metadata retained for compatibility |
 
 ### Seal Text Detection
 
 | Model | Model File | Size | Description |
 |-------|------------|------|-------------|
-| Seal Detection (Mobile) | [`pp-ocrv4_mobile_seal_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_mobile_seal_det.onnx) | 4.6MB | Fast seal detection |
-| Seal Detection (Server) | [`pp-ocrv4_server_seal_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_server_seal_det.onnx) | 108.2MB | Accurate seal detection |
+| Seal Detection (Mobile) | [`pp-ocrv4_mobile_seal_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_mobile_seal_det.onnx) | 4.6 MiB | Fast seal detection |
+| Seal Detection (Server) | [`pp-ocrv4_server_seal_det.onnx`](https://github.com/GreatV/oar-ocr/releases/download/v0.3.0/pp-ocrv4_server_seal_det.onnx) | 108.2 MiB | Accurate seal detection |
 
 ## Auto-download (via the `auto-download` feature)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -143,7 +143,7 @@ let structure = OARStructureBuilder::new("picodet-l_layout_17cls.onnx")
     .with_table_cell_detection("rt-detr-l_wired_table_cell_det.onnx", "wired")
     .with_table_structure_recognition("slanext_wired.onnx", "wired")
     .table_structure_dict_path("table_structure_dict_ch.txt")
-    .with_formula_recognition("pp-formulanet-l.onnx", "unimernet_tokenizer.json", "pp_formulanet")
+    .with_formula_recognition("pp-formulanet-l.onnx", "pp-formulanet-tokenizer.json", "pp_formulanet")
     .build()?;
 
 // Structure analysis with integrated OCR
@@ -165,7 +165,7 @@ let structure = OARStructureBuilder::new("picodet-l_layout_17cls.onnx")
 | `.formula_recognition_config(config)` | Set formula score threshold, max length, and batch size |
 | `.formula_ort_session(config)` | Apply ONNX Runtime configuration only to formula recognition |
 | `.with_ocr(det, rec, dict)` | Add integrated OCR pipeline |
-| `.with_seal_detection(path)` | Add seal/stamp text detection |
+| `.with_seal_text_detection(path)` | Add seal/stamp text detection |
 | `.image_batch_size(n)` | Set batch size for image processing |
 | `.region_batch_size(n)` | Set batch size for region processing |
 | `.ort_session(config)` | Apply ONNX Runtime configuration |
@@ -222,14 +222,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 OAROCR supports multiple execution providers via feature flags:
 
+See the [Cargo feature guide](features.md) for the root-crate features, default behavior, platform requirements, and recommended combinations.
+
 | Feature | Provider | Platform |
 |---------|----------|----------|
 | `cuda` | NVIDIA CUDA | Linux, Windows |
 | `tensorrt` | NVIDIA TensorRT | Linux, Windows |
 | `directml` | DirectML | Windows |
 | `coreml` | Core ML | macOS, iOS |
+| `webgpu` | WebGPU | Supported ONNX Runtime targets |
 | `openvino` | Intel OpenVINO | Linux, Windows |
-| `webgpu` | WebGPU | Cross-platform |
 
 Example with TensorRT:
 
@@ -241,6 +243,13 @@ let ort_config = OrtSessionConfig::new()
             max_workspace_size: None,
             min_subgraph_size: None,
             fp16_enable: None,
+            timing_cache: None,
+            timing_cache_path: None,
+            force_timing_cache: None,
+            engine_cache: None,
+            engine_cache_path: None,
+            dump_ep_context_model: None,
+            ep_context_file_path: None,
         },
         OrtExecutionProvider::CUDA {
             device_id: Some(0),
@@ -255,27 +264,31 @@ let ort_config = OrtSessionConfig::new()
 
 ## PaddleOCR-VL (Vision-Language)
 
-[PaddleOCR-VL](https://huggingface.co/PaddlePaddle/PaddleOCR-VL) is an ultra-compact (0.9B parameters) Vision-Language Model for document parsing, released by Baidu's PaddlePaddle team. It supports **109 languages** and excels in recognizing complex elements including text, tables, formulas, and 11 chart types. The model achieves SOTA performance in both page-level document parsing and element-level recognition while maintaining minimal resource consumption.
+[PaddleOCR-VL](https://huggingface.co/PaddlePaddle/PaddleOCR-VL) is a 0.9B document Vision-Language Model from the PaddlePaddle team. It supports 109 languages and task-specific recognition for text, tables, formulas, and charts.
 
 This functionality is available in the separate `oar-ocr-vl` crate, using [Candle](https://github.com/huggingface/candle) for native Rust inference.
 
-PaddleOCR-VL-1.5 is also supported as a drop-in replacement via `PaddleOcrVl::from_dir`, and adds **text spotting** and **seal recognition** tasks.
+PaddleOCR-VL-1.5 and PaddleOCR-VL-1.6 are drop-in replacements via `PaddleOcrVl::from_dir`. Both add **text spotting** and **seal recognition** to the original model's task set.
 
 ### Installation
 
-Add the VL crate to your `Cargo.toml`:
+Add the VL crate and the core crate used by the snippets below to your `Cargo.toml`. `download-binaries` supplies ONNX Runtime for the core helpers unless you link a system installation with `ORT_LIB_PATH` or `ORT_LIB_LOCATION`.
 
 ```toml
 [dependencies]
-oar-ocr-vl = "0.7"
+oar-ocr-core = { version = "0.8", default-features = false }
+oar-ocr-vl = { version = "0.8", features = ["download-binaries"] }
 ```
 
 For GPU acceleration, enable CUDA:
 
 ```toml
 [dependencies]
-oar-ocr-vl = { version = "0.7", features = ["cuda"] }
+oar-ocr-core = { version = "0.8", default-features = false }
+oar-ocr-vl = { version = "0.8", features = ["cuda", "download-binaries"] }
 ```
+
+On macOS, use the `metal` feature instead.
 
 ### Downloading the Model
 
@@ -289,9 +302,13 @@ git clone https://huggingface.co/PaddlePaddle/PaddleOCR-VL
 # PaddleOCR-VL-1.5
 git clone https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5
 
+# PaddleOCR-VL-1.6
+git clone https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6
+
 # Or using hf
 hf download PaddlePaddle/PaddleOCR-VL --local-dir PaddleOCR-VL
 hf download PaddlePaddle/PaddleOCR-VL-1.5 --local-dir PaddleOCR-VL-1.5
+hf download PaddlePaddle/PaddleOCR-VL-1.6 --local-dir PaddleOCR-VL-1.6
 ```
 
 ### Basic Usage
@@ -304,7 +321,7 @@ use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = load_image(Path::new("document.png"))?;
-    let device = parse_device("cpu")?;  // or "cuda", "cuda:0"
+    let device = parse_device("cpu")?; // or "cuda", "cuda:0", "metal"
     let vl = PaddleOcrVl::from_dir("PaddleOCR-VL", device)?;
 
     // Element-level OCR. The API is batch-oriented, so pass one task per image.
@@ -319,7 +336,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-PaddleOCR-VL-1.5 uses the same API:
+PaddleOCR-VL-1.5 and PaddleOCR-VL-1.6 use the same API:
 
 ```rust,no_run
 use oar_ocr_core::utils::load_image;
@@ -330,7 +347,8 @@ use std::path::Path;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = load_image(Path::new("seal.png"))?;
     let device = parse_device("cpu")?;
-    let vl = PaddleOcrVl::from_dir("PaddleOCR-VL-1.5", device)?;
+    // Use "PaddleOCR-VL-1.5" here to load the 1.5 checkpoint instead.
+    let vl = PaddleOcrVl::from_dir("PaddleOCR-VL-1.6", device)?;
 
     let result = vl
         .generate(&[image], &[PaddleOcrVlTask::Seal], 256)
@@ -346,11 +364,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
     -m PaddleOCR-VL --device cuda --task ocr document.jpg
 
-cargo run -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
     -m PaddleOCR-VL-1.5 --device cuda --task spotting spotting.jpg
+
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
+    -m PaddleOCR-VL-1.6 --device cuda --task seal seal.jpg
 ```
 
 ### Supported Tasks
@@ -368,7 +389,7 @@ cargo run -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
 
 [HunyuanOCR 1.5](https://huggingface.co/tencent/HunyuanOCR) is a lightweight OCR expert VLM. It is available in the `oar-ocr-vl` crate and supports prompt-driven image-to-text OCR. `HunyuanOcr::from_dir` automatically detects 1.5 at the model repository root and remains compatible with archived 1.0 weights under `v1.0/`.
 
-HunyuanOCR 1.5 inputs use the checkpoint's 16M-pixel budget (up to a 4K square input). The 2048 value in `vision_config.max_image_size` describes the learned positional-embedding base grid; larger input grids are interpolated, as in the official implementation.
+HunyuanOCR 1.5 inputs use the checkpoint's 16M-pixel budget (up to a 4K square input). The 2048 value in `vision_config.max_image_size` describes the learned positional-embedding base grid. Larger input grids are interpolated, as in the official implementation.
 
 ### Downloading the Model
 
@@ -380,7 +401,7 @@ git clone https://huggingface.co/tencent/HunyuanOCR
 hf download tencent/HunyuanOCR --local-dir HunyuanOCR
 ```
 
-The download places 1.5 weights directly in `HunyuanOCR/`. To use 1.0 instead, pass `HunyuanOCR/v1.0` as the model directory.
+The download places 1.5 weights directly in `HunyuanOCR/` and its optional DFlash draft in `HunyuanOCR/dflash/`. To use 1.0 instead, pass `HunyuanOCR/v1.0` as the model directory.
 
 ### Basic Usage
 
@@ -391,7 +412,7 @@ use oar_ocr_vl::utils::parse_device;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = load_image("document.jpg")?;
-    let device = parse_device("cpu")?; // or "cuda", "cuda:0"
+    let device = parse_device("cpu")?; // or "cuda", "cuda:0", "metal"
 
     // Repository root = HunyuanOCR 1.5; `HunyuanOCR/v1.0` also works.
     let model = HunyuanOcr::from_dir("HunyuanOCR", device)?;
@@ -408,11 +429,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+HunyuanOCR 1.5 can load the official DFlash draft for speculative decoding:
+
+```rust,no_run
+use oar_ocr_vl::HunyuanOcr;
+use oar_ocr_vl::utils::parse_device;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let model = HunyuanOcr::from_dir_with_dflash(
+        "HunyuanOCR",
+        parse_device("cuda:0")?,
+    )?;
+    assert!(model.dflash_enabled());
+    Ok(())
+}
+```
+
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda --example hunyuanocr -- \
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example hunyuanocr -- \
     --model-dir HunyuanOCR \
+    --dflash-dir HunyuanOCR/dflash \
     --device cuda \
     --prompt "Detect and recognize text in the image, and output the text coordinates in a formatted manner." \
     document.jpg
@@ -452,7 +490,7 @@ use oar_ocr_vl::utils::parse_device;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = load_image("document.jpg")?;
-    let device = parse_device("cpu")?; // or "cuda", "cuda:0"
+    let device = parse_device("cpu")?; // or "cuda", "cuda:0", "metal"
 
     let model = GlmOcr::from_dir("GLM-OCR", device)?;
     let prompt = "Text Recognition:";
@@ -470,25 +508,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda --example glmocr -- \
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example glmocr -- \
     --model-dir GLM-OCR \
     --device cuda \
     --prompt "Text Recognition:" \
     document.jpg
 ```
 
-## MinerU2.5
+## MinerU2.5 and MinerU2.5-Pro
 
-[MinerU2.5](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) is a document parsing VLM supported by `oar-ocr-vl`. For full-page documents, use its model-native two-step pipeline rather than forcing it through `DocParser`.
+[MinerU2.5](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) and [MinerU2.5-Pro](https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B) are document parsing VLMs supported by the same `MinerU` loader. For full-page documents, use their model-native two-step pipeline rather than forcing them through `DocParser`.
 
 ### Downloading the Model
 
 ```bash
 git lfs install
 git clone https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B
+git clone https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B
 
 # Or using hf
 hf download opendatalab/MinerU2.5-2509-1.2B --local-dir MinerU2.5-2509-1.2B
+hf download opendatalab/MinerU2.5-Pro-2605-1.2B --local-dir MinerU2.5-Pro-2605-1.2B
 ```
 
 ### Basic Usage
@@ -500,8 +540,9 @@ use oar_ocr_vl::utils::parse_device;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = load_image("document.jpg")?;
-    let device = parse_device("cpu")?; // or "cuda", "cuda:0"
+    let device = parse_device("cpu")?; // or "cuda", "cuda:0", "metal"
 
+    // MinerU2.5-Pro-2605-1.2B is loaded through the same API.
     let model = MinerU::from_dir("MinerU2.5-2509-1.2B", device)?;
     let prompt = "\nText Recognition:";
     let text = model
@@ -518,17 +559,71 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda --example mineru -- \
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
     --model-dir MinerU2.5-2509-1.2B \
     --device cuda \
+    document.jpg
+
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
+    --model-dir MinerU2.5-Pro-2605-1.2B \
+    --device cuda \
+    document.jpg
+```
+
+## MinerU-Diffusion-V1
+
+[MinerU-Diffusion-V1](https://huggingface.co/opendatalab/MinerU-Diffusion-V1-0320-2.5B) replaces autoregressive text generation with block-diffusion decoding. The `mineru_diffusion` example defaults to MinerU-style two-step structured extraction and also provides `--single-pass` for flat full-page text recognition.
+
+### Downloading the Model
+
+```bash
+git lfs install
+git clone https://huggingface.co/opendatalab/MinerU-Diffusion-V1-0320-2.5B
+
+# Or using hf
+hf download opendatalab/MinerU-Diffusion-V1-0320-2.5B \
+    --local-dir MinerU-Diffusion-V1-0320-2.5B
+```
+
+### Basic Usage
+
+```rust,no_run
+use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::mineru_diffusion::DEFAULT_PROMPT;
+use oar_ocr_vl::utils::parse_device;
+use oar_ocr_vl::{DiffusionGenerationConfig, MinerUDiffusion};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let image = load_image("document.jpg")?;
+    let model = MinerUDiffusion::from_dir(
+        "MinerU-Diffusion-V1-0320-2.5B",
+        parse_device("cuda:0")?,
+    )?;
+    let text = model.generate(
+        &image,
+        DEFAULT_PROMPT,
+        &DiffusionGenerationConfig::default(),
+    )?;
+    println!("{text}");
+    Ok(())
+}
+```
+
+### Running the Example
+
+```bash
+cargo run -p oar-ocr-vl --features cuda,download-binaries \
+    --example mineru_diffusion -- \
+    --model-dir MinerU-Diffusion-V1-0320-2.5B \
+    --device cuda:0 \
     document.jpg
 ```
 
 ## DocParser
 
-DocParser provides a unified API for external layout-first document parsing with VL-based recognition. It supports PaddleOCR-VL, PaddleOCR-VL-1.5, and GLM-OCR as recognition backends.
+DocParser provides a unified API for external layout-first document parsing with VL-based recognition. The `doc_parser` example supports PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR.
 
-Use `parse(&layout, image)` with an ONNX layout detector. HunyuanOCR and MinerU2.5 are not exposed by the `doc_parser` example because their reference-quality paths are prompt-driven full-page parsing and model-native two-step extraction, respectively.
+Use `parse(&layout, image)` with an ONNX layout detector. The library also implements `RecognitionBackend` for HunyuanOCR and MinerU2.5/Pro, but they are intentionally not exposed by the CLI example because their reference-quality paths are prompt-driven full-page parsing and model-native two-step extraction, respectively. MinerU-Diffusion uses its dedicated example.
 
 ### Basic Usage
 
@@ -556,13 +651,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = parser.parse(&layout, image.clone())?;
     println!("{}", result.to_markdown());
 
-    // Option 2: Using PaddleOCR-VL-1.5 (next-gen, more accurate)
+    // Option 2: Using PaddleOCR-VL-1.5
     let paddleocr_vl_15 = PaddleOcrVl::from_dir("PaddleOCR-VL-1.5", device.clone())?;
     let parser = DocParser::new(&paddleocr_vl_15);
     let result = parser.parse(&layout, image.clone())?;
     println!("{}", result.to_markdown());
 
-    // Option 3: Using GLM-OCR with external layout
+    // Option 3: Using PaddleOCR-VL-1.6
+    let paddleocr_vl_16 = PaddleOcrVl::from_dir("PaddleOCR-VL-1.6", device.clone())?;
+    let parser = DocParser::new(&paddleocr_vl_16);
+    let result = parser.parse(&layout, image.clone())?;
+    println!("{}", result.to_markdown());
+
+    // Option 4: Using GLM-OCR with external layout
     let glmocr = GlmOcr::from_dir("GLM-OCR", device)?;
     let parser = DocParser::new(&glmocr);
     let result = parser.parse(&layout, image)?;
@@ -576,23 +677,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ```bash
 # Using PaddleOCR-VL
-cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example doc_parser -- \
     --model-name paddleocr-vl \
     --model-dir PaddleOCR-VL \
     --layout-model models/pp-doclayoutv3.onnx \
     --device cuda \
     document.jpg
 
-# Using PaddleOCR-VL-1.5 (next-gen, more accurate)
-cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
+# Using PaddleOCR-VL-1.5
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example doc_parser -- \
     --model-name paddleocr-vl-1.5 \
     --model-dir PaddleOCR-VL-1.5 \
     --layout-model models/pp-doclayoutv3.onnx \
     --device cuda \
     document.jpg
 
+# Using PaddleOCR-VL-1.6
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example doc_parser -- \
+    --model-name paddleocr-vl-1.6 \
+    --model-dir PaddleOCR-VL-1.6 \
+    --layout-model models/pp-doclayoutv3.onnx \
+    --device cuda \
+    document.jpg
+
 # Using GLM-OCR with layout
-cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example doc_parser -- \
     --model-name glmocr \
     --model-dir GLM-OCR \
     --layout-model models/pp-doclayoutv3.onnx \

--- a/oar-ocr-core/README.md
+++ b/oar-ocr-core/README.md
@@ -24,14 +24,17 @@ cargo add oar-ocr-core
 
 | Feature | Description |
 | :--- | :--- |
+| `simd` | Accelerate CPU image normalization and CTC argmax decoding (default) |
 | `cuda` | Enable NVIDIA CUDA execution provider |
 | `tensorrt` | Enable NVIDIA TensorRT execution provider |
 | `directml` | Enable DirectML execution provider (Windows) |
 | `coreml` | Enable Core ML execution provider (macOS/iOS) |
+| `webgpu` | Enable WebGPU execution provider on supported ONNX Runtime targets |
 | `openvino` | Enable Intel OpenVINO execution provider |
-| `webgpu` | Enable WebGPU execution provider |
-| `visualization` | Enable drawing utilities for debugging |
 | `download-binaries` | Automatically download ONNX Runtime binaries (default) |
+| `auto-download` | Download registered OCR model files from ModelScope at runtime |
+
+The root `oar-ocr` crate forwards the same feature names. See the [Cargo feature guide](https://github.com/GreatV/oar-ocr/blob/main/docs/features.md) for provider selection, system requirements, default behavior, and recommended combinations.
 
 ## Quick Start
 
@@ -106,10 +109,12 @@ for element in &results.elements[0] {
 | :--- | :--- |
 | `TextDetectionPredictor` | Locates text regions (polygons) in images. |
 | `TextRecognitionPredictor` | Converts text regions into strings. |
+| `TextLineOrientationPredictor` | Classifies the orientation of individual text lines. |
 | `LayoutDetectionPredictor` | Identifies semantic elements (Title, Table, Figure). |
-| `TableStructureRecognitionPredictor` | Extracts HTML/Markdown structure from tables. |
+| `TableClassificationPredictor` | Classifies tables as wired or wireless. |
+| `TableStructureRecognitionPredictor` | Produces HTML structure tokens and cell bounding boxes. |
 | `TableCellDetectionPredictor` | Locates individual cells within a table. |
 | `FormulaRecognitionPredictor` | Converts math formulas to LaTeX. |
-| `DocumentOrientationPredictor` | Detects and corrects document rotation. |
+| `DocumentOrientationPredictor` | Classifies document rotation. |
 | `DocumentRectificationPredictor` | Unwarps perspective or curved document images. |
 | `SealTextDetectionPredictor` | Specialized detection for curved official stamps. |

--- a/oar-ocr-vl/README.md
+++ b/oar-ocr-vl/README.md
@@ -6,14 +6,18 @@ This crate provides native Rust inference for document VLMs using [Candle](https
 
 ## Supported Models
 
-| Model | Parameters | Description |
-|-------|------------|-------------|
-| [PaddleOCR-VL](https://huggingface.co/PaddlePaddle/PaddleOCR-VL) | 0.9B | SOTA document parsing VLM supporting 109 languages, text, tables, formulas, and 11 chart types |
-| [PaddleOCR-VL-1.5](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5) | 0.9B | Next-gen PaddleOCR-VL with 94.5% on OmniDocBench v1.5, adds text spotting and seal recognition |
-| [PaddleOCR-VL-1.6](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6) | 1.0B | Region-aware refinement on top of PaddleOCR-VL-1.5; 96.33% on OmniDocBench v1.6 (SOTA), drop-in compatible with the 1.5 loader |
-| [HunyuanOCR 1.5](https://huggingface.co/tencent/HunyuanOCR) | 1.0B | End-to-end OCR VLM for multilingual document parsing, text spotting, and information extraction (archived 1.0 weights also supported) |
-| [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) | 0.9B | #1 on OmniDocBench v1.5 (94.62), optimized for real-world scenarios with MTP loss and RL training |
-| [MinerU2.5](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) | 1.2B | Decoupled document parsing VLM with strong text, formula, and table recognition |
+| Model | Parameters | Inference path |
+|---|---:|---|
+| [PaddleOCR-VL](https://huggingface.co/PaddlePaddle/PaddleOCR-VL) | 0.9B | External-layout page parsing, text, table, formula, and chart recognition |
+| [PaddleOCR-VL-1.5](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5) | 0.9B | PaddleOCR-VL tasks plus text spotting and seal recognition |
+| [PaddleOCR-VL-1.6](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6) | 0.9B | Region-aware refinement, drop-in compatible with the 1.5 loader |
+| [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) | 0.9B | External-layout page parsing, text, table, and formula recognition |
+| [HunyuanOCR 1.5 / 1.0](https://huggingface.co/tencent/HunyuanOCR) | 1B | Model-native prompt-driven parsing with optional DFlash decoding for 1.5 |
+| [MinerU2.5-2509](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) | 1.2B | Model-native two-step layout detection and content extraction |
+| [MinerU2.5-Pro-2605](https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B) | 1.2B | Newer compatible checkpoint using the MinerU2.5 two-step pipeline |
+| [MinerU-Diffusion-V1-0320](https://huggingface.co/opendatalab/MinerU-Diffusion-V1-0320-2.5B) | 2.5B | Block-diffusion OCR with two-step structured extraction or single-pass recognition |
+
+See [`examples`](examples) for runnable examples.
 
 ## Document Parsing Pipeline
 
@@ -22,33 +26,37 @@ This crate provides native Rust inference for document VLMs using [Candle](https
 1. **Layout detection** (ONNX models like PP-DocLayoutV3) to identify document regions
 2. **VL-based recognition** to extract content from each region
 
-Use DocParser with PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR. HunyuanOCR should be used with its model-native full-page prompts, and MinerU2.5 should use its model-native two-step extraction example.
+Use DocParser with PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR. HunyuanOCR should be used with its model-native full-page prompts. MinerU2.5, MinerU2.5-Pro, and MinerU-Diffusion should use their model-native two-step extraction examples.
 
 ## Installation
 
-Add `oar-ocr-vl` to your project:
-
-```bash
-cargo add oar-ocr-vl
-```
-
-If you use ONNX-based helpers from `oar-ocr-core` and want ORT binaries to be fetched automatically during build, enable `download-binaries` explicitly:
+Add `oar-ocr-vl` with bundled ONNX Runtime binaries. The snippets below also import image-loading and layout helpers from `oar-ocr-core`, so declare it as a direct dependency:
 
 ```bash
 cargo add oar-ocr-vl --features download-binaries
+cargo add oar-ocr-core --no-default-features
+```
+
+The VL crate has no default features and depends on `oar-ocr-core`, which links ONNX Runtime. You may omit `download-binaries` only when a system ONNX Runtime installation is available through `ORT_LIB_PATH` or `ORT_LIB_LOCATION`.
+
+```bash
+cargo add oar-ocr-vl
+cargo add oar-ocr-core --no-default-features
 ```
 
 To enable GPU acceleration (CUDA), add the feature flag:
 
 ```bash
-cargo add oar-ocr-vl --features cuda
+cargo add oar-ocr-vl --features cuda,download-binaries
 ```
 
-HunyuanOCR's custom CUDA kernels compile PTX for the oldest GPU detected by
-`nvidia-smi` at build time. For headless, container, or cross-machine builds,
-set the target explicitly, for example
-`CUDA_COMPUTE_CAP=89 cargo build --features cuda`. The DFlash kernels require
-compute capability 8.0 or newer.
+On macOS, enable Metal instead:
+
+```bash
+cargo add oar-ocr-vl --features metal,download-binaries
+```
+
+The crate's custom CUDA kernels compile to PTX for the oldest GPU detected by `nvidia-smi` at build time. For headless, container, or cross-machine builds, set the target explicitly, for example `CUDA_COMPUTE_CAP=89 cargo build -p oar-ocr-vl --features cuda,download-binaries`. These kernels require compute capability 8.0 or newer.
 
 ## Usage
 
@@ -59,9 +67,10 @@ Use PaddleOCR-VL to recognize a specific aspect of an image (e.g., just the tabl
 ```rust
 use oar_ocr_core::utils::load_image;
 use oar_ocr_vl::{PaddleOcrVl, PaddleOcrVlTask};
+use oar_ocr_vl::utils::parse_device;
 
 let image = load_image("document.png")?;
-let device = candle_core::Device::Cpu; // Or Device::new_cuda(0)?
+let device = parse_device("cpu")?; // Or "cuda", "cuda:0", or "metal"
 
 // Initialize model
 let model = PaddleOcrVl::from_dir("PaddleOCR-VL", device)?;
@@ -80,9 +89,10 @@ PaddleOCR-VL-1.5 and PaddleOCR-VL-1.6 are loaded the same way, with additional t
 ```rust
 use oar_ocr_core::utils::load_image;
 use oar_ocr_vl::{PaddleOcrVl, PaddleOcrVlTask};
+use oar_ocr_vl::utils::parse_device;
 
 let image = load_image("seal.png")?;
-let device = candle_core::Device::Cpu;
+let device = parse_device("cpu")?;
 let model = PaddleOcrVl::from_dir("PaddleOCR-VL-1.5", device)?;
 let result = model
     .generate(&[image], &[PaddleOcrVlTask::Seal], 256)
@@ -100,8 +110,9 @@ Parse an entire page into Markdown with a layout predictor. This path is intende
 use oar_ocr_core::utils::load_image;
 use oar_ocr_core::predictors::LayoutDetectionPredictor;
 use oar_ocr_vl::{DocParser, PaddleOcrVl};
+use oar_ocr_vl::utils::parse_device;
 
-let device = candle_core::Device::Cpu;
+let device = parse_device("cpu")?;
 
 // 1. Setup Layout Detector
 let layout_predictor = LayoutDetectionPredictor::builder()
@@ -120,14 +131,15 @@ let result = parser.parse(&layout_predictor, image)?;
 println!("{}", result.to_markdown());
 ```
 
-### MinerU2.5
+### MinerU2.5 / MinerU2.5-Pro
 
 ```rust
 use oar_ocr_core::utils::load_image;
 use oar_ocr_vl::MinerU;
+use oar_ocr_vl::utils::parse_device;
 
 let image = load_image("document.png")?;
-let device = candle_core::Device::Cpu;
+let device = parse_device("cpu")?;
 let model = MinerU::from_dir("models/MinerU2.5-2509-1.2B", device)?;
 // For full documents, prefer the `mineru` example, which follows the
 // model-native two-step pipeline: layout detection, then crop recognition.
@@ -148,7 +160,7 @@ The `oar-ocr-vl` crate includes several examples demonstrating its capabilities.
 This example combines layout detection (ONNX) with a VLM for recognition. It supports PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR.
 
 ```bash
-cargo run --release --features cuda --example doc_parser -- \
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example doc_parser -- \
     --model-name paddleocr-vl-1.5 \
     --model-dir models/PaddleOCR-VL-1.5 \
     --layout-model models/pp-doclayoutv3.onnx \
@@ -156,7 +168,7 @@ cargo run --release --features cuda --example doc_parser -- \
     document.jpg
 ```
 
-HunyuanOCR and MinerU2.5 are intentionally not exposed by this example because their reference-quality paths are prompt-driven full-page parsing and model-native two-step extraction, respectively.
+HunyuanOCR and the MinerU models are intentionally not exposed by this example because their reference-quality paths are prompt-driven full-page parsing and model-native two-step extraction, respectively.
 
 ### PaddleOCR-VL (Direct Inference)
 
@@ -164,29 +176,29 @@ Run the PaddleOCR-VL model directly on an image with a specific task prompt.
 
 ```bash
 # OCR task
-cargo run --release --features cuda --example paddleocr_vl -- \
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
     --model-dir models/PaddleOCR-VL \
     --device cuda \
     --task ocr \
     document.jpg
 
 # Table task
-cargo run --release --features cuda --example paddleocr_vl -- \
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
     --model-dir models/PaddleOCR-VL \
     --device cuda \
     --task table \
     table.jpg
 
-# Text spotting (PaddleOCR-VL-1.5)
-cargo run --release --features cuda --example paddleocr_vl -- \
+# Text spotting (PaddleOCR-VL-1.5 or 1.6)
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
     --model-dir models/PaddleOCR-VL-1.5 \
     --device cuda \
     --task spotting \
     spotting.jpg
 
-# Seal recognition (PaddleOCR-VL-1.5)
-cargo run --release --features cuda --example paddleocr_vl -- \
-    --model-dir models/PaddleOCR-VL-1.5 \
+# Seal recognition (PaddleOCR-VL-1.5 or 1.6)
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
+    --model-dir models/PaddleOCR-VL-1.6 \
     --device cuda \
     --task seal \
     seal.jpg
@@ -195,7 +207,7 @@ cargo run --release --features cuda --example paddleocr_vl -- \
 ### HunyuanOCR 1.5 (Direct Inference)
 
 ```bash
-cargo run --release --features cuda --example hunyuanocr -- \
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example hunyuanocr -- \
     --model-dir models/HunyuanOCR \
     --dflash-dir models/HunyuanOCR/dflash \
     --device cuda \
@@ -203,25 +215,45 @@ cargo run --release --features cuda --example hunyuanocr -- \
     document.jpg
 ```
 
-The model repository root contains HunyuanOCR 1.5. The loader detects it automatically; use `--model-dir models/HunyuanOCR/v1.0` for the archived 1.0 checkpoint. `--dflash-dir` enables the official 15-token parallel draft path for 1.5; omit it for ordinary autoregressive decoding. Library callers can use `HunyuanOcr::from_dirs(target_dir, dflash_dir, device)` or `HunyuanOcr::from_dir_with_dflash(model_dir, device)` when the draft is stored in the official `dflash/` subdirectory.
+The model repository root contains HunyuanOCR 1.5. The loader detects it automatically. Use `--model-dir models/HunyuanOCR/v1.0` for the archived 1.0 checkpoint. `--dflash-dir` enables the official 15-token parallel draft path for 1.5. Omit it for ordinary autoregressive decoding. Library callers can use `HunyuanOcr::from_dirs(target_dir, dflash_dir, device)` or `HunyuanOcr::from_dir_with_dflash(model_dir, device)` when the draft is stored in the official `dflash/` subdirectory.
 
 ### GLM-OCR (Direct Inference)
 
 ```bash
-cargo run --release --features cuda --example glmocr -- \
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example glmocr -- \
     --model-dir models/GLM-OCR \
     --device cuda \
     --prompt "Text Recognition:" \
     document.jpg
 ```
 
-### MinerU2.5 (Direct Inference)
+### MinerU2.5 / MinerU2.5-Pro (Direct Inference)
 
 Model-native two-step document extraction (layout prompt + content extraction):
 
 ```bash
-cargo run --release --features cuda --example mineru -- \
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
     --model-dir models/MinerU2.5-2509-1.2B \
+    --device cuda:0 \
+    document.jpg
+```
+
+`MinerU2.5-Pro-2605` uses the same loader and example:
+
+```bash
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
+    --model-dir models/MinerU2.5-Pro-2605-1.2B \
+    --device cuda:0 \
+    document.jpg
+```
+
+### MinerU-Diffusion-V1 (Direct Inference)
+
+The default mode performs two-step structured extraction with block-diffusion decoding. Add `--single-pass` for flat full-page text recognition.
+
+```bash
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example mineru_diffusion -- \
+    --model-dir models/MinerU-Diffusion-V1-0320-2.5B \
     --device cuda:0 \
     document.jpg
 ```

--- a/oar-ocr-vl/examples/doc_parser.rs
+++ b/oar-ocr-vl/examples/doc_parser.rs
@@ -3,29 +3,36 @@
 //! This example demonstrates the unified DocParser API for external
 //! layout-first document parsing (layout detection + region recognition).
 //!
-//! HunyuanOCR and MinerU2.5 are intentionally not exposed here:
-//! their reference-quality usage is full-page prompt-driven parsing or a
-//! model-native two-step pipeline, not forced external layout crops.
+//! HunyuanOCR and the MinerU models are intentionally not exposed here: their
+//! reference-quality usage is full-page prompt-driven parsing or a model-native
+//! two-step pipeline, not forced external layout crops.
 //!
 //! # Usage
 //!
 //! ```bash
 //! # Using PaddleOCR-VL model
-//! cargo run -p oar-ocr-vl --example doc_parser -- \
+//! cargo run -p oar-ocr-vl --features download-binaries --example doc_parser -- \
 //!     --model-name paddleocr-vl \
 //!     --model-dir PaddleOCR-VL \
 //!     --layout-model models/pp-doclayoutv3.onnx \
 //!     document.jpg
 //!
-//! # Using PaddleOCR-VL-1.5 model (next-gen, more accurate)
-//! cargo run -p oar-ocr-vl --example doc_parser -- \
+//! # Using PaddleOCR-VL-1.5 model
+//! cargo run -p oar-ocr-vl --features download-binaries --example doc_parser -- \
 //!     --model-name paddleocr-vl-1.5 \
 //!     --model-dir PaddleOCR-VL-1.5 \
 //!     --layout-model models/pp-doclayoutv3.onnx \
 //!     document.jpg
 //!
+//! # Using PaddleOCR-VL-1.6 model
+//! cargo run -p oar-ocr-vl --features download-binaries --example doc_parser -- \
+//!     --model-name paddleocr-vl-1.6 \
+//!     --model-dir PaddleOCR-VL-1.6 \
+//!     --layout-model models/pp-doclayoutv3.onnx \
+//!     document.jpg
+//!
 //! # Using GLM-OCR model
-//! cargo run -p oar-ocr-vl --example doc_parser -- \
+//! cargo run -p oar-ocr-vl --features download-binaries --example doc_parser -- \
 //!     --model-name glmocr \
 //!     --model-dir models/GLM-OCR \
 //!     --layout-model models/pp-doclayoutv3.onnx \
@@ -52,10 +59,10 @@ enum ModelName {
     /// PaddleOCR-VL 0.9B: VLM with task prompts
     #[value(name = "paddleocr-vl")]
     PaddleOcrVl,
-    /// PaddleOCR-VL 1.5: Next-gen VLM with spotting and seal recognition
+    /// PaddleOCR-VL 1.5 (0.9B): spotting and seal recognition
     #[value(name = "paddleocr-vl-1.5")]
     PaddleOcrVl15,
-    /// PaddleOCR-VL 1.6: Latest VLM with enhanced recognition
+    /// PaddleOCR-VL 1.6 (0.9B): region-aware enhanced recognition
     #[value(name = "paddleocr-vl-1.6")]
     PaddleOcrVl16,
     /// GLM-OCR: OCR expert VLM (GLM-V)
@@ -67,7 +74,7 @@ enum ModelName {
 #[derive(Parser)]
 #[command(name = "doc_parser")]
 #[command(
-    about = "Unified external-layout DocParser - supports PaddleOCR-VL, PaddleOCR-VL-1.5, and GLM-OCR"
+    about = "Unified external-layout DocParser - supports PaddleOCR-VL, PaddleOCR-VL-1.5/1.6, and GLM-OCR"
 )]
 struct Args {
     /// Recognition model to use

--- a/oar-ocr-vl/examples/glmocr.rs
+++ b/oar-ocr-vl/examples/glmocr.rs
@@ -5,13 +5,13 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --example glmocr -- [OPTIONS] <IMAGES>...
+//! cargo run -p oar-ocr-vl --features download-binaries --example glmocr -- [OPTIONS] <IMAGES>...
 //! ```
 //!
 //! # Examples
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --example glmocr -- \
+//! cargo run -p oar-ocr-vl --features download-binaries --example glmocr -- \
 //!     --model-dir models/GLM-OCR \
 //!     --prompt "Text Recognition:" \
 //!     document.jpg

--- a/oar-ocr-vl/examples/hunyuanocr.rs
+++ b/oar-ocr-vl/examples/hunyuanocr.rs
@@ -6,13 +6,13 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --example hunyuanocr -- [OPTIONS] <IMAGES>...
+//! cargo run -p oar-ocr-vl --features download-binaries --example hunyuanocr -- [OPTIONS] <IMAGES>...
 //! ```
 //!
 //! # Examples
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --example hunyuanocr -- \\
+//! cargo run -p oar-ocr-vl --features download-binaries --example hunyuanocr -- \\
 //!     --model-dir models/HunyuanOCR \\
 //!     --prompt "Detect and recognize text in the image, and output the text coordinates in a formatted manner." \\
 //!     document.jpg

--- a/oar-ocr-vl/examples/mineru.rs
+++ b/oar-ocr-vl/examples/mineru.rs
@@ -1,19 +1,26 @@
-//! MinerU2.5 Two-Step Document Extraction Example (Candle-based)
+//! MinerU2.5 / MinerU2.5-Pro Two-Step Document Extraction Example (Candle-based)
 //!
-//! This example demonstrates how to run `opendatalab/MinerU2.5-2509-1.2B` in Rust
-//! using the two-step extraction pipeline: layout detection followed by content extraction.
+//! This example runs `opendatalab/MinerU2.5-2509-1.2B` or
+//! `opendatalab/MinerU2.5-Pro-2605-1.2B` in Rust using the same two-step
+//! extraction pipeline: layout detection followed by content extraction.
 //!
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --example mineru -- [OPTIONS] <IMAGES>...
+//! cargo run -p oar-ocr-vl --features download-binaries --example mineru -- [OPTIONS] <IMAGES>...
 //! ```
 //!
 //! # Example
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --example mineru -- \
+//! cargo run -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
 //!     --model-dir models/MinerU2.5-2509-1.2B \
+//!     --device cuda:0 \
+//!     document.jpg
+//!
+//! # MinerU2.5-Pro uses the same loader and pipeline
+//! cargo run -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
+//!     --model-dir models/MinerU2.5-Pro-2605-1.2B \
 //!     --device cuda:0 \
 //!     document.jpg
 //! ```
@@ -38,9 +45,11 @@ use utils::token_fingerprint;
 
 #[derive(Parser)]
 #[command(name = "mineru")]
-#[command(about = "MinerU2.5 Two-Step Document Extraction - layout detection + content extraction")]
+#[command(
+    about = "MinerU2.5 / MinerU2.5-Pro two-step extraction - layout detection + content extraction"
+)]
 struct Args {
-    /// Path to the MinerU2.5 model directory
+    /// Path to a MinerU2.5 or MinerU2.5-Pro model directory
     #[arg(short, long)]
     model_dir: PathBuf,
 
@@ -97,7 +106,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let device = parse_device(&args.device)?;
     info!("Using device: {:?}", device);
 
-    info!("Loading MinerU2.5 model from: {}", args.model_dir.display());
+    info!("Loading MinerU model from: {}", args.model_dir.display());
     let load_start = Instant::now();
     let model = MinerU::from_dir(&args.model_dir, device)?;
     info!(

--- a/oar-ocr-vl/examples/mineru_diffusion.rs
+++ b/oar-ocr-vl/examples/mineru_diffusion.rs
@@ -19,7 +19,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --example mineru_diffusion --features cuda,download-binaries -- \
+//! cargo run -p oar-ocr-vl --features cuda,download-binaries --example mineru_diffusion -- \
 //!     --model-dir /path/to/MinerU-Diffusion-V1-0320-2.5B \
 //!     --device cuda:0 \
 //!     document.jpg

--- a/oar-ocr-vl/examples/paddleocr_vl.rs
+++ b/oar-ocr-vl/examples/paddleocr_vl.rs
@@ -1,12 +1,14 @@
 //! PaddleOCR-VL Recognition Example (Candle-based)
 //!
-//! This example demonstrates how to use PaddleOCR-VL for task-specific recognition
-//! of text, formulas, tables, and charts using the Candle ML framework.
+//! This example runs PaddleOCR-VL, PaddleOCR-VL-1.5, or PaddleOCR-VL-1.6 for
+//! task-specific recognition using the Candle ML framework. All variants
+//! support text, formula, table, and chart recognition. Versions 1.5 and 1.6
+//! also support text spotting and seal recognition.
 //!
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --example paddleocr_vl -- [OPTIONS] <IMAGES>...
+//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- [OPTIONS] <IMAGES>...
 //! ```
 //!
 //! # Arguments
@@ -21,31 +23,31 @@
 //!
 //! ```bash
 //! # OCR (text recognition)
-//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
 //!     -m PaddleOCR-VL --task ocr document.jpg
 //!
 //! # Table recognition
-//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
 //!     -m PaddleOCR-VL --task table table.jpg
 //!
 //! # Formula recognition
-//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
 //!     -m PaddleOCR-VL --task formula formula.jpg
 //!
 //! # Chart recognition
-//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
 //!     -m PaddleOCR-VL --task chart chart.jpg
 //!
-//! # Text spotting (PaddleOCR-VL-1.5)
-//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
+//! # Text spotting (PaddleOCR-VL-1.5 or 1.6)
+//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
 //!     -m PaddleOCR-VL-1.5 --task spotting spotting.jpg
 //!
-//! # Seal recognition (PaddleOCR-VL-1.5)
-//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
-//!     -m PaddleOCR-VL-1.5 --task seal seal.jpg
+//! # Seal recognition (PaddleOCR-VL-1.5 or 1.6)
+//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
+//!     -m PaddleOCR-VL-1.6 --task seal seal.jpg
 //!
 //! # Run on CUDA GPU
-//! cargo run -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
 //!     -m PaddleOCR-VL -d cuda --task ocr document.jpg
 //! ```
 

--- a/oar-ocr-vl/src/attention.rs
+++ b/oar-ocr-vl/src/attention.rs
@@ -1,6 +1,7 @@
-//! Unified attention and rotary embedding shared by all VLM models
-//! (PaddleOCR-VL, HunyuanOCR, GLM-OCR, MinerU2.5), for consistent mask handling,
-//! KV-cache logic, and multi-axis RoPE (MRoPE, XDRoPE).
+//! Unified attention and rotary embedding shared by the VLM backends
+//! (PaddleOCR-VL, HunyuanOCR, GLM-OCR, MinerU2.5/Pro, and MinerU-Diffusion),
+//! for consistent mask handling, KV-cache logic, and multi-axis RoPE
+//! (MRoPE, XDRoPE).
 //!
 //! ## Usage
 //!

--- a/oar-ocr-vl/src/doc_parser.rs
+++ b/oar-ocr-vl/src/doc_parser.rs
@@ -3,10 +3,14 @@
 //! backend into structured results.
 //!
 //! Supported backends:
-//! - `PaddleOcrVl` - VLM with task-specific prompts
-//! - `HunyuanOcr` - OCR expert VLM (HunYuanVL)
-//! - `GlmOcr` - GLM-OCR OCR expert VLM
-//! - `MinerU` - MinerU2.5 document parsing VLM (Qwen2-VL backbone)
+//! - [`PaddleOcrVl`] - PaddleOCR-VL, 1.5, and 1.6 with task-specific prompts
+//! - [`HunyuanOcr`] - HunyuanOCR 1.5 / 1.0 (HunYuanVL)
+//! - [`GlmOcr`] - GLM-OCR
+//! - [`MinerU`] - MinerU2.5 and MinerU2.5-Pro (Qwen2-VL backbone)
+//!
+//! The `doc_parser` example exposes the layout-first PaddleOCR-VL and GLM-OCR
+//! paths. For reference-quality full-page parsing, prefer HunyuanOCR's native
+//! page prompt and the MinerU models' native two-step extraction pipeline.
 
 use super::utils::{
     DetectedBox, calculate_overlap_ratio, calculate_projection_overlap_ratio, convert_otsl_to_html,

--- a/oar-ocr-vl/src/lib.rs
+++ b/oar-ocr-vl/src/lib.rs
@@ -4,11 +4,14 @@
 //!
 //! ## Modules
 //!
-//! - `paddleocr_vl` - PaddleOCR-VL for OCR, table, formula, chart, spotting, and seal recognition
+//! - `paddleocr_vl` - PaddleOCR-VL, 1.5, and 1.6 for OCR, table, formula,
+//!   chart, spotting, and seal recognition
 //! - `hunyuanocr` - HunyuanOCR 1.5 / 1.0 OCR expert VLM
 //! - `glmocr` - GLM-OCR OCR expert VLM
-//! - `mineru` - MinerU2.5 document parsing VLM (Qwen2-VL backbone)
-//! - `mineru_diffusion` - MinerU-Diffusion-V1 block-diffusion document OCR (Qwen2-VL vision + SDAR decoder)
+//! - `mineru` - MinerU2.5 and MinerU2.5-Pro document parsing VLMs (Qwen2-VL
+//!   backbone)
+//! - `mineru_diffusion` - MinerU-Diffusion-V1 block-diffusion document OCR
+//!   (Qwen2-VL vision + SDAR decoder)
 //! - `doc_parser` - Unified document parsing with pluggable recognition backends
 //! - `utils` - Device parsing, candle helpers, markdown, OTSL conversion
 //! - `attention` - Unified attention shared by all models

--- a/oar-ocr-vl/src/mineru/mod.rs
+++ b/oar-ocr-vl/src/mineru/mod.rs
@@ -1,4 +1,9 @@
 //! MinerU2.5 Vision-Language model implementation (Qwen2-VL backbone).
+//!
+//! [`MinerU::from_dir`] supports both `MinerU2.5-2509-1.2B` and
+//! `MinerU2.5-Pro-2605-1.2B`. For full-page documents, use the model-native
+//! two-step layout-detection and crop-recognition pipeline demonstrated by the
+//! `mineru` example.
 
 mod config;
 mod model;

--- a/oar-ocr-vl/src/paddleocr_vl/mod.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/mod.rs
@@ -1,12 +1,14 @@
 //! PaddleOCR-VL (Vision-Language) model.
 //!
-//! A ~2B parameter VLM for document understanding tasks including:
+//! Native Rust inference for the 0.9B PaddleOCR-VL, PaddleOCR-VL-1.5, and
+//! PaddleOCR-VL-1.6 checkpoints. All three use [`PaddleOcrVl::from_dir`].
+//! Supported tasks include:
 //! - OCR (text recognition)
 //! - Table recognition (outputs HTML)
 //! - Formula recognition (outputs LaTeX)
 //! - Chart recognition
-//! - Text spotting
-//! - Seal recognition
+//! - Text spotting (1.5 and 1.6)
+//! - Seal recognition (1.5 and 1.6)
 
 mod config;
 mod ernie;

--- a/src/oarocr/ocr.rs
+++ b/src/oarocr/ocr.rs
@@ -139,7 +139,7 @@ impl OAROCRBuilder {
 
     /// Sets the text detection model configuration.
     ///
-    /// The configuration should be a JSON value containing model-specific settings.
+    /// Controls text detection preprocessing and postprocessing.
     pub fn text_detection_config(mut self, config: TextDetectionConfig) -> Self {
         self.text_detection_config = Some(config);
         self
@@ -147,7 +147,7 @@ impl OAROCRBuilder {
 
     /// Sets the text recognition model configuration.
     ///
-    /// The configuration should be a JSON value containing model-specific settings.
+    /// Controls text recognition preprocessing and postprocessing.
     pub fn text_recognition_config(mut self, config: TextRecognitionConfig) -> Self {
         self.text_recognition_config = Some(config);
         self


### PR DESCRIPTION
## Summary

- polish the root README with concise setup, current model coverage, and focused examples
- add a complete Cargo feature guide and align model documentation with the auto-download registry
- document the current `oar-ocr-vl` model lineup, native inference paths, environment variables, and runnable examples
- correct stale API names, predictor descriptions, PP-OCRv6 defaults, tokenizer mappings, dictionary compatibility, and model sizes
- make standalone VL commands include the ONNX Runtime setup required by the crate

## Why

The documentation had drifted from the current APIs and model registry. In particular, several VL commands omitted `download-binaries`, external snippets relied on undeclared transitive dependencies, PP-OCRv3 and PP-OCRv6 asset mappings were incomplete, and a few predictor and formula-model descriptions overstated the implemented behavior.

## Impact

Users now get setup commands that work on a clean machine, accurate model and dictionary selections, complete feature guidance, and examples that match the current classic and VLM APIs. Existing acknowledgment descriptions are preserved.

## Validation

- `cargo test --workspace --doc`
- `cargo check --workspace --examples`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `cargo check -p oar-ocr-vl --examples --no-default-features --features download-binaries`
- `cargo check -p oar-ocr-vl --examples --no-default-features --features cuda,download-binaries`
- `cargo test -p oar-ocr-core --features auto-download registry_`
- verified all tracked Markdown links, anchors, and code fences
- verified every registered model asset is documented and displayed sizes match registry bytes
- `cargo fmt --all --check`
- `git diff --check HEAD`