### PR TITLE
feat(vl): add OvisOCR2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,13 @@ The [`oar-ocr-vl`](oar-ocr-vl/README.md) crate provides native [Candle](https://
 | [PaddleOCR-VL-1.5](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5) | 0.9B | PaddleOCR-VL tasks plus text spotting and seal recognition |
 | [PaddleOCR-VL-1.6](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6) | 0.9B | Region-aware page parsing and task-specific recognition |
 | [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) | 0.9B | Page parsing, text, table, and formula recognition |
+| [OvisOCR2](https://huggingface.co/ATH-MaaS/OvisOCR2) | 0.8B | Model-native full-page document-to-Markdown parsing |
 | [HunyuanOCR 1.5 / 1.0](https://huggingface.co/tencent/HunyuanOCR) | 1B | Prompt-driven full-page parsing, text spotting, table, formula, and chart recognition, with optional DFlash decoding for 1.5 |
 | [MinerU2.5-2509](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) | 1.2B | Model-native two-step layout detection and content extraction |
 | [MinerU2.5-Pro-2605](https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B) | 1.2B | Newer MinerU2.5 checkpoint using the same two-step pipeline |
 | [MinerU-Diffusion-V1-0320](https://huggingface.co/opendatalab/MinerU-Diffusion-V1-0320-2.5B) | 2.5B | Block-diffusion OCR with structured two-step extraction or single-pass text recognition |
 
-PaddleOCR-VL variants and GLM-OCR integrate with the external-layout [`DocParser`](oar-ocr-vl/README.md#document-parsing-pipeline). HunyuanOCR and the MinerU models use their model-native parsing pipelines.
+PaddleOCR-VL variants and GLM-OCR integrate with the external-layout [`DocParser`](oar-ocr-vl/README.md#document-parsing-pipeline). OvisOCR2 is instead a model-native full-page parser: its dedicated example applies the official fixed prompt, pixel preprocessing, and output cleanup and does not use DocParser. HunyuanOCR and the MinerU models also use their model-native parsing pipelines.
 
 See the [`oar-ocr-vl` guide](oar-ocr-vl/README.md) for setup and [`oar-ocr-vl/examples`](oar-ocr-vl/examples) for runnable examples.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -36,7 +36,7 @@ OAR_HOME=/data/oar-models cargo run --release --example ocr -- doc.jpg
 
 ## `OAR_VL_DTYPE`
 
-Overrides the automatic weight/compute dtype selection for Vision-Language models (PaddleOCR-VL, GLM-OCR, HunyuanOCR, MinerU2.5/Pro, and MinerU-Diffusion).
+Overrides the automatic weight/compute dtype selection for Vision-Language models (PaddleOCR-VL, GLM-OCR, OvisOCR2, HunyuanOCR, MinerU2.5/Pro, and MinerU-Diffusion).
 
 Accepted values (case-insensitive):
 
@@ -81,9 +81,11 @@ The following presence-based switches select portable fallbacks or disable optio
 
 These switches are primarily useful for compatibility checks, debugging, and numerical comparisons. The accelerated paths remain enabled by default when the active device and dtype support them.
 
+OvisOCR2 uses the shared dtype, FlashAttention, and grouped-query-attention controls. It has no model-specific runtime environment override.
+
 ## CUDA Build Overrides
 
-With the `cuda` feature enabled, `oar-ocr-vl` compiles its custom kernels to PTX. `CUDA_COMPUTE_CAP` overrides automatic GPU detection and accepts values such as `89`, `8.9`, `sm_89`, or `compute_89`. Compute capability 8.0 or newer is required. `NVCC` overrides the CUDA compiler executable.
+With the `cuda` feature enabled, `oar-ocr-vl` compiles its custom kernels, including OvisOCR2 Gated DeltaNet, to PTX. `CUDA_COMPUTE_CAP` overrides automatic GPU detection and accepts values such as `89`, `8.9`, `sm_89`, or `compute_89`. Compute capability 8.0 or newer is required. `NVCC` overrides the CUDA compiler executable.
 
 ```bash
 CUDA_COMPUTE_CAP=89 NVCC=/usr/local/cuda/bin/nvcc \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -380,6 +380,67 @@ cargo run -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl
 | `PaddleOcrVlTask::Spotting` | Text spotting (localization + recognition) | Structured text |
 | `PaddleOcrVlTask::Seal` | Seal recognition | Plain text |
 
+## OvisOCR2
+
+[OvisOCR2](https://huggingface.co/ATH-MaaS/OvisOCR2) is a 0.8B end-to-end page parser in the `oar-ocr-vl` crate. It turns each complete page into one Markdown document using its model-native path. It does not use an external layout detector and is not a `DocParser` backend.
+
+### Downloading the Model
+
+```bash
+git lfs install
+git clone https://huggingface.co/ATH-MaaS/OvisOCR2
+
+# Or using hf
+hf download ATH-MaaS/OvisOCR2 --local-dir OvisOCR2
+```
+
+### Official Input and Output Contract
+
+The library uses the official prompt internally; callers do not need to provide it. The leading newline below is part of the prompt:
+
+```text
+
+Extract all readable content from the image in natural human reading order and output the result as a single Markdown document. For charts or images, represent them using an HTML image tag: <img src="images/bbox_{left}_{top}_{right}_{bottom}.jpg" />, where left, top, right, bottom are bounding box coordinates scaled to [0, 1000). Format formulas as LaTeX. Format tables as HTML: <table>...</table>. Transcribe all other text as standard Markdown. Preserve the original text without translation or paraphrasing.
+```
+
+Input pages are converted to RGB, resized with bicubic antialiasing, and aligned to the model's 32-pixel factor. The official runtime constrains image area to `448²` through `2880²` pixels. Output is reading-order Markdown with LaTeX formulas and HTML tables. Visual regions may be emitted as `<img src="images/bbox_left_top_right_bottom.jpg" />`, with coordinates scaled to `[0, 1000)`.
+
+`OvisOcr2::parse` applies truncated-repeat cleanup and removes standalone visual-region image-tag blocks, matching the default official post-processing. Use `parse_with_image_tags(..., true)` or `generate` when those tags must be retained.
+
+### Basic Usage
+
+```rust,no_run
+use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::ovisocr2::DEFAULT_MAX_NEW_TOKENS;
+use oar_ocr_vl::utils::parse_device;
+use oar_ocr_vl::OvisOcr2;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let image = load_image("document.jpg")?;
+    let model = OvisOcr2::from_dir("OvisOCR2", parse_device("cpu")?)?;
+    let markdown = model
+        .parse(&[image], DEFAULT_MAX_NEW_TOKENS)
+        .into_iter()
+        .next()
+        .expect("one result")?;
+    println!("{markdown}");
+    Ok(())
+}
+```
+
+The API is batch-oriented: pass multiple page images to `parse` and receive one result per page in the same order. The upstream generation limit, exported as `DEFAULT_MAX_NEW_TOKENS`, is 16,384.
+
+### Running the Example
+
+```bash
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example ovisocr2 -- \
+    --model-dir OvisOCR2 \
+    --device cuda:0 \
+    document-1.jpg document-2.jpg
+```
+
+Add `--keep-image-tags` to retain visual-region image-tag references, or use `--max-tokens` to override the 16,384-token default. The example does not create the referenced bounding-box crop files.
+
 ## HunyuanOCR 1.5
 
 [HunyuanOCR 1.5](https://huggingface.co/tencent/HunyuanOCR) is a lightweight OCR expert VLM. It is available in the `oar-ocr-vl` crate and supports prompt-driven image-to-text OCR. `HunyuanOcr::from_dir` automatically detects 1.5 at the model repository root and remains compatible with archived 1.0 weights under `v1.0/`.
@@ -618,7 +679,7 @@ cargo run -p oar-ocr-vl --features cuda,download-binaries \
 
 DocParser provides a unified API for external layout-first document parsing with VL-based recognition. The `doc_parser` example supports PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR.
 
-Use `parse(&layout, image)` with an ONNX layout detector. The library also implements `RecognitionBackend` for HunyuanOCR and MinerU2.5/Pro, but they are intentionally not exposed by the CLI example because their reference-quality paths are prompt-driven full-page parsing and model-native two-step extraction, respectively. MinerU-Diffusion uses its dedicated example.
+Use `parse(&layout, image)` with an ONNX layout detector. OvisOCR2 deliberately does not implement `RecognitionBackend`; use its full-page `OvisOcr2::parse` API instead. The library also implements `RecognitionBackend` for HunyuanOCR and MinerU2.5/Pro, but they are intentionally not exposed by the CLI example because their reference-quality paths are prompt-driven full-page parsing and model-native two-step extraction, respectively. MinerU-Diffusion uses its dedicated example.
 
 ### Basic Usage
 

--- a/oar-ocr-vl/README.md
+++ b/oar-ocr-vl/README.md
@@ -12,6 +12,7 @@ This crate provides native Rust inference for document VLMs using [Candle](https
 | [PaddleOCR-VL-1.5](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5) | 0.9B | PaddleOCR-VL tasks plus text spotting and seal recognition |
 | [PaddleOCR-VL-1.6](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6) | 0.9B | Region-aware refinement, drop-in compatible with the 1.5 loader |
 | [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) | 0.9B | External-layout page parsing, text, table, and formula recognition |
+| [OvisOCR2](https://huggingface.co/ATH-MaaS/OvisOCR2) | 0.8B | Model-native full-page document-to-Markdown parsing |
 | [HunyuanOCR 1.5 / 1.0](https://huggingface.co/tencent/HunyuanOCR) | 1B | Model-native prompt-driven parsing with optional DFlash decoding for 1.5 |
 | [MinerU2.5-2509](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) | 1.2B | Model-native two-step layout detection and content extraction |
 | [MinerU2.5-Pro-2605](https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B) | 1.2B | Newer compatible checkpoint using the MinerU2.5 two-step pipeline |
@@ -26,7 +27,7 @@ See [`examples`](examples) for runnable examples.
 1. **Layout detection** (ONNX models like PP-DocLayoutV3) to identify document regions
 2. **VL-based recognition** to extract content from each region
 
-Use DocParser with PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR. HunyuanOCR should be used with its model-native full-page prompts. MinerU2.5, MinerU2.5-Pro, and MinerU-Diffusion should use their model-native two-step extraction examples.
+Use DocParser with PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR. OvisOCR2 is an end-to-end full-page parser and deliberately does not use DocParser. HunyuanOCR should be used with its model-native full-page prompts. MinerU2.5, MinerU2.5-Pro, and MinerU-Diffusion should use their model-native two-step extraction examples.
 
 ## Installation
 
@@ -102,6 +103,28 @@ let result = model
 println!("Result: {}", result);
 ```
 
+### OvisOCR2
+
+OvisOCR2 performs model-native full-page parsing without an external layout detector. `parse` applies the official prompt, image resizing, and post-processing and returns one Markdown document per page.
+
+```rust
+use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::ovisocr2::DEFAULT_MAX_NEW_TOKENS;
+use oar_ocr_vl::utils::parse_device;
+use oar_ocr_vl::OvisOcr2;
+
+let image = load_image("document.png")?;
+let model = OvisOcr2::from_dir("models/OvisOCR2", parse_device("cpu")?)?;
+let markdown = model
+    .parse(&[image], DEFAULT_MAX_NEW_TOKENS)
+    .into_iter()
+    .next()
+    .expect("one result")?;
+println!("{markdown}");
+```
+
+The official runtime resizes RGB input with bicubic antialiasing to a 32-pixel-aligned area between `448²` and `2880²` pixels. Its fixed prompt requests reading-order Markdown, LaTeX formulas, HTML tables, and bounding-box `<img>` tags for visual regions. `parse` removes those visual-region blocks by default before applying truncated-repeat cleanup; call `parse_with_image_tags(..., true)` or `generate` to retain the references. The library does not create the referenced bounding-box crop files.
+
 ### DocParser
 
 Parse an entire page into Markdown with a layout predictor. This path is intended for external layout-first backends such as PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR.
@@ -168,7 +191,7 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example do
     document.jpg
 ```
 
-HunyuanOCR and the MinerU models are intentionally not exposed by this example because their reference-quality paths are prompt-driven full-page parsing and model-native two-step extraction, respectively.
+OvisOCR2, HunyuanOCR, and the MinerU models are intentionally not exposed by this example because their reference-quality paths are model-native full-page parsing, prompt-driven full-page parsing, and model-native two-step extraction, respectively.
 
 ### PaddleOCR-VL Direct Inference
 
@@ -225,6 +248,17 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example gl
     --device cuda \
     --prompt "Text Recognition:" \
     document.jpg
+```
+
+### OvisOCR2 Full-Page Parsing
+
+The example accepts multiple page images. It uses the official prompt and defaults to 16,384 generated tokens per page. Add `--keep-image-tags` to retain the model's visual-region `<img>` blocks.
+
+```bash
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example ovisocr2 -- \
+    --model-dir models/OvisOCR2 \
+    --device cuda:0 \
+    document-1.jpg document-2.jpg
 ```
 
 ### MinerU2.5 and MinerU2.5-Pro Direct Inference

--- a/oar-ocr-vl/build.rs
+++ b/oar-ocr-vl/build.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::{fs, path::Path, process::Command};
 
 const MIN_CUDA_COMPUTE_CAP: u32 = 80;
 
@@ -71,8 +71,48 @@ fn cuda_compute_arch() -> String {
     }
 }
 
+fn collect_cuda_sources(dir: &Path, sources: &mut Vec<std::path::PathBuf>) {
+    for entry in fs::read_dir(dir)
+        .unwrap_or_else(|error| panic!("failed to scan CUDA source directory {dir:?}: {error}"))
+    {
+        let path = entry.expect("failed to read CUDA source entry").path();
+        if path.is_dir() {
+            collect_cuda_sources(&path, sources);
+        } else if path.extension().and_then(|extension| extension.to_str()) == Some("cu") {
+            sources.push(path);
+        }
+    }
+}
+
+fn validate_cuda_aggregator(sources: &[std::path::PathBuf]) {
+    let aggregator_path = Path::new("src/cuda_kernels.cu");
+    let aggregator = fs::read_to_string(aggregator_path)
+        .unwrap_or_else(|error| panic!("failed to read {aggregator_path:?}: {error}"));
+    for source in sources {
+        if source == aggregator_path {
+            continue;
+        }
+        let relative = source
+            .strip_prefix("src")
+            .expect("CUDA sources are collected under src")
+            .to_string_lossy()
+            .replace('\\', "/");
+        let include = format!("#include \"{relative}\"");
+        assert!(
+            aggregator.lines().any(|line| line.trim() == include),
+            "{aggregator_path:?} must include CUDA source {source:?} as {include:?}"
+        );
+    }
+}
+
 fn main() {
-    println!("cargo:rerun-if-changed=src/hunyuanocr/dynamic_kv.cu");
+    let mut cuda_sources = Vec::new();
+    collect_cuda_sources(Path::new("src"), &mut cuda_sources);
+    cuda_sources.sort();
+    for source in &cuda_sources {
+        println!("cargo:rerun-if-changed={}", source.display());
+    }
+    validate_cuda_aggregator(&cuda_sources);
     println!("cargo:rerun-if-env-changed=CUDA_COMPUTE_CAP");
     println!("cargo:rerun-if-env-changed=NVCC");
     let metal_enabled = std::env::var_os("CARGO_FEATURE_METAL").is_some();
@@ -94,7 +134,7 @@ fn main() {
             .arg(format!("--gpu-architecture={cuda_arch}"))
             .arg("-o")
             .arg(out_dir.join("oar_vl_kernels.ptx"))
-            .arg("src/hunyuanocr/dynamic_kv.cu")
+            .arg("src/cuda_kernels.cu")
             .output()
             .unwrap_or_else(|error| {
                 panic!(

--- a/oar-ocr-vl/examples/ovisocr2.rs
+++ b/oar-ocr-vl/examples/ovisocr2.rs
@@ -1,0 +1,127 @@
+//! OvisOCR2 full-page document parsing example (Candle-based).
+//!
+//! OvisOCR2 uses its official prompt and image preprocessing internally and
+//! returns one Markdown document per input page.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run -p oar-ocr-vl --features download-binaries --example ovisocr2 -- \
+//!     --model-dir models/OvisOCR2 \
+//!     --device cpu \
+//!     document-1.jpg document-2.png
+//! ```
+
+mod utils;
+
+use clap::Parser;
+use std::path::PathBuf;
+use std::time::Instant;
+use tracing::{error, info};
+
+use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::OvisOcr2;
+use oar_ocr_vl::ovisocr2::DEFAULT_MAX_NEW_TOKENS;
+use oar_ocr_vl::utils::parse_device;
+
+#[derive(Parser)]
+#[command(name = "ovisocr2")]
+#[command(about = "OvisOCR2 model-native full-page document-to-Markdown parsing")]
+struct Args {
+    /// Path to the OvisOCR2 model directory
+    #[arg(short, long)]
+    model_dir: PathBuf,
+
+    /// Paths to one or more page images
+    #[arg(required = true)]
+    images: Vec<PathBuf>,
+
+    /// Device to run on: cpu, cuda, cuda:N, or metal
+    #[arg(short, long, default_value = "cpu")]
+    device: String,
+
+    /// Maximum number of new tokens to generate per page
+    #[arg(long, default_value_t = DEFAULT_MAX_NEW_TOKENS)]
+    max_tokens: usize,
+
+    /// Retain visual-region <img> tags in the generated Markdown
+    #[arg(long)]
+    keep_image_tags: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    utils::init_tracing();
+    let args = Args::parse();
+    let mut had_errors = false;
+
+    if !args.model_dir.exists() {
+        error!("Model directory not found: {}", args.model_dir.display());
+        return Err("Model directory not found".into());
+    }
+
+    let mut image_paths = Vec::new();
+    let mut images = Vec::new();
+    for image_path in args.images {
+        if !image_path.exists() {
+            error!("Image file not found: {}", image_path.display());
+            had_errors = true;
+            continue;
+        }
+        match load_image(&image_path) {
+            Ok(image) => {
+                image_paths.push(image_path);
+                images.push(image);
+            }
+            Err(err) => {
+                error!("Failed to load {}: {err}", image_path.display());
+                had_errors = true;
+            }
+        }
+    }
+    if images.is_empty() {
+        return Err("No valid image files found".into());
+    }
+
+    let device = parse_device(&args.device)?;
+    info!("Using device: {:?}", device);
+
+    info!("Loading OvisOCR2 model from: {}", args.model_dir.display());
+    let load_start = Instant::now();
+    let model = OvisOcr2::from_dir(&args.model_dir, device)?;
+    info!(
+        "Model loaded in {:.2}ms",
+        load_start.elapsed().as_secs_f64() * 1000.0
+    );
+
+    let page_count = images.len();
+    info!("Processing {page_count} page(s)");
+    let infer_start = Instant::now();
+    let results = model.parse_with_image_tags(&images, args.max_tokens, args.keep_image_tags);
+    let infer_ms = infer_start.elapsed().as_secs_f64() * 1000.0;
+    info!(
+        "Inference completed for {page_count} page(s) in {infer_ms:.2}ms ({:.2}ms/page)",
+        infer_ms / page_count as f64
+    );
+
+    for (index, (image_path, result)) in image_paths.iter().zip(results).enumerate() {
+        match result {
+            Ok(markdown) => {
+                if index > 0 {
+                    println!();
+                }
+                println!("<!-- OvisOCR2 source: {} -->", image_path.display());
+                println!("{markdown}");
+            }
+            Err(err) => {
+                error!("Inference failed for {}: {err}", image_path.display());
+                had_errors = true;
+            }
+        }
+    }
+
+    if had_errors {
+        Err("One or more OvisOCR2 pages failed".into())
+    } else {
+        Ok(())
+    }
+}

--- a/oar-ocr-vl/src/attention.rs
+++ b/oar-ocr-vl/src/attention.rs
@@ -114,6 +114,42 @@ pub fn scaled_dot_product_attention(
     attn_weights.matmul(v)
 }
 
+/// Sequence length above which vision backends use query-chunked attention to
+/// cap the size of the temporary attention-score matrix.
+pub(crate) const VISION_CHUNKED_ATTN_SEQ_THRESHOLD: usize = 1024;
+/// Query chunk size used by the shared eager vision-attention fallback.
+pub(crate) const VISION_CHUNKED_ATTN_CHUNK_SIZE: usize = 256;
+
+/// Non-causal scaled dot-product attention computed in query chunks. This has
+/// the same result as one eager attention call while reducing peak memory.
+pub(crate) fn chunked_vision_attention(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    scale: f64,
+    chunk_size: usize,
+) -> Result<Tensor> {
+    if chunk_size == 0 {
+        candle_core::bail!("vision attention chunk size must be non-zero")
+    }
+    let seq_len = q.dim(2)?;
+    if seq_len == 0 {
+        return scaled_dot_product_attention(q, k, v, None, scale, false);
+    }
+    let mut chunks = Vec::with_capacity(seq_len.div_ceil(chunk_size));
+    let mut start = 0usize;
+    while start < seq_len {
+        let len = (seq_len - start).min(chunk_size);
+        let q_chunk = q.narrow(2, start, len)?;
+        chunks.push(scaled_dot_product_attention(
+            &q_chunk, k, v, None, scale, false,
+        )?);
+        start += len;
+    }
+    let chunks = chunks.iter().collect::<Vec<_>>();
+    Tensor::cat(&chunks, 2)
+}
+
 /// Scaled dot-product attention for grouped-query attention without expanding
 /// K/V heads. Query heads that share one KV head are folded into the matrix row
 /// dimension, preserving the usual head order in the returned tensor.
@@ -734,6 +770,26 @@ mod tests {
         let out = scaled_dot_product_attention(&q, &k, &v, None, scale, true)?;
         assert_eq!(out.dims(), &[1, 4, 8, 64]);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_chunked_vision_attention_matches_eager() -> Result<()> {
+        let device = Device::Cpu;
+        let q = Tensor::randn(0f32, 1., (1, 2, 7, 8), &device)?;
+        let k = Tensor::randn(0f32, 1., (1, 2, 5, 8), &device)?;
+        let v = Tensor::randn(0f32, 1., (1, 2, 5, 8), &device)?;
+        let scale = 1.0 / 8f64.sqrt();
+        let eager = scaled_dot_product_attention(&q, &k, &v, None, scale, false)?;
+        let chunked = chunked_vision_attention(&q, &k, &v, scale, 3)?;
+        let eager = eager.flatten_all()?.to_vec1::<f32>()?;
+        let chunked = chunked.flatten_all()?.to_vec1::<f32>()?;
+        assert!(
+            eager
+                .iter()
+                .zip(chunked)
+                .all(|(left, right)| (left - right).abs() < 1e-6)
+        );
         Ok(())
     }
 

--- a/oar-ocr-vl/src/cuda_kernels.cu
+++ b/oar-ocr-vl/src/cuda_kernels.cu
@@ -1,0 +1,6 @@
+// Single translation unit for the crate's custom CUDA kernels. Keeping all
+// kernels in one PTX module lets existing callers continue loading
+// `oar_vl_kernels.ptx` while model-specific implementations remain colocated
+// with their Rust modules.
+#include "hunyuanocr/dynamic_kv.cu"
+#include "ovisocr2/gated_delta.cu"

--- a/oar-ocr-vl/src/lib.rs
+++ b/oar-ocr-vl/src/lib.rs
@@ -12,6 +12,7 @@
 //!   backbone)
 //! - `mineru_diffusion` - MinerU-Diffusion-V1 block-diffusion document OCR
 //!   (Qwen2-VL vision + SDAR decoder)
+//! - `ovisocr2` - OvisOCR2 end-to-end page-to-Markdown parser (Qwen3.5)
 //! - `doc_parser` - Unified document parsing with pluggable recognition backends
 //! - `utils` - Device parsing, candle helpers, markdown, OTSL conversion
 //! - `attention` - Unified attention shared by all models
@@ -35,6 +36,7 @@ pub mod glmocr;
 pub mod hunyuanocr;
 pub mod mineru;
 pub mod mineru_diffusion;
+pub mod ovisocr2;
 pub mod paddleocr_vl;
 pub mod utils;
 
@@ -63,5 +65,6 @@ pub use glmocr::GlmOcr;
 pub use hunyuanocr::{DFlashConfig, DFlashTargetConfig, HunyuanOcr, HunyuanOcrVersion};
 pub use mineru::MinerU;
 pub use mineru_diffusion::{DiffusionGenerationConfig, MinerUDiffusion};
+pub use ovisocr2::OvisOcr2;
 
 pub use doc_parser::{DocParser, DocParserConfig, RecognitionBackend, RecognitionTask};

--- a/oar-ocr-vl/src/mineru/vision.rs
+++ b/oar-ocr-vl/src/mineru/vision.rs
@@ -1,14 +1,12 @@
 use super::config::MinerUVisionConfig;
-use crate::attention::{on_compute_device, scaled_dot_product_attention};
+use crate::attention::{
+    VISION_CHUNKED_ATTN_CHUNK_SIZE, VISION_CHUNKED_ATTN_SEQ_THRESHOLD, chunked_vision_attention,
+    on_compute_device, scaled_dot_product_attention,
+};
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::{LayerNorm, LayerNormConfig, Linear, Module, VarBuilder, layer_norm, linear};
 use oar_ocr_core::core::OCRError;
-
-/// Sequence length threshold above which chunked attention is used to reduce peak memory.
-const CHUNKED_ATTN_SEQ_THRESHOLD: usize = 1024;
-/// Chunk size for chunked attention when processing large images.
-const CHUNKED_ATTN_CHUNK_SIZE: usize = 256;
 
 fn quick_gelu(xs: &Tensor) -> Result<Tensor, OCRError> {
     let scaled = (xs * 1.702).map_err(|e| {
@@ -377,25 +375,9 @@ impl VisionAttention {
         let seq_len = q
             .dim(2)
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "vision q dim", e))?;
-        let attn = if seq_len > CHUNKED_ATTN_SEQ_THRESHOLD {
-            // Chunked attention to reduce peak memory for large images.
-            let chunk_size = CHUNKED_ATTN_CHUNK_SIZE;
-            let mut chunks: Vec<Tensor> = Vec::new();
-            let mut start = 0usize;
-            while start < seq_len {
-                let len = (seq_len - start).min(chunk_size);
-                let q_chunk = q
-                    .narrow(2, start, len)
-                    .map_err(|e| candle_to_ocr_inference("MinerU2.5", "vision q narrow", e))?;
-                let out =
-                    scaled_dot_product_attention(&q_chunk, &k, &v, None, self.scale, false)
-                        .map_err(|e| candle_to_ocr_inference("MinerU2.5", "vision attention", e))?;
-                chunks.push(out);
-                start += len;
-            }
-            let refs: Vec<&Tensor> = chunks.iter().collect();
-            Tensor::cat(&refs, 2)
-                .map_err(|e| candle_to_ocr_inference("MinerU2.5", "vision attn cat", e))?
+        let attn = if seq_len > VISION_CHUNKED_ATTN_SEQ_THRESHOLD {
+            chunked_vision_attention(&q, &k, &v, self.scale, VISION_CHUNKED_ATTN_CHUNK_SIZE)
+                .map_err(|e| candle_to_ocr_inference("MinerU2.5", "vision attention", e))?
         } else {
             scaled_dot_product_attention(&q, &k, &v, None, self.scale, false)
                 .map_err(|e| candle_to_ocr_inference("MinerU2.5", "vision attention", e))?

--- a/oar-ocr-vl/src/ovisocr2/config.rs
+++ b/oar-ocr-vl/src/ovisocr2/config.rs
@@ -1,0 +1,624 @@
+use candle_nn::Activation;
+use oar_ocr_core::core::OCRError;
+use serde::Deserialize;
+use std::path::Path;
+
+/// Minimum image area used by the official OvisOCR2 runtime.
+pub const OVIS_OCR2_MIN_PIXELS: u32 = 448 * 448;
+/// Maximum image area used by the official OvisOCR2 runtime.
+pub const OVIS_OCR2_MAX_PIXELS: u32 = 2880 * 2880;
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_rescale_factor() -> f32 {
+    1.0 / 255.0
+}
+
+fn default_partial_rotary_factor() -> f64 {
+    0.25
+}
+
+fn default_rope_theta() -> f64 {
+    10_000_000.0
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OvisOcr2RopeParameters {
+    pub rope_type: String,
+    pub mrope_section: Vec<usize>,
+    #[serde(default)]
+    pub mrope_interleaved: bool,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f64,
+    #[serde(default = "default_partial_rotary_factor")]
+    pub partial_rotary_factor: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OvisOcr2TextConfig {
+    pub model_type: String,
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    pub hidden_act: Activation,
+    pub max_position_embeddings: usize,
+    pub rms_norm_eps: f64,
+    pub rope_parameters: OvisOcr2RopeParameters,
+    pub layer_types: Vec<String>,
+    pub linear_conv_kernel_dim: usize,
+    pub linear_key_head_dim: usize,
+    pub linear_value_head_dim: usize,
+    pub linear_num_key_heads: usize,
+    pub linear_num_value_heads: usize,
+    pub eos_token_id: u32,
+    #[serde(default)]
+    pub attention_bias: bool,
+    #[serde(default)]
+    pub attention_dropout: f32,
+    #[serde(default)]
+    pub attn_output_gate: bool,
+    #[serde(default)]
+    pub initializer_range: f64,
+    #[serde(default)]
+    pub full_attention_interval: usize,
+    #[serde(default)]
+    pub mlp_only_layers: Vec<usize>,
+    #[serde(default)]
+    pub mtp_num_hidden_layers: usize,
+    #[serde(default)]
+    pub mtp_use_dedicated_embeddings: bool,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+    #[serde(default)]
+    pub use_cache: bool,
+    #[serde(default)]
+    pub dtype: Option<String>,
+    #[serde(default)]
+    pub mamba_ssm_dtype: Option<String>,
+}
+
+impl OvisOcr2TextConfig {
+    pub fn validate(&self) -> Result<(), OCRError> {
+        if self.hidden_size == 0
+            || self.intermediate_size == 0
+            || self.vocab_size == 0
+            || self.num_hidden_layers == 0
+            || self.num_attention_heads == 0
+            || self.num_key_value_heads == 0
+            || self.head_dim == 0
+            || self.max_position_embeddings == 0
+        {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 text dimensions must be non-zero".to_string(),
+            });
+        }
+        if self.model_type != "qwen3_5_text" {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 expected text model_type 'qwen3_5_text', got '{}'",
+                    self.model_type
+                ),
+            });
+        }
+        if self.hidden_act != Activation::Silu {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 text decoder supports hidden_act 'silu', got {:?}",
+                    self.hidden_act
+                ),
+            });
+        }
+        if self.attention_bias {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 attention_bias=true is not supported".to_string(),
+            });
+        }
+        if !self.attn_output_gate {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 requires attn_output_gate=true".to_string(),
+            });
+        }
+        if !self.rms_norm_eps.is_finite() || self.rms_norm_eps <= 0.0 {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 rms_norm_eps must be finite and positive, got {}",
+                    self.rms_norm_eps
+                ),
+            });
+        }
+        if self.eos_token_id as usize >= self.vocab_size {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 eos_token_id {} is outside vocab_size {}",
+                    self.eos_token_id, self.vocab_size
+                ),
+            });
+        }
+        if !self
+            .num_attention_heads
+            .is_multiple_of(self.num_key_value_heads)
+        {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 num_attention_heads ({}) must be divisible by num_key_value_heads ({})",
+                    self.num_attention_heads, self.num_key_value_heads
+                ),
+            });
+        }
+        if self.layer_types.len() != self.num_hidden_layers {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 layer_types length ({}) must equal num_hidden_layers ({})",
+                    self.layer_types.len(),
+                    self.num_hidden_layers
+                ),
+            });
+        }
+        if self
+            .layer_types
+            .iter()
+            .any(|kind| kind != "linear_attention" && kind != "full_attention")
+        {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 layer_types contains an unsupported layer type".to_string(),
+            });
+        }
+        if self.linear_conv_kernel_dim == 0
+            || self.linear_key_head_dim == 0
+            || self.linear_value_head_dim == 0
+            || self.linear_num_key_heads == 0
+            || self.linear_num_value_heads == 0
+        {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 linear-attention dimensions must be non-zero".to_string(),
+            });
+        }
+        if self.linear_key_head_dim != self.linear_value_head_dim {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 requires equal linear key/value head dims, got {}/{}",
+                    self.linear_key_head_dim, self.linear_value_head_dim
+                ),
+            });
+        }
+        if !self
+            .linear_num_value_heads
+            .is_multiple_of(self.linear_num_key_heads)
+        {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 linear_num_value_heads ({}) must be divisible by linear_num_key_heads ({})",
+                    self.linear_num_value_heads, self.linear_num_key_heads
+                ),
+            });
+        }
+        if self.rope_parameters.rope_type != "default" {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 unsupported rope_type '{}'",
+                    self.rope_parameters.rope_type
+                ),
+            });
+        }
+        if !self.rope_parameters.mrope_interleaved {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 requires interleaved MRoPE".to_string(),
+            });
+        }
+        if self.rope_parameters.mrope_section.len() != 3
+            || self.rope_parameters.mrope_section.contains(&0)
+        {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 mrope_section must contain three non-zero entries".to_string(),
+            });
+        }
+        if !self.rope_parameters.rope_theta.is_finite() || self.rope_parameters.rope_theta <= 0.0 {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 rope_theta must be finite and positive, got {}",
+                    self.rope_parameters.rope_theta
+                ),
+            });
+        }
+        let partial = self.rope_parameters.partial_rotary_factor;
+        if !partial.is_finite() || !(0.0..=1.0).contains(&partial) || partial == 0.0 {
+            return Err(OCRError::ConfigError {
+                message: format!("OvisOCR2 partial_rotary_factor must be in (0, 1], got {partial}"),
+            });
+        }
+        let rotary_dim = (self.head_dim as f64 * partial) as usize;
+        let section_sum = self
+            .rope_parameters
+            .mrope_section
+            .iter()
+            .try_fold(0usize, |sum, &value| sum.checked_add(value))
+            .ok_or_else(|| OCRError::ConfigError {
+                message: "OvisOCR2 mrope_section sum overflow".to_string(),
+            })?;
+        if rotary_dim == 0 || !rotary_dim.is_multiple_of(2) || section_sum != rotary_dim / 2 {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 mrope_section {:?} must sum to rotary_dim/2 ({})",
+                    self.rope_parameters.mrope_section,
+                    rotary_dim / 2
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OvisOcr2VisionConfig {
+    pub model_type: String,
+    pub depth: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_heads: usize,
+    pub in_channels: usize,
+    pub patch_size: usize,
+    pub spatial_merge_size: usize,
+    pub temporal_patch_size: usize,
+    pub out_hidden_size: usize,
+    pub num_position_embeddings: usize,
+    pub hidden_act: Activation,
+    #[serde(default)]
+    pub initializer_range: f64,
+    #[serde(default)]
+    pub deepstack_visual_indexes: Vec<usize>,
+}
+
+impl OvisOcr2VisionConfig {
+    pub fn head_dim(&self) -> Result<usize, OCRError> {
+        if self.num_heads == 0 || !self.hidden_size.is_multiple_of(self.num_heads) {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 vision hidden_size {} must be divisible by num_heads {}",
+                    self.hidden_size, self.num_heads
+                ),
+            });
+        }
+        Ok(self.hidden_size / self.num_heads)
+    }
+
+    pub fn position_grid_size(&self) -> Result<usize, OCRError> {
+        let side = (self.num_position_embeddings as f64).sqrt() as usize;
+        if side == 0 || side * side != self.num_position_embeddings {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 num_position_embeddings must be a non-zero square, got {}",
+                    self.num_position_embeddings
+                ),
+            });
+        }
+        Ok(side)
+    }
+
+    pub fn validate(&self) -> Result<(), OCRError> {
+        if self.model_type != "qwen3_5" {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 expected vision model_type 'qwen3_5', got '{}'",
+                    self.model_type
+                ),
+            });
+        }
+        if self.hidden_size == 0
+            || self.intermediate_size == 0
+            || self.in_channels == 0
+            || self.patch_size == 0
+            || self.spatial_merge_size == 0
+            || self.temporal_patch_size == 0
+            || self.out_hidden_size == 0
+        {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 vision dimensions must be non-zero".to_string(),
+            });
+        }
+        let head_dim = self.head_dim()?;
+        if !head_dim.is_multiple_of(4) {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 vision head_dim must be divisible by 4 for 2D RoPE, got {head_dim}"
+                ),
+            });
+        }
+        self.position_grid_size()?;
+        if !self.deepstack_visual_indexes.is_empty() {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 deepstack vision features are not supported".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OvisOcr2Config {
+    pub architectures: Vec<String>,
+    pub model_type: String,
+    pub text_config: OvisOcr2TextConfig,
+    pub vision_config: OvisOcr2VisionConfig,
+    pub image_token_id: u32,
+    pub video_token_id: u32,
+    pub vision_start_token_id: u32,
+    pub vision_end_token_id: u32,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+    #[serde(default)]
+    pub transformers_version: Option<String>,
+}
+
+impl OvisOcr2Config {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+        let cfg: Self = crate::utils::load_json_config(path, "OvisOCR2", "config.json")?;
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    pub fn tie_word_embeddings(&self) -> bool {
+        self.tie_word_embeddings || self.text_config.tie_word_embeddings
+    }
+
+    pub fn validate(&self) -> Result<(), OCRError> {
+        if self.model_type != "qwen3_5" {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 expected model_type 'qwen3_5', got '{}'",
+                    self.model_type
+                ),
+            });
+        }
+        self.text_config.validate()?;
+        self.vision_config.validate()?;
+        if !self.tie_word_embeddings() {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 requires tied token embeddings".to_string(),
+            });
+        }
+        for (name, token_id) in [
+            ("image_token_id", self.image_token_id),
+            ("video_token_id", self.video_token_id),
+            ("vision_start_token_id", self.vision_start_token_id),
+            ("vision_end_token_id", self.vision_end_token_id),
+        ] {
+            if token_id as usize >= self.text_config.vocab_size {
+                return Err(OCRError::ConfigError {
+                    message: format!(
+                        "OvisOCR2 {name} {token_id} is outside vocab_size {}",
+                        self.text_config.vocab_size
+                    ),
+                });
+            }
+        }
+        if self.vision_config.out_hidden_size != self.text_config.hidden_size {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 vision out_hidden_size ({}) must equal text hidden_size ({})",
+                    self.vision_config.out_hidden_size, self.text_config.hidden_size
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OvisOcr2ImageProcessorSize {
+    pub shortest_edge: u32,
+    pub longest_edge: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OvisOcr2ImageProcessorConfig {
+    pub size: OvisOcr2ImageProcessorSize,
+    pub patch_size: usize,
+    pub temporal_patch_size: usize,
+    pub merge_size: usize,
+    pub image_mean: Vec<f32>,
+    pub image_std: Vec<f32>,
+    #[serde(default = "default_true")]
+    pub do_resize: bool,
+    #[serde(default = "default_true")]
+    pub do_rescale: bool,
+    #[serde(default = "default_true")]
+    pub do_normalize: bool,
+    #[serde(default = "default_true")]
+    pub do_convert_rgb: bool,
+    #[serde(default = "default_rescale_factor")]
+    pub rescale_factor: f32,
+    #[serde(default)]
+    pub resample: Option<u32>,
+    #[serde(default)]
+    pub processor_class: Option<String>,
+    #[serde(default)]
+    pub image_processor_type: Option<String>,
+}
+
+impl OvisOcr2ImageProcessorConfig {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+        let cfg: Self =
+            crate::utils::load_json_config(path, "OvisOCR2", "preprocessor_config.json")?;
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    /// Pixel bounds used for OvisOCR2 inference.
+    ///
+    /// The checkpoint's generic Qwen processor metadata advertises a wider
+    /// `256²..4096²` range. OvisOCR2's official inference wrapper overrides it
+    /// with `448²..2880²`, which is the range used by this native backend.
+    pub const fn runtime_pixel_bounds(&self) -> (u32, u32) {
+        (OVIS_OCR2_MIN_PIXELS, OVIS_OCR2_MAX_PIXELS)
+    }
+
+    pub fn validate(&self) -> Result<(), OCRError> {
+        crate::utils::validate_image_mean_std("OvisOCR2", &self.image_mean, &self.image_std)?;
+        if self
+            .image_mean
+            .iter()
+            .chain(&self.image_std)
+            .any(|value| !value.is_finite())
+        {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 image_mean/std values must be finite".to_string(),
+            });
+        }
+        if self.do_normalize && self.image_std.iter().any(|&value| value <= 0.0) {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 image_std values must be positive".to_string(),
+            });
+        }
+        if self.do_rescale && !self.rescale_factor.is_finite() {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 rescale_factor must be finite, got {}",
+                    self.rescale_factor
+                ),
+            });
+        }
+        crate::utils::validate_patch_merge_temporal(
+            "OvisOCR2",
+            self.patch_size,
+            self.merge_size,
+            self.temporal_patch_size,
+        )?;
+        if self.size.shortest_edge == 0 || self.size.longest_edge == 0 {
+            return Err(OCRError::ConfigError {
+                message: "OvisOCR2 processor size bounds must be non-zero".to_string(),
+            });
+        }
+        if self.size.shortest_edge > self.size.longest_edge {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 shortest_edge {} exceeds longest_edge {}",
+                    self.size.shortest_edge, self.size.longest_edge
+                ),
+            });
+        }
+        if let Some(resample) = self.resample
+            && resample > 5
+        {
+            return Err(OCRError::ConfigError {
+                message: format!("OvisOCR2 unsupported PIL resample value {resample}"),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONFIG: &str = r#"
+    {
+      "architectures": ["Qwen3_5ForConditionalGeneration"],
+      "image_token_id": 248056,
+      "model_type": "qwen3_5",
+      "text_config": {
+        "attention_bias": false,
+        "attention_dropout": 0.0,
+        "attn_output_gate": true,
+        "dtype": "bfloat16",
+        "eos_token_id": 248044,
+        "full_attention_interval": 4,
+        "head_dim": 256,
+        "hidden_act": "silu",
+        "hidden_size": 1024,
+        "initializer_range": 0.02,
+        "intermediate_size": 3584,
+        "layer_types": ["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+        "linear_conv_kernel_dim": 4,
+        "linear_key_head_dim": 128,
+        "linear_num_key_heads": 16,
+        "linear_num_value_heads": 16,
+        "linear_value_head_dim": 128,
+        "max_position_embeddings": 262144,
+        "mlp_only_layers": [],
+        "model_type": "qwen3_5_text",
+        "mtp_num_hidden_layers": 1,
+        "mtp_use_dedicated_embeddings": false,
+        "num_attention_heads": 8,
+        "num_hidden_layers": 4,
+        "num_key_value_heads": 2,
+        "rms_norm_eps": 1e-6,
+        "tie_word_embeddings": true,
+        "use_cache": true,
+        "vocab_size": 248320,
+        "mamba_ssm_dtype": "float32",
+        "rope_parameters": {
+          "mrope_interleaved": true,
+          "mrope_section": [11, 11, 10],
+          "rope_type": "default",
+          "rope_theta": 10000000,
+          "partial_rotary_factor": 0.25
+        }
+      },
+      "tie_word_embeddings": true,
+      "video_token_id": 248057,
+      "vision_config": {
+        "deepstack_visual_indexes": [],
+        "depth": 12,
+        "hidden_act": "gelu_pytorch_tanh",
+        "hidden_size": 768,
+        "in_channels": 3,
+        "initializer_range": 0.02,
+        "intermediate_size": 3072,
+        "model_type": "qwen3_5",
+        "num_heads": 12,
+        "num_position_embeddings": 2304,
+        "out_hidden_size": 1024,
+        "patch_size": 16,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 2
+      },
+      "vision_end_token_id": 248054,
+      "vision_start_token_id": 248053
+    }
+    "#;
+
+    #[test]
+    fn parses_local_checkpoint_shape() {
+        let cfg: OvisOcr2Config = serde_json::from_str(CONFIG).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(cfg.text_config.layer_types.len(), 4);
+        assert_eq!(cfg.vision_config.position_grid_size().unwrap(), 48);
+        assert_eq!(cfg.vision_config.head_dim().unwrap(), 64);
+        assert!(cfg.tie_word_embeddings());
+        assert_eq!(cfg.text_config.hidden_act, Activation::Silu);
+        assert_eq!(cfg.vision_config.hidden_act, Activation::GeluPytorchTanh);
+    }
+
+    #[test]
+    fn processor_uses_official_runtime_bounds() {
+        let cfg: OvisOcr2ImageProcessorConfig = serde_json::from_str(
+            r#"{
+              "size": {"shortest_edge": 65536, "longest_edge": 16777216},
+              "patch_size": 16,
+              "temporal_patch_size": 2,
+              "merge_size": 2,
+              "image_mean": [0.5, 0.5, 0.5],
+              "image_std": [0.5, 0.5, 0.5]
+            }"#,
+        )
+        .unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(cfg.runtime_pixel_bounds(), (448 * 448, 2880 * 2880));
+        assert_eq!(cfg.rescale_factor, 1.0 / 255.0);
+    }
+
+    #[test]
+    fn rejects_untied_checkpoint() {
+        let mut cfg: OvisOcr2Config = serde_json::from_str(CONFIG).unwrap();
+        cfg.tie_word_embeddings = false;
+        cfg.text_config.tie_word_embeddings = false;
+        assert!(cfg.validate().unwrap_err().to_string().contains("tied"));
+    }
+}

--- a/oar-ocr-vl/src/ovisocr2/gated_delta.cu
+++ b/oar-ocr-vl/src/ovisocr2/gated_delta.cu
@@ -98,13 +98,16 @@ __device__ __forceinline__ void ovis_gated_delta_rule_body(
     }
     __syncthreads();
 
-    for (uint64_t index = lane; index < state_size; index += blockDim.x) {
-      const uint32_t key_dim = static_cast<uint32_t>(index / head_dim);
-      const uint32_t value_dim = static_cast<uint32_t>(index -
-                                                        static_cast<uint64_t>(key_dim) * head_dim);
+    // Traverse the state matrix directly instead of recovering its row and
+    // column with integer division for every element.
+    for (uint32_t key_dim = 0; key_dim < head_dim; ++key_dim) {
       const float key =
           ovis_gd_to_float(qkv[qkv_offset + head_dim + key_dim]) * k_inv_norm;
-      state[index] += key * delta[value_dim];
+      for (uint32_t value_dim = lane; value_dim < head_dim;
+           value_dim += blockDim.x) {
+        const uint64_t index = static_cast<uint64_t>(key_dim) * head_dim + value_dim;
+        state[index] += key * delta[value_dim];
+      }
     }
     __syncthreads();
 

--- a/oar-ocr-vl/src/ovisocr2/gated_delta.cu
+++ b/oar-ocr-vl/src/ovisocr2/gated_delta.cu
@@ -1,0 +1,144 @@
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <math.h>
+#include <stdint.h>
+
+namespace {
+
+__device__ __forceinline__ float ovis_gd_to_float(float value) { return value; }
+
+__device__ __forceinline__ float ovis_gd_to_float(half value) {
+  return __half2float(value);
+}
+
+__device__ __forceinline__ float ovis_gd_to_float(__nv_bfloat16 value) {
+  return __bfloat162float(value);
+}
+
+// One block owns one (batch, head) recurrent state. The state is kept in the
+// F32 tail of the packed output buffer so it is both the working buffer and the
+// returned final state. Q/K/V may be BF16, F16, or F32; all recurrence math is
+// deliberately F32, matching the Qwen3.5 reference fallback.
+template <typename T>
+__device__ __forceinline__ void ovis_gated_delta_rule_body(
+    const T* qkv,
+    const float* gate_beta,
+    const float* initial_state,
+    float* packed_output,
+    uint32_t batch_size,
+    uint32_t sequence_length,
+    uint32_t num_heads,
+    uint32_t head_dim,
+    float* q_reduction,
+    float* k_reduction,
+    float* delta) {
+  const uint32_t batch_head = blockIdx.x;
+  const uint32_t batch = batch_head / num_heads;
+  const uint32_t head = batch_head - batch * num_heads;
+  if (batch >= batch_size) {
+    return;
+  }
+
+  const uint32_t lane = threadIdx.x;
+  const uint64_t state_size = static_cast<uint64_t>(head_dim) * head_dim;
+  const uint64_t core_count =
+      static_cast<uint64_t>(batch_size) * sequence_length * num_heads * head_dim;
+  const uint64_t state_offset = static_cast<uint64_t>(batch_head) * state_size;
+  float* state = packed_output + core_count + state_offset;
+  for (uint64_t index = lane; index < state_size; index += blockDim.x) {
+    state[index] = initial_state[state_offset + index];
+  }
+  __syncthreads();
+
+  const float q_scale = rsqrtf(static_cast<float>(head_dim));
+  for (uint32_t token = 0; token < sequence_length; ++token) {
+    const uint64_t token_head =
+        (static_cast<uint64_t>(batch) * sequence_length + token) * num_heads + head;
+    const uint64_t qkv_offset = token_head * (3u * head_dim);
+    float q_sum = 0.0f;
+    float k_sum = 0.0f;
+    for (uint32_t dim = lane; dim < head_dim; dim += blockDim.x) {
+      const float q_value = ovis_gd_to_float(qkv[qkv_offset + dim]);
+      const float k_value = ovis_gd_to_float(qkv[qkv_offset + head_dim + dim]);
+      q_sum += q_value * q_value;
+      k_sum += k_value * k_value;
+    }
+    q_reduction[lane] = q_sum;
+    k_reduction[lane] = k_sum;
+    for (uint32_t stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+      __syncthreads();
+      if (lane < stride) {
+        q_reduction[lane] += q_reduction[lane + stride];
+        k_reduction[lane] += k_reduction[lane + stride];
+      }
+    }
+    __syncthreads();
+    const float q_inv_norm = rsqrtf(q_reduction[0] + 1.0e-6f) * q_scale;
+    const float k_inv_norm = rsqrtf(k_reduction[0] + 1.0e-6f);
+    const uint64_t gate_offset = token_head * 2u;
+    const float decay = expf(gate_beta[gate_offset]);
+    const float beta = gate_beta[gate_offset + 1u];
+
+    for (uint64_t index = lane; index < state_size; index += blockDim.x) {
+      state[index] *= decay;
+    }
+    __syncthreads();
+
+    for (uint32_t value_dim = lane; value_dim < head_dim;
+         value_dim += blockDim.x) {
+      float memory = 0.0f;
+      for (uint32_t key_dim = 0; key_dim < head_dim; ++key_dim) {
+        const float key =
+            ovis_gd_to_float(qkv[qkv_offset + head_dim + key_dim]) * k_inv_norm;
+        memory += state[static_cast<uint64_t>(key_dim) * head_dim + value_dim] * key;
+      }
+      const float value =
+          ovis_gd_to_float(qkv[qkv_offset + 2u * head_dim + value_dim]);
+      delta[value_dim] = (value - memory) * beta;
+    }
+    __syncthreads();
+
+    for (uint64_t index = lane; index < state_size; index += blockDim.x) {
+      const uint32_t key_dim = static_cast<uint32_t>(index / head_dim);
+      const uint32_t value_dim = static_cast<uint32_t>(index -
+                                                        static_cast<uint64_t>(key_dim) * head_dim);
+      const float key =
+          ovis_gd_to_float(qkv[qkv_offset + head_dim + key_dim]) * k_inv_norm;
+      state[index] += key * delta[value_dim];
+    }
+    __syncthreads();
+
+    const uint64_t output_offset = token_head * head_dim;
+    for (uint32_t value_dim = lane; value_dim < head_dim;
+         value_dim += blockDim.x) {
+      float output = 0.0f;
+      for (uint32_t key_dim = 0; key_dim < head_dim; ++key_dim) {
+        const float query = ovis_gd_to_float(qkv[qkv_offset + key_dim]) * q_inv_norm;
+        output += state[static_cast<uint64_t>(key_dim) * head_dim + value_dim] * query;
+      }
+      packed_output[output_offset + value_dim] = output;
+    }
+    __syncthreads();
+  }
+}
+
+}  // namespace
+
+#define OVIS_DEFINE_GATED_DELTA_KERNEL(name, input_type)                         \
+  extern "C" __global__ void name(                                               \
+      const input_type* qkv, const float* gate_beta,                             \
+      const float* initial_state, float* packed_output, uint32_t batch_size,      \
+      uint32_t sequence_length, uint32_t num_heads, uint32_t head_dim) {          \
+    __shared__ float q_reduction[256];                                             \
+    __shared__ float k_reduction[256];                                             \
+    __shared__ float delta[256];                                                   \
+    ovis_gated_delta_rule_body(qkv, gate_beta, initial_state, packed_output,       \
+                               batch_size, sequence_length, num_heads, head_dim,   \
+                               q_reduction, k_reduction, delta);                   \
+  }
+
+OVIS_DEFINE_GATED_DELTA_KERNEL(gated_delta_rule_bf16, __nv_bfloat16)
+OVIS_DEFINE_GATED_DELTA_KERNEL(gated_delta_rule_f16, half)
+OVIS_DEFINE_GATED_DELTA_KERNEL(gated_delta_rule_f32, float)
+
+#undef OVIS_DEFINE_GATED_DELTA_KERNEL

--- a/oar-ocr-vl/src/ovisocr2/gated_delta.rs
+++ b/oar-ocr-vl/src/ovisocr2/gated_delta.rs
@@ -1,0 +1,626 @@
+//! Recurrent Gated Delta Rule used by Qwen3.5 linear-attention layers.
+//!
+//! The custom-op ABI packs the two logical outputs into one flat F32 buffer
+//! because Candle custom ops return a single tensor. [`gated_delta_rule`]
+//! immediately unpacks that buffer into the public crate-internal layout:
+//! `[B, S, H, D]` core output (cast back to the QKV dtype) and
+//! `[B, H, D, D]` final recurrent state in F32.
+
+#[cfg(feature = "cuda")]
+use crate::cuda_kernels::CUDA_KERNEL_MODULE;
+use candle_core::backend::BackendStorage;
+use candle_core::{CpuStorage, CustomOp3, D, DType, Layout, Result, Shape, Tensor};
+
+#[cfg(feature = "cuda")]
+const PTX: &str = include_str!(concat!(env!("OUT_DIR"), "/oar_vl_kernels.ptx"));
+
+const QK_NORM_EPS: f32 = 1e-6;
+#[cfg(feature = "cuda")]
+const MAX_CUDA_HEAD_DIM: usize = 256;
+
+#[derive(Debug, Clone, Copy)]
+struct GatedDeltaRule {
+    batch: usize,
+    sequence: usize,
+    heads: usize,
+    head_dim: usize,
+}
+
+impl GatedDeltaRule {
+    fn core_len(self) -> usize {
+        self.batch * self.sequence * self.heads * self.head_dim
+    }
+
+    fn state_len(self) -> usize {
+        self.batch * self.heads * self.head_dim * self.head_dim
+    }
+
+    fn packed_len(self) -> usize {
+        self.core_len() + self.state_len()
+    }
+
+    fn validate_layouts(
+        self,
+        qkv_layout: &Layout,
+        gate_beta_layout: &Layout,
+        state_layout: &Layout,
+    ) -> Result<()> {
+        if !qkv_layout.is_contiguous()
+            || !gate_beta_layout.is_contiguous()
+            || !state_layout.is_contiguous()
+        {
+            candle_core::bail!("gated delta rule requires contiguous tensors")
+        }
+
+        let expected_qkv = [self.batch, self.sequence, self.heads, self.head_dim * 3];
+        let expected_gate_beta = [self.batch, self.sequence, self.heads, 2];
+        let expected_state = [self.batch, self.heads, self.head_dim, self.head_dim];
+        if qkv_layout.shape().dims() != expected_qkv
+            || gate_beta_layout.shape().dims() != expected_gate_beta
+            || state_layout.shape().dims() != expected_state
+        {
+            candle_core::bail!(
+                "gated delta rule shape mismatch: qkv={:?} (expected {:?}), gate_beta={:?} (expected {:?}), state={:?} (expected {:?})",
+                qkv_layout.shape(),
+                expected_qkv,
+                gate_beta_layout.shape(),
+                expected_gate_beta,
+                state_layout.shape(),
+                expected_state,
+            )
+        }
+        Ok(())
+    }
+}
+
+trait IntoF32: Copy {
+    fn into_f32(self) -> f32;
+}
+
+impl IntoF32 for f32 {
+    fn into_f32(self) -> f32 {
+        self
+    }
+}
+
+impl IntoF32 for half::bf16 {
+    fn into_f32(self) -> f32 {
+        f32::from(self)
+    }
+}
+
+impl IntoF32 for half::f16 {
+    fn into_f32(self) -> f32 {
+        f32::from(self)
+    }
+}
+
+fn contiguous_range(layout: &Layout, name: &str) -> Result<(usize, usize)> {
+    layout
+        .contiguous_offsets()
+        .ok_or_else(|| candle_core::Error::Msg(format!("{name} must be contiguous")))
+}
+
+fn cpu_recurrent<T: IntoF32>(
+    op: GatedDeltaRule,
+    qkv: &[T],
+    gate_beta: &[f32],
+    initial_state: &[f32],
+) -> Vec<f32> {
+    let GatedDeltaRule {
+        batch,
+        sequence,
+        heads,
+        head_dim,
+    } = op;
+    let core_len = op.core_len();
+    let mut packed = vec![0f32; op.packed_len()];
+    let (core, final_states) = packed.split_at_mut(core_len);
+    let q_scale = (head_dim as f32).sqrt().recip();
+
+    for batch_idx in 0..batch {
+        for head_idx in 0..heads {
+            let state_offset = (batch_idx * heads + head_idx) * head_dim * head_dim;
+            let state = &mut final_states[state_offset..state_offset + head_dim * head_dim];
+            state.copy_from_slice(&initial_state[state_offset..state_offset + head_dim * head_dim]);
+
+            let mut q = vec![0f32; head_dim];
+            let mut k = vec![0f32; head_dim];
+            let mut delta = vec![0f32; head_dim];
+            for token_idx in 0..sequence {
+                let token_offset =
+                    ((batch_idx * sequence + token_idx) * heads + head_idx) * head_dim * 3;
+                let mut q_norm_sq = 0f32;
+                let mut k_norm_sq = 0f32;
+                for lane in 0..head_dim {
+                    let q_value = qkv[token_offset + lane].into_f32();
+                    let k_value = qkv[token_offset + head_dim + lane].into_f32();
+                    q[lane] = q_value;
+                    k[lane] = k_value;
+                    q_norm_sq += q_value * q_value;
+                    k_norm_sq += k_value * k_value;
+                }
+                let q_inv_norm = (q_norm_sq + QK_NORM_EPS).sqrt().recip() * q_scale;
+                let k_inv_norm = (k_norm_sq + QK_NORM_EPS).sqrt().recip();
+                for lane in 0..head_dim {
+                    q[lane] *= q_inv_norm;
+                    k[lane] *= k_inv_norm;
+                }
+
+                let gate_offset = ((batch_idx * sequence + token_idx) * heads + head_idx) * 2;
+                let decay = gate_beta[gate_offset].exp();
+                let beta = gate_beta[gate_offset + 1];
+                for value in state.iter_mut() {
+                    *value *= decay;
+                }
+
+                for value_lane in 0..head_dim {
+                    let mut memory = 0f32;
+                    for key_lane in 0..head_dim {
+                        memory += state[key_lane * head_dim + value_lane] * k[key_lane];
+                    }
+                    let value = qkv[token_offset + head_dim * 2 + value_lane].into_f32();
+                    delta[value_lane] = (value - memory) * beta;
+                }
+
+                for key_lane in 0..head_dim {
+                    for value_lane in 0..head_dim {
+                        state[key_lane * head_dim + value_lane] += k[key_lane] * delta[value_lane];
+                    }
+                }
+
+                let output_offset =
+                    ((batch_idx * sequence + token_idx) * heads + head_idx) * head_dim;
+                for value_lane in 0..head_dim {
+                    let mut value = 0f32;
+                    for key_lane in 0..head_dim {
+                        value += state[key_lane * head_dim + value_lane] * q[key_lane];
+                    }
+                    core[output_offset + value_lane] = value;
+                }
+            }
+        }
+    }
+    packed
+}
+
+impl CustomOp3 for GatedDeltaRule {
+    fn name(&self) -> &'static str {
+        "qwen3.5-gated-delta-rule"
+    }
+
+    fn cpu_fwd(
+        &self,
+        qkv: &CpuStorage,
+        qkv_layout: &Layout,
+        gate_beta: &CpuStorage,
+        gate_beta_layout: &Layout,
+        initial_state: &CpuStorage,
+        state_layout: &Layout,
+    ) -> Result<(CpuStorage, Shape)> {
+        self.validate_layouts(qkv_layout, gate_beta_layout, state_layout)?;
+        if gate_beta.dtype() != DType::F32 || initial_state.dtype() != DType::F32 {
+            candle_core::bail!(
+                "gated delta rule requires F32 gate_beta and initial_state, got {:?} and {:?}",
+                gate_beta.dtype(),
+                initial_state.dtype()
+            )
+        }
+        let (gate_start, gate_end) = contiguous_range(gate_beta_layout, "gate_beta")?;
+        let (state_start, state_end) = contiguous_range(state_layout, "initial_state")?;
+        let gates = &gate_beta.as_slice::<f32>()?[gate_start..gate_end];
+        let state = &initial_state.as_slice::<f32>()?[state_start..state_end];
+        let (qkv_start, qkv_end) = contiguous_range(qkv_layout, "qkv")?;
+        let packed = match qkv {
+            CpuStorage::BF16(values) => {
+                cpu_recurrent(*self, &values[qkv_start..qkv_end], gates, state)
+            }
+            CpuStorage::F16(values) => {
+                cpu_recurrent(*self, &values[qkv_start..qkv_end], gates, state)
+            }
+            CpuStorage::F32(values) => {
+                cpu_recurrent(*self, &values[qkv_start..qkv_end], gates, state)
+            }
+            _ => candle_core::bail!(
+                "gated delta rule supports BF16, F16, or F32 QKV, got {:?}",
+                qkv.dtype()
+            ),
+        };
+        Ok((
+            CpuStorage::F32(packed),
+            Shape::from_dims(&[self.packed_len()]),
+        ))
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        qkv: &candle_core::CudaStorage,
+        qkv_layout: &Layout,
+        gate_beta: &candle_core::CudaStorage,
+        gate_beta_layout: &Layout,
+        initial_state: &candle_core::CudaStorage,
+        state_layout: &Layout,
+    ) -> Result<(candle_core::CudaStorage, Shape)> {
+        use candle_core::cuda_backend::WrapErr;
+        use candle_core::cuda_backend::cudarc::driver::{LaunchConfig, PushKernelArg};
+
+        self.validate_layouts(qkv_layout, gate_beta_layout, state_layout)?;
+        if gate_beta.dtype() != DType::F32 || initial_state.dtype() != DType::F32 {
+            candle_core::bail!(
+                "gated delta rule requires F32 gate_beta and initial_state, got {:?} and {:?}",
+                gate_beta.dtype(),
+                initial_state.dtype()
+            )
+        }
+        if self.head_dim > MAX_CUDA_HEAD_DIM {
+            candle_core::bail!(
+                "gated delta rule CUDA kernel supports head_dim <= {MAX_CUDA_HEAD_DIM}, got {}",
+                self.head_dim
+            )
+        }
+
+        let device = qkv.device().clone();
+        let gate_beta = gate_beta.as_cuda_slice::<f32>()?;
+        let gate_beta = gate_beta.slice(gate_beta_layout.start_offset()..);
+        let initial_state = initial_state.as_cuda_slice::<f32>()?;
+        let initial_state = initial_state.slice(state_layout.start_offset()..);
+        let mut output = unsafe { device.alloc::<f32>(self.packed_len()) }?;
+        let function_name = match qkv.dtype() {
+            DType::BF16 => "gated_delta_rule_bf16",
+            DType::F16 => "gated_delta_rule_f16",
+            DType::F32 => "gated_delta_rule_f32",
+            dtype => {
+                candle_core::bail!("gated delta rule supports BF16, F16, or F32 QKV, got {dtype:?}")
+            }
+        };
+        let function = device.get_or_load_custom_func(function_name, CUDA_KERNEL_MODULE, PTX)?;
+        let threads = self.head_dim.next_power_of_two().min(MAX_CUDA_HEAD_DIM) as u32;
+
+        macro_rules! launch {
+            ($ty:ty) => {{
+                let qkv = qkv.as_cuda_slice::<$ty>()?;
+                let qkv = qkv.slice(qkv_layout.start_offset()..);
+                let mut builder = function.builder();
+                builder.arg(&qkv);
+                builder.arg(&gate_beta);
+                builder.arg(&initial_state);
+                builder.arg(&mut output);
+                candle_core::builder_arg!(
+                    builder,
+                    self.batch as u32,
+                    self.sequence as u32,
+                    self.heads as u32,
+                    self.head_dim as u32
+                );
+                unsafe {
+                    builder.launch(LaunchConfig {
+                        grid_dim: ((self.batch * self.heads) as u32, 1, 1),
+                        block_dim: (threads, 1, 1),
+                        shared_mem_bytes: 0,
+                    })
+                }
+                .w()?;
+            }};
+        }
+
+        match qkv.dtype() {
+            DType::BF16 => launch!(half::bf16),
+            DType::F16 => launch!(half::f16),
+            DType::F32 => launch!(f32),
+            _ => unreachable!(),
+        }
+        Ok((
+            candle_core::CudaStorage::wrap_cuda_slice(output, device),
+            Shape::from_dims(&[self.packed_len()]),
+        ))
+    }
+}
+
+fn validate_inputs(
+    qkv: &Tensor,
+    gate_beta: &Tensor,
+    initial_state: &Tensor,
+) -> Result<GatedDeltaRule> {
+    let (batch, sequence, heads, packed_dim) = qkv.dims4()?;
+    if batch == 0 || sequence == 0 || heads == 0 || packed_dim == 0 || packed_dim % 3 != 0 {
+        candle_core::bail!(
+            "gated delta rule expects non-empty qkv [B,S,H,3D], got {:?}",
+            qkv.shape()
+        )
+    }
+    let head_dim = packed_dim / 3;
+    if gate_beta.dims4()? != (batch, sequence, heads, 2) {
+        candle_core::bail!(
+            "gated delta rule expects gate_beta [B,S,H,2], got {:?} for qkv {:?}",
+            gate_beta.shape(),
+            qkv.shape()
+        )
+    }
+    if initial_state.dims4()? != (batch, heads, head_dim, head_dim) {
+        candle_core::bail!(
+            "gated delta rule expects initial_state [B,H,D,D], got {:?} for qkv {:?}",
+            initial_state.shape(),
+            qkv.shape()
+        )
+    }
+    if !qkv.device().same_device(gate_beta.device())
+        || !qkv.device().same_device(initial_state.device())
+    {
+        candle_core::bail!(
+            "gated delta rule inputs must be on the same device, got qkv={:?}, gate_beta={:?}, state={:?}",
+            qkv.device(),
+            gate_beta.device(),
+            initial_state.device()
+        )
+    }
+    if !matches!(qkv.dtype(), DType::BF16 | DType::F16 | DType::F32) {
+        candle_core::bail!(
+            "gated delta rule supports BF16, F16, or F32 QKV, got {:?}",
+            qkv.dtype()
+        )
+    }
+    if gate_beta.dtype() != DType::F32 || initial_state.dtype() != DType::F32 {
+        candle_core::bail!(
+            "gated delta rule requires F32 gate_beta and initial_state, got {:?} and {:?}",
+            gate_beta.dtype(),
+            initial_state.dtype()
+        )
+    }
+    Ok(GatedDeltaRule {
+        batch,
+        sequence,
+        heads,
+        head_dim,
+    })
+}
+
+/// Apply Qwen3.5's recurrent Gated Delta Rule.
+///
+/// Input layouts are:
+///
+/// - `qkv`: contiguous logical `[B, S, H, 3D]`, packed as Q then K then V.
+/// - `gate_beta`: F32 `[B, S, H, 2]`, with log-decay `g` in lane 0 and
+///   delta interpolation `beta` in lane 1.
+/// - `initial_state`: F32 `[B, H, D, D]`, key dimension before value dimension.
+///
+/// The returned core output is `[B, S, H, D]` in the original QKV dtype. The
+/// returned final state is `[B, H, D, D]` in F32. Q and K are L2-normalized
+/// with epsilon `1e-6`; Q additionally receives the `1/sqrt(D)` attention
+/// scale. CPU and CUDA use the packed-output [`CustomOp3`] above. Metal uses a
+/// portable Candle tensor recurrence because Candle custom ops have no Metal
+/// implementation here.
+pub(crate) fn gated_delta_rule(
+    qkv: &Tensor,
+    gate_beta: &Tensor,
+    initial_state: &Tensor,
+) -> Result<(Tensor, Tensor)> {
+    let op = validate_inputs(qkv, gate_beta, initial_state)?;
+    if qkv.device().is_metal() {
+        return tensor_recurrent(qkv, gate_beta, initial_state, op);
+    }
+
+    let qkv = qkv.contiguous()?;
+    let gate_beta = gate_beta.contiguous()?;
+    let initial_state = initial_state.contiguous()?;
+    let packed = qkv.apply_op3_no_bwd(&gate_beta, &initial_state, &op)?;
+    let core = packed
+        .narrow(0, 0, op.core_len())?
+        .reshape((op.batch, op.sequence, op.heads, op.head_dim))?
+        .to_dtype(qkv.dtype())?;
+    let final_state = packed.narrow(0, op.core_len(), op.state_len())?.reshape((
+        op.batch,
+        op.heads,
+        op.head_dim,
+        op.head_dim,
+    ))?;
+    Ok((core, final_state))
+}
+
+fn tensor_recurrent(
+    qkv: &Tensor,
+    gate_beta: &Tensor,
+    initial_state: &Tensor,
+    op: GatedDeltaRule,
+) -> Result<(Tensor, Tensor)> {
+    let source_dtype = qkv.dtype();
+    let qkv = qkv.to_dtype(DType::F32)?;
+    let q = qkv.narrow(3, 0, op.head_dim)?;
+    let k = qkv.narrow(3, op.head_dim, op.head_dim)?;
+    let v = qkv.narrow(3, op.head_dim * 2, op.head_dim)?;
+    let q_norm = q
+        .sqr()?
+        .sum_keepdim(D::Minus1)?
+        .affine(1.0, QK_NORM_EPS as f64)?
+        .sqrt()?;
+    let k_norm = k
+        .sqr()?
+        .sum_keepdim(D::Minus1)?
+        .affine(1.0, QK_NORM_EPS as f64)?
+        .sqrt()?;
+    let q = q
+        .broadcast_div(&q_norm)?
+        .affine((op.head_dim as f64).sqrt().recip(), 0.0)?;
+    let k = k.broadcast_div(&k_norm)?;
+    let g = gate_beta.narrow(3, 0, 1)?.squeeze(3)?;
+    let beta = gate_beta.narrow(3, 1, 1)?.squeeze(3)?;
+
+    let mut state = initial_state.clone();
+    let mut outputs = Vec::with_capacity(op.sequence);
+    for token_idx in 0..op.sequence {
+        let q_t = q.narrow(1, token_idx, 1)?.squeeze(1)?;
+        let k_t = k.narrow(1, token_idx, 1)?.squeeze(1)?;
+        let v_t = v.narrow(1, token_idx, 1)?.squeeze(1)?;
+        let decay = g
+            .narrow(1, token_idx, 1)?
+            .squeeze(1)?
+            .exp()?
+            .unsqueeze(2)?
+            .unsqueeze(3)?;
+        state = state.broadcast_mul(&decay)?;
+        let memory = state.broadcast_mul(&k_t.unsqueeze(3)?)?.sum(2)?;
+        let beta_t = beta.narrow(1, token_idx, 1)?.squeeze(1)?.unsqueeze(2)?;
+        let delta = v_t.broadcast_sub(&memory)?.broadcast_mul(&beta_t)?;
+        state = state.broadcast_add(&k_t.unsqueeze(3)?.broadcast_mul(&delta.unsqueeze(2)?)?)?;
+        let output = state
+            .broadcast_mul(&q_t.unsqueeze(3)?)?
+            .sum(2)?
+            .unsqueeze(1)?;
+        outputs.push(output);
+    }
+    let output_refs: Vec<&Tensor> = outputs.iter().collect();
+    let core = Tensor::cat(&output_refs, 1)?.to_dtype(source_dtype)?;
+    Ok((core, state))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    const B: usize = 1;
+    const S: usize = 3;
+    const H: usize = 1;
+    const D_HEAD: usize = 2;
+
+    fn inputs(device: &Device, dtype: DType) -> Result<(Tensor, Tensor, Tensor)> {
+        let qkv = [
+            3.0f32, 4.0, 0.0, 2.0, 1.0, -1.0, // token 0
+            -1.0, 2.0, 2.0, 1.0, 0.5, 3.0, // token 1
+            0.5, -0.25, -1.0, 0.75, 2.0, 0.25, // token 2
+        ];
+        let gate_beta = [0.5f32.ln(), 0.25, 0.8f32.ln(), 0.75, 0.9f32.ln(), 0.4];
+        let state = [0.1f32, -0.2, 0.3, 0.4];
+        Ok((
+            Tensor::from_slice(&qkv, (B, S, H, D_HEAD * 3), device)?.to_dtype(dtype)?,
+            Tensor::from_slice(&gate_beta, (B, S, H, 2), device)?,
+            Tensor::from_slice(&state, (B, H, D_HEAD, D_HEAD), device)?,
+        ))
+    }
+
+    fn assert_close(actual: &Tensor, expected: &Tensor, tolerance: f32) -> Result<()> {
+        let actual = actual
+            .to_dtype(DType::F32)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        let expected = expected
+            .to_dtype(DType::F32)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        assert_eq!(actual.len(), expected.len());
+        for (index, (actual, expected)) in actual.iter().zip(&expected).enumerate() {
+            assert!(
+                (actual - expected).abs() <= tolerance,
+                "mismatch at {index}: actual={actual}, expected={expected}, tolerance={tolerance}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn cpu_custom_op_matches_tensor_recurrence() -> Result<()> {
+        let (qkv, gate_beta, state) = inputs(&Device::Cpu, DType::F32)?;
+        let op = validate_inputs(&qkv, &gate_beta, &state)?;
+        let expected = tensor_recurrent(&qkv, &gate_beta, &state, op)?;
+        let actual = gated_delta_rule(&qkv, &gate_beta, &state)?;
+        assert_eq!(actual.0.dims(), &[B, S, H, D_HEAD]);
+        assert_eq!(actual.1.dims(), &[B, H, D_HEAD, D_HEAD]);
+        assert_eq!(actual.0.dtype(), DType::F32);
+        assert_eq!(actual.1.dtype(), DType::F32);
+        assert_close(&actual.0, &expected.0, 2e-6)?;
+        assert_close(&actual.1, &expected.1, 2e-6)?;
+
+        // Independently calculated from the scalar recurrence in the
+        // Transformers Qwen3.5 fallback. This guards against both
+        // implementations agreeing on the same layout mistake.
+        let expected_core = Tensor::from_slice(
+            &[
+                0.226_274_16f32,
+                -0.098_994_926,
+                0.170_762_97,
+                -0.025_298_197,
+                -0.513_062_3,
+                0.540_510_9,
+            ],
+            (B, S, H, D_HEAD),
+            &Device::Cpu,
+        )?;
+        let expected_state = Tensor::from_slice(
+            &[-0.393_449_7f32, 1.428_460_7, 0.835_548_7, 1.147_673_1],
+            (B, H, D_HEAD, D_HEAD),
+            &Device::Cpu,
+        )?;
+        assert_close(&actual.0, &expected_core, 3e-6)?;
+        assert_close(&actual.1, &expected_state, 3e-6)
+    }
+
+    #[test]
+    fn bf16_core_preserves_dtype_and_is_numerically_close() -> Result<()> {
+        let (qkv, gate_beta, state) = inputs(&Device::Cpu, DType::BF16)?;
+        let op = validate_inputs(&qkv, &gate_beta, &state)?;
+        let expected = tensor_recurrent(&qkv, &gate_beta, &state, op)?;
+        let actual = gated_delta_rule(&qkv, &gate_beta, &state)?;
+        assert_eq!(actual.0.dtype(), DType::BF16);
+        assert_eq!(actual.1.dtype(), DType::F32);
+        assert_close(&actual.0, &expected.0, 2e-2)?;
+        assert_close(&actual.1, &expected.1, 2e-5)
+    }
+
+    #[test]
+    fn f16_core_preserves_dtype_and_is_numerically_close() -> Result<()> {
+        let (qkv, gate_beta, state) = inputs(&Device::Cpu, DType::F16)?;
+        let op = validate_inputs(&qkv, &gate_beta, &state)?;
+        let expected = tensor_recurrent(&qkv, &gate_beta, &state, op)?;
+        let actual = gated_delta_rule(&qkv, &gate_beta, &state)?;
+        assert_eq!(actual.0.dtype(), DType::F16);
+        assert_eq!(actual.1.dtype(), DType::F32);
+        assert_close(&actual.0, &expected.0, 3e-3)?;
+        assert_close(&actual.1, &expected.1, 3e-6)
+    }
+
+    #[test]
+    fn recurrent_state_makes_split_sequence_match_full_sequence() -> Result<()> {
+        let (qkv, gate_beta, state) = inputs(&Device::Cpu, DType::F32)?;
+        let (full_output, full_state) = gated_delta_rule(&qkv, &gate_beta, &state)?;
+        let (first_output, first_state) =
+            gated_delta_rule(&qkv.narrow(1, 0, 1)?, &gate_beta.narrow(1, 0, 1)?, &state)?;
+        let (rest_output, rest_state) = gated_delta_rule(
+            &qkv.narrow(1, 1, S - 1)?,
+            &gate_beta.narrow(1, 1, S - 1)?,
+            &first_state,
+        )?;
+        let split_output = Tensor::cat(&[&first_output, &rest_output], 1)?;
+        assert_close(&split_output, &full_output, 2e-6)?;
+        assert_close(&rest_state, &full_state, 2e-6)
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn cuda_supported_dtypes_match_cpu_reference_when_available() -> Result<()> {
+        let Ok(device) = Device::new_cuda(0) else {
+            return Ok(());
+        };
+        for (dtype, core_tolerance, state_tolerance) in [
+            (DType::BF16, 3e-2, 3e-4),
+            (DType::F16, 3e-3, 3e-5),
+            (DType::F32, 3e-6, 3e-6),
+        ] {
+            let (cpu_qkv, cpu_gate_beta, cpu_state) = inputs(&Device::Cpu, dtype)?;
+            let expected = gated_delta_rule(&cpu_qkv, &cpu_gate_beta, &cpu_state)?;
+            let (qkv, gate_beta, state) = inputs(&device, dtype)?;
+            let actual = gated_delta_rule(&qkv, &gate_beta, &state)?;
+            assert_eq!(actual.0.dtype(), dtype);
+            assert_close(
+                &actual.0.to_device(&Device::Cpu)?,
+                &expected.0,
+                core_tolerance,
+            )?;
+            assert_close(
+                &actual.1.to_device(&Device::Cpu)?,
+                &expected.1,
+                state_tolerance,
+            )?;
+        }
+        Ok(())
+    }
+}

--- a/oar-ocr-vl/src/ovisocr2/mod.rs
+++ b/oar-ocr-vl/src/ovisocr2/mod.rs
@@ -1,0 +1,17 @@
+//! OvisOCR2 document-to-Markdown model support.
+
+mod config;
+mod gated_delta;
+mod model;
+pub(crate) mod processing;
+pub(crate) mod text;
+pub(crate) mod vision;
+
+pub use config::{
+    OVIS_OCR2_MAX_PIXELS, OVIS_OCR2_MIN_PIXELS, OvisOcr2Config, OvisOcr2ImageProcessorConfig,
+    OvisOcr2ImageProcessorSize, OvisOcr2RopeParameters, OvisOcr2TextConfig, OvisOcr2VisionConfig,
+};
+pub use model::{
+    DEFAULT_MAX_NEW_TOKENS, DEFAULT_PROMPT, OvisOcr2, clean_truncated_repeats,
+    filter_visual_image_tags,
+};

--- a/oar-ocr-vl/src/ovisocr2/model.rs
+++ b/oar-ocr-vl/src/ovisocr2/model.rs
@@ -1,0 +1,668 @@
+use super::config::{OvisOcr2Config, OvisOcr2ImageProcessorConfig};
+use super::processing::{
+    OvisOcr2ImageInputs, preprocess_image, validate_processor_vision_compatibility,
+};
+use super::text::OvisOcr2TextModel;
+use super::vision::OvisOcr2VisionModel;
+#[cfg(feature = "cuda")]
+use crate::cuda_kernels::{ArgmaxFirstBf16, ArgmaxFirstF32};
+use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
+use candle_core::{DType, Device, IndexOp, Tensor};
+use candle_nn::{Linear, Module, VarBuilder};
+use image::RgbImage;
+use oar_ocr_core::core::OCRError;
+use std::path::Path;
+use tokenizers::Tokenizer;
+
+const MODEL_NAME: &str = "OvisOCR2";
+
+/// Official OvisOCR2 full-page document parsing instruction.
+pub const DEFAULT_PROMPT: &str = "\nExtract all readable content from the image in natural human reading order and output the result as a single Markdown document. For charts or images, represent them using an HTML image tag: <img src=\"images/bbox_{left}_{top}_{right}_{bottom}.jpg\" />, where left, top, right, bottom are bounding box coordinates scaled to [0, 1000). Format formulas as LaTeX. Format tables as HTML: <table>...</table>. Transcribe all other text as standard Markdown. Preserve the original text without translation or paraphrasing.";
+
+/// Upstream generation limit used by the official OvisOCR2 example.
+pub const DEFAULT_MAX_NEW_TOKENS: usize = 16_384;
+
+/// End-to-end OvisOCR2 page parser backed by Qwen3.5-0.8B.
+pub struct OvisOcr2 {
+    device: Device,
+    dtype: DType,
+    cfg: OvisOcr2Config,
+    image_cfg: OvisOcr2ImageProcessorConfig,
+    tokenizer: Tokenizer,
+    text: OvisOcr2TextModel,
+    vision: OvisOcr2VisionModel,
+    lm_head: Linear,
+    stop_token_ids: Vec<u32>,
+    image_token_id: u32,
+}
+
+struct TextCacheGuard<'a>(&'a OvisOcr2TextModel);
+
+impl Drop for TextCacheGuard<'_> {
+    fn drop(&mut self) {
+        self.0.clear_cache();
+    }
+}
+
+impl OvisOcr2 {
+    /// Load an OvisOCR2 Hugging Face model directory.
+    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, OCRError> {
+        let model_dir = model_dir.as_ref();
+        let cfg = OvisOcr2Config::from_path(model_dir.join("config.json"))?;
+        let image_cfg =
+            OvisOcr2ImageProcessorConfig::from_path(model_dir.join("preprocessor_config.json"))?;
+        validate_processor_vision_compatibility(&image_cfg, &cfg.vision_config)?;
+        let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| {
+            OCRError::ConfigError {
+                message: format!("failed to load OvisOCR2 tokenizer.json: {e}"),
+            }
+        })?;
+        require_token_id(&tokenizer, "<|image_pad|>", Some(cfg.image_token_id))?;
+        require_token_id(
+            &tokenizer,
+            "<|vision_start|>",
+            Some(cfg.vision_start_token_id),
+        )?;
+        require_token_id(&tokenizer, "<|vision_end|>", Some(cfg.vision_end_token_id))?;
+        require_token_id(&tokenizer, "<|im_start|>", None)?;
+        let tokenizer_eos = require_token_id(&tokenizer, "<|im_end|>", None)?;
+
+        let dtype = crate::utils::select_dtype(&device);
+        let weight_files = crate::utils::collect_safetensors(model_dir, MODEL_NAME)?;
+        // SAFETY: The model files must remain unchanged while their mmap is in use.
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&weight_files, dtype, &device)
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load safetensors", e))?
+        };
+        let text = OvisOcr2TextModel::load(&cfg.text_config, vb.pp("model").pp("language_model"))?;
+        let vision = OvisOcr2VisionModel::load(&cfg.vision_config, vb.pp("model").pp("visual"))?;
+        // OvisOCR2 ties the language-model output projection to token embeddings.
+        let lm_head = Linear::new(text.token_embedding_weight(), None);
+
+        // vLLM's OvisOCR2 path stops on both the model-config EOS
+        // (`<|endoftext|>`) and the tokenizer EOS (`<|im_end|>`).
+        let stop_token_ids = build_stop_token_ids(cfg.text_config.eos_token_id, tokenizer_eos);
+        let image_token_id = cfg.image_token_id;
+        Ok(Self {
+            device,
+            dtype,
+            cfg,
+            image_cfg,
+            tokenizer,
+            text,
+            vision,
+            lm_head,
+            stop_token_ids,
+            image_token_id,
+        })
+    }
+
+    /// Generate model-native Markdown, retaining visual-region image tags.
+    pub fn generate(
+        &self,
+        images: &[RgbImage],
+        max_new_tokens: usize,
+    ) -> Vec<Result<String, OCRError>> {
+        self.generate_tokens(images, max_new_tokens)
+            .into_iter()
+            .map(|result| result.and_then(|tokens| self.decode_tokens(&tokens)))
+            .collect()
+    }
+
+    /// Parse pages using the official post-processing, which removes visual
+    /// region `<img ...>` blocks by default.
+    pub fn parse(
+        &self,
+        images: &[RgbImage],
+        max_new_tokens: usize,
+    ) -> Vec<Result<String, OCRError>> {
+        self.parse_with_image_tags(images, max_new_tokens, false)
+    }
+
+    /// Parse pages and optionally retain the model's visual-region image tags.
+    pub fn parse_with_image_tags(
+        &self,
+        images: &[RgbImage],
+        max_new_tokens: usize,
+        keep_image_tags: bool,
+    ) -> Vec<Result<String, OCRError>> {
+        self.generate_tokens(images, max_new_tokens)
+            .into_iter()
+            .map(|result| {
+                result.and_then(|tokens| {
+                    let text = self.decode_tokens_raw(&tokens)?;
+                    let text = if keep_image_tags {
+                        text
+                    } else {
+                        filter_visual_image_tags(&text)
+                    };
+                    Ok(clean_truncated_repeats(&text))
+                })
+            })
+            .collect()
+    }
+
+    /// Generate raw token ids for each input page.
+    pub fn generate_tokens(
+        &self,
+        images: &[RgbImage],
+        max_new_tokens: usize,
+    ) -> Vec<Result<Vec<u32>, OCRError>> {
+        images
+            .iter()
+            .map(|image| self.generate_one(image, max_new_tokens))
+            .collect()
+    }
+
+    fn generate_one(&self, image: &RgbImage, max_new_tokens: usize) -> Result<Vec<u32>, OCRError> {
+        self.text.clear_cache();
+        let _cache_guard = TextCacheGuard(&self.text);
+        if max_new_tokens == 0 {
+            return Ok(Vec::new());
+        }
+        if max_new_tokens > self.cfg.text_config.max_position_embeddings {
+            return Err(OCRError::InvalidInput {
+                message: format!(
+                    "OvisOCR2 max_new_tokens {max_new_tokens} exceeds context limit {}",
+                    self.cfg.text_config.max_position_embeddings
+                ),
+            });
+        }
+        let image_inputs = preprocess_image(
+            image,
+            &self.image_cfg,
+            &self.cfg.vision_config,
+            &self.device,
+            self.dtype,
+        )?;
+        let prompt = build_prompt(image_inputs.num_image_tokens);
+        let encoding =
+            self.tokenizer
+                .encode(prompt, false)
+                .map_err(|e| OCRError::InvalidInput {
+                    message: format!("OvisOCR2: tokenizer encode failed: {e}"),
+                })?;
+        let input_ids = encoding.get_ids().to_vec();
+        if input_ids.is_empty() {
+            return Err(OCRError::InvalidInput {
+                message: "OvisOCR2: prompt tokenization produced no tokens".to_string(),
+            });
+        }
+        validate_generation_length(
+            input_ids.len(),
+            max_new_tokens,
+            self.cfg.text_config.max_position_embeddings,
+        )?;
+
+        let inputs_embeds = self.prepare_inputs(&input_ids, &image_inputs)?;
+        let (position_ids, rope_delta) = build_position_ids(
+            &input_ids,
+            image_inputs.grid_thw,
+            self.cfg.vision_config.spatial_merge_size,
+            self.image_token_id,
+            &self.device,
+        )?;
+        let hidden = self.text.forward(&inputs_embeds, &position_ids)?;
+        let prompt_len = input_ids.len();
+        let last_hidden = hidden
+            .i((0, prompt_len - 1, ..))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "select prompt hidden", e))?;
+        let mut logits = self.logits_from_hidden(&last_hidden)?;
+        let mut generated = Vec::new();
+        generated
+            .try_reserve_exact(max_new_tokens)
+            .map_err(|e| OCRError::InvalidInput {
+                message: format!("OvisOCR2 cannot reserve output for {max_new_tokens} tokens: {e}"),
+            })?;
+
+        for step in 0..max_new_tokens {
+            let token = select_greedy_token(&logits)?;
+            if self.stop_token_ids.contains(&token) {
+                break;
+            }
+            generated.push(token);
+            if step + 1 == max_new_tokens {
+                break;
+            }
+
+            let token_ids = Tensor::from_vec(vec![token], (1, 1), &self.device).map_err(|e| {
+                candle_to_ocr_processing(
+                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    "OvisOCR2: create decode token",
+                    e,
+                )
+            })?;
+            let token_embed = self.text.embed(&token_ids)?;
+            let position = prompt_len as i64 + step as i64 + rope_delta;
+            let position_ids = text_position_ids(position, &self.device)?;
+            let hidden = self.text.forward(&token_embed, &position_ids)?;
+            logits =
+                self.logits_from_hidden(&hidden.i((0, 0, ..)).map_err(|e| {
+                    candle_to_ocr_inference(MODEL_NAME, "select decode hidden", e)
+                })?)?;
+        }
+        Ok(generated)
+    }
+
+    fn prepare_inputs(
+        &self,
+        input_ids: &[u32],
+        image_inputs: &OvisOcr2ImageInputs,
+    ) -> Result<Tensor, OCRError> {
+        let seq_len = input_ids.len();
+        let token_ids = Tensor::from_vec(input_ids.to_vec(), (1, seq_len), &self.device)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "create prompt token ids", e))?;
+        let embeds = self.text.embed(&token_ids)?;
+        let image_embeds = self
+            .vision
+            .forward(&image_inputs.pixel_values, image_inputs.grid_thw)?
+            .to_dtype(self.dtype)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "cast image embeddings", e))?;
+
+        let image_positions: Vec<usize> = input_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &token)| (token == self.image_token_id).then_some(index))
+            .collect();
+        let image_len = image_embeds
+            .dim(0)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "image embedding length", e))?;
+        if image_positions.len() != image_len || image_positions.is_empty() {
+            return Err(OCRError::InvalidInput {
+                message: format!(
+                    "OvisOCR2: image placeholder count ({}) != image embedding count ({image_len})",
+                    image_positions.len()
+                ),
+            });
+        }
+        let start = image_positions[0];
+        if image_positions
+            .iter()
+            .enumerate()
+            .any(|(offset, &position)| position != start + offset)
+        {
+            return Err(OCRError::InvalidInput {
+                message: "OvisOCR2: image placeholder tokens must be contiguous".to_string(),
+            });
+        }
+        let end = start + image_positions.len();
+        let hidden_size = embeds
+            .dim(2)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "embedding hidden size", e))?;
+        let prefix = if start == 0 {
+            Tensor::zeros((1, 0, hidden_size), embeds.dtype(), embeds.device())
+        } else {
+            embeds.narrow(1, 0, start)
+        }
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "embedding prefix", e))?;
+        let suffix = if end == seq_len {
+            Tensor::zeros((1, 0, hidden_size), embeds.dtype(), embeds.device())
+        } else {
+            embeds.narrow(1, end, seq_len - end)
+        }
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "embedding suffix", e))?;
+        let image_embeds = image_embeds
+            .unsqueeze(0)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "image embedding batch", e))?;
+        Tensor::cat(&[&prefix, &image_embeds, &suffix], 1)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "merge multimodal embeddings", e))
+    }
+
+    fn logits_from_hidden(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+        self.lm_head
+            .forward(
+                &hidden
+                    .unsqueeze(0)
+                    .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "LM head input", e))?,
+            )
+            .and_then(|logits| logits.squeeze(0))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "language model head", e))
+    }
+
+    /// Decode generated token ids and apply the official truncated-repeat cleanup.
+    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+        Ok(clean_truncated_repeats(&self.decode_tokens_raw(tokens)?))
+    }
+
+    /// Decode token ids without OvisOCR2 post-processing.
+    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, OCRError> {
+        self.tokenizer
+            .decode(tokens, true)
+            .map(|text| text.trim().to_string())
+            .map_err(|e| OCRError::InvalidInput {
+                message: format!("OvisOCR2: tokenizer decode failed: {e}"),
+            })
+    }
+
+    pub fn tokenizer(&self) -> &Tokenizer {
+        &self.tokenizer
+    }
+
+    pub fn config(&self) -> &OvisOcr2Config {
+        &self.cfg
+    }
+
+    pub fn image_processor_config(&self) -> &OvisOcr2ImageProcessorConfig {
+        &self.image_cfg
+    }
+}
+
+fn require_token_id(
+    tokenizer: &Tokenizer,
+    token: &str,
+    expected: Option<u32>,
+) -> Result<u32, OCRError> {
+    let token_id = tokenizer
+        .token_to_id(token)
+        .ok_or_else(|| OCRError::ConfigError {
+            message: format!("OvisOCR2 tokenizer is missing required token {token:?}"),
+        })?;
+    if let Some(expected) = expected
+        && token_id != expected
+    {
+        return Err(OCRError::ConfigError {
+            message: format!(
+                "OvisOCR2 token {token:?} id mismatch: tokenizer {token_id} != config {expected}"
+            ),
+        });
+    }
+    Ok(token_id)
+}
+
+fn build_stop_token_ids(config_eos: u32, tokenizer_eos: u32) -> Vec<u32> {
+    let mut token_ids = vec![config_eos, tokenizer_eos];
+    token_ids.sort_unstable();
+    token_ids.dedup();
+    token_ids
+}
+
+fn validate_generation_length(
+    prompt_len: usize,
+    max_new_tokens: usize,
+    context_limit: usize,
+) -> Result<(), OCRError> {
+    let requested =
+        prompt_len
+            .checked_add(max_new_tokens)
+            .ok_or_else(|| OCRError::InvalidInput {
+                message: "OvisOCR2 requested sequence length overflows usize".to_string(),
+            })?;
+    if requested > context_limit {
+        return Err(OCRError::InvalidInput {
+            message: format!(
+                "OvisOCR2 prompt ({prompt_len}) plus max_new_tokens ({max_new_tokens}) exceeds context limit {context_limit}"
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn build_prompt(num_image_tokens: usize) -> String {
+    let mut prompt = String::with_capacity(DEFAULT_PROMPT.len() + num_image_tokens * 13 + 128);
+    prompt.push_str("<|im_start|>user\n<|vision_start|>");
+    for _ in 0..num_image_tokens {
+        prompt.push_str("<|image_pad|>");
+    }
+    prompt.push_str("<|vision_end|>");
+    prompt.push_str(DEFAULT_PROMPT);
+    prompt.push_str("<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n");
+    prompt
+}
+
+fn build_position_ids(
+    input_ids: &[u32],
+    grid_thw: (usize, usize, usize),
+    spatial_merge_size: usize,
+    image_token_id: u32,
+    device: &Device,
+) -> Result<(Tensor, i64), OCRError> {
+    let image_start = input_ids
+        .iter()
+        .position(|&token| token == image_token_id)
+        .ok_or_else(|| OCRError::InvalidInput {
+            message: "OvisOCR2: image token missing from prompt".to_string(),
+        })?;
+    let image_len = input_ids
+        .iter()
+        .skip(image_start)
+        .take_while(|&&token| token == image_token_id)
+        .count();
+    if input_ids[image_start + image_len..].contains(&image_token_id) {
+        return Err(OCRError::InvalidInput {
+            message: "OvisOCR2: non-contiguous image token span".to_string(),
+        });
+    }
+    let (grid_t, grid_h, grid_w) = grid_thw;
+    if spatial_merge_size == 0
+        || !grid_h.is_multiple_of(spatial_merge_size)
+        || !grid_w.is_multiple_of(spatial_merge_size)
+    {
+        return Err(OCRError::ConfigError {
+            message: format!(
+                "OvisOCR2: invalid image grid {grid_thw:?} for merge size {spatial_merge_size}"
+            ),
+        });
+    }
+    let llm_h = grid_h / spatial_merge_size;
+    let llm_w = grid_w / spatial_merge_size;
+    if image_len != grid_t * llm_h * llm_w {
+        return Err(OCRError::InvalidInput {
+            message: format!(
+                "OvisOCR2: image token count {image_len} != merged grid token count {}",
+                grid_t * llm_h * llm_w
+            ),
+        });
+    }
+
+    let seq_len = input_ids.len();
+    let mut axes = [
+        Vec::with_capacity(seq_len),
+        Vec::with_capacity(seq_len),
+        Vec::with_capacity(seq_len),
+    ];
+    for position in 0..image_start as i64 {
+        for axis in &mut axes {
+            axis.push(position);
+        }
+    }
+    let vision_start = image_start as i64;
+    for temporal in 0..grid_t {
+        for row in 0..llm_h {
+            for col in 0..llm_w {
+                axes[0].push(vision_start + temporal as i64);
+                axes[1].push(vision_start + row as i64);
+                axes[2].push(vision_start + col as i64);
+            }
+        }
+    }
+    let text_start = vision_start + llm_h.max(llm_w) as i64;
+    for (offset, _) in (image_start + image_len..seq_len).enumerate() {
+        let current = text_start + offset as i64;
+        for axis in &mut axes {
+            axis.push(current);
+        }
+    }
+    let max_position = axes
+        .iter()
+        .flat_map(|axis| axis.iter())
+        .copied()
+        .max()
+        .unwrap_or(0);
+    let rope_delta = max_position + 1 - seq_len as i64;
+    let data: Vec<i64> = axes.into_iter().flatten().collect();
+    let tensor = Tensor::from_vec(data, (3, 1, seq_len), device).map_err(|e| {
+        candle_to_ocr_processing(
+            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            "OvisOCR2: create multimodal position ids",
+            e,
+        )
+    })?;
+    Ok((tensor, rope_delta))
+}
+
+fn text_position_ids(position: i64, device: &Device) -> Result<Tensor, OCRError> {
+    Tensor::from_vec(vec![position; 3], (3, 1, 1), device).map_err(|e| {
+        candle_to_ocr_processing(
+            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            "OvisOCR2: create decode position ids",
+            e,
+        )
+    })
+}
+
+fn select_greedy_token(logits: &Tensor) -> Result<u32, OCRError> {
+    #[cfg(feature = "cuda")]
+    if logits.device().is_cuda() && matches!(logits.dtype(), DType::BF16 | DType::F32) {
+        let vocab_size = logits.elem_count();
+        let logits = logits
+            .reshape((1, vocab_size))
+            .and_then(|logits| logits.contiguous())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "reshape GPU logits", e))?;
+        let tokens = match logits.dtype() {
+            DType::BF16 => logits.apply_op1_no_bwd(&ArgmaxFirstBf16),
+            DType::F32 => logits.apply_op1_no_bwd(&ArgmaxFirstF32),
+            _ => unreachable!("dtype checked above"),
+        }
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "stable GPU argmax", e))?;
+        return tokens
+            .i(0)
+            .and_then(|token| token.to_scalar::<u32>())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "copy selected token", e));
+    }
+
+    logits
+        .argmax(candle_core::D::Minus1)
+        .and_then(|token| token.to_scalar::<u32>())
+        .map_err(|e| {
+            candle_to_ocr_processing(
+                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                "OvisOCR2: greedy argmax",
+                e,
+            )
+        })
+}
+
+/// Remove model-emitted visual-region image-tag blocks, matching upstream.
+pub fn filter_visual_image_tags(text: &str) -> String {
+    text.split("\n\n")
+        .filter(|block| !block.trim().starts_with("<img src=\"images/bbox_"))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+/// Clean a truncated repetitive tail using the official OvisOCR2 heuristic.
+pub fn clean_truncated_repeats(text: &str) -> String {
+    const MIN_TEXT_LEN: usize = 8_000;
+    const MAX_PERIOD: usize = 200;
+    const MIN_REPEAT_CHARS: usize = 100;
+    const MIN_REPEAT_TIMES: usize = 5;
+
+    let chars: Vec<char> = text.chars().collect();
+    let n = chars.len();
+    if n < MIN_TEXT_LEN {
+        return text.to_string();
+    }
+    for unit_len in 1..=MAX_PERIOD.min(n - 1) {
+        if chars[n - 1] != chars[n - 1 - unit_len] {
+            continue;
+        }
+        let mut match_len = 1usize;
+        let mut index = n - 2;
+        while index >= unit_len && chars[index] == chars[index - unit_len] {
+            match_len += 1;
+            index -= 1;
+        }
+        let total_len = match_len + unit_len;
+        let repeat_times = total_len / unit_len;
+        let tail_len = total_len % unit_len;
+        if repeat_times >= MIN_REPEAT_TIMES && total_len >= MIN_REPEAT_CHARS {
+            let prefix_end = n - total_len + unit_len;
+            let mut output: String = chars[..prefix_end].iter().collect();
+            output.extend(chars[n - tail_len..].iter());
+            return output;
+        }
+    }
+    text.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stop_tokens_include_model_and_tokenizer_eos() {
+        assert_eq!(build_stop_token_ids(248_044, 248_046), [248_044, 248_046]);
+        assert_eq!(build_stop_token_ids(248_044, 248_044), [248_044]);
+    }
+
+    #[test]
+    fn greedy_argmax_prefers_the_first_tied_token() {
+        let logits = Tensor::from_vec(vec![1f32, 3., 3., 2.], 4, &Device::Cpu).unwrap();
+        assert_eq!(select_greedy_token(&logits).unwrap(), 1);
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn cuda_greedy_argmax_prefers_the_first_tied_token() -> candle_core::Result<()> {
+        let Ok(device) = Device::new_cuda(0) else {
+            return Ok(());
+        };
+        for dtype in [DType::F32, DType::BF16] {
+            let logits = Tensor::from_vec(vec![1f32, 3., 3., 2.], 4, &device)?.to_dtype(dtype)?;
+            assert_eq!(select_greedy_token(&logits).unwrap(), 1);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn generation_length_is_checked_without_overflow() {
+        validate_generation_length(775, 16_384, 262_144).unwrap();
+        assert!(validate_generation_length(775, 262_000, 262_144).is_err());
+        assert!(validate_generation_length(1, usize::MAX, usize::MAX).is_err());
+    }
+
+    #[test]
+    fn official_prompt_has_exact_no_think_framing() {
+        let prompt = build_prompt(2);
+        assert!(prompt.starts_with(
+            "<|im_start|>user\n<|vision_start|><|image_pad|><|image_pad|><|vision_end|>\nExtract"
+        ));
+        assert!(prompt.ends_with("<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"));
+    }
+
+    #[test]
+    fn layout_golden_position_ids_match_upstream() {
+        let mut ids = vec![1u32; 775];
+        ids[4..652].fill(248_056);
+        let (positions, delta) =
+            build_position_ids(&ids, (1, 54, 48), 2, 248_056, &Device::Cpu).unwrap();
+        assert_eq!(delta, -621);
+        let positions = positions.to_vec3::<i64>().unwrap();
+        assert_eq!(positions[0][0][4], 4);
+        assert_eq!(positions[1][0][651], 30);
+        assert_eq!(positions[2][0][651], 27);
+        assert_eq!(positions[0][0][652], 31);
+        assert_eq!(positions[0][0][774], 153);
+    }
+
+    #[test]
+    fn visual_image_tag_blocks_are_removed() {
+        let text = "before\n\n<img src=\"images/bbox_1_2_3_4.jpg\" />\n\nafter";
+        assert_eq!(filter_visual_image_tags(text), "before\n\nafter");
+    }
+
+    #[test]
+    fn short_text_is_not_repeat_cleaned() {
+        let text = "abc".repeat(100);
+        assert_eq!(clean_truncated_repeats(&text), text);
+    }
+
+    #[test]
+    fn long_repetitive_tail_is_cleaned() {
+        let prefix = "x".repeat(8_000);
+        let text = format!("{prefix}{}", "abcdef".repeat(30));
+        let cleaned = clean_truncated_repeats(&text);
+        assert!(cleaned.len() < text.len());
+        assert!(cleaned.starts_with(&prefix));
+    }
+}

--- a/oar-ocr-vl/src/ovisocr2/processing.rs
+++ b/oar-ocr-vl/src/ovisocr2/processing.rs
@@ -1,0 +1,289 @@
+use super::config::{OvisOcr2ImageProcessorConfig, OvisOcr2VisionConfig};
+use crate::utils::{
+    candle_to_ocr_processing,
+    image::{image_to_chw, patchify_merge_grouped, pil_resample_to_filter_type, smart_resize},
+};
+use candle_core::{DType, Device, Tensor};
+use image::{RgbImage, imageops::FilterType};
+use oar_ocr_core::core::OCRError;
+
+#[derive(Debug, Clone)]
+pub struct OvisOcr2ImageInputs {
+    pub pixel_values: Tensor,
+    pub grid_thw: (usize, usize, usize),
+    pub num_image_tokens: usize,
+}
+
+pub(crate) fn validate_processor_vision_compatibility(
+    cfg: &OvisOcr2ImageProcessorConfig,
+    vision_cfg: &OvisOcr2VisionConfig,
+) -> Result<(), OCRError> {
+    if cfg.patch_size != vision_cfg.patch_size {
+        return Err(OCRError::ConfigError {
+            message: format!(
+                "OvisOCR2 patch_size mismatch: processor {} != vision {}",
+                cfg.patch_size, vision_cfg.patch_size
+            ),
+        });
+    }
+    if cfg.temporal_patch_size != vision_cfg.temporal_patch_size {
+        return Err(OCRError::ConfigError {
+            message: format!(
+                "OvisOCR2 temporal_patch_size mismatch: processor {} != vision {}",
+                cfg.temporal_patch_size, vision_cfg.temporal_patch_size
+            ),
+        });
+    }
+    if cfg.merge_size != vision_cfg.spatial_merge_size {
+        return Err(OCRError::ConfigError {
+            message: format!(
+                "OvisOCR2 merge_size mismatch: processor {} != vision {}",
+                cfg.merge_size, vision_cfg.spatial_merge_size
+            ),
+        });
+    }
+    if vision_cfg.in_channels != 3 {
+        return Err(OCRError::ConfigError {
+            message: format!(
+                "OvisOCR2 image preprocessing supports three RGB channels, got {}",
+                vision_cfg.in_channels
+            ),
+        });
+    }
+    Ok(())
+}
+
+pub fn preprocess_image(
+    image: &RgbImage,
+    cfg: &OvisOcr2ImageProcessorConfig,
+    vision_cfg: &OvisOcr2VisionConfig,
+    device: &Device,
+    dtype: DType,
+) -> Result<OvisOcr2ImageInputs, OCRError> {
+    cfg.validate()?;
+    vision_cfg.validate()?;
+    validate_processor_vision_compatibility(cfg, vision_cfg)?;
+
+    let factor = cfg
+        .patch_size
+        .checked_mul(cfg.merge_size)
+        .and_then(|factor| u32::try_from(factor).ok())
+        .ok_or_else(|| OCRError::ConfigError {
+            message: "OvisOCR2 patch/merge factor overflow".to_string(),
+        })?;
+    let (min_pixels, max_pixels) = cfg.runtime_pixel_bounds();
+    let (height, width) = (image.height(), image.width());
+    if height == 0 || width == 0 {
+        return Err(OCRError::InvalidInput {
+            message: format!("OvisOCR2 input image must be non-empty, got {width}x{height}"),
+        });
+    }
+    let (resized_height, resized_width) = if cfg.do_resize {
+        smart_resize(height, width, factor, min_pixels, max_pixels)?
+    } else {
+        (height, width)
+    };
+
+    if resized_height % factor != 0 || resized_width % factor != 0 {
+        return Err(OCRError::InvalidInput {
+            message: format!(
+                "OvisOCR2 preprocessed dimensions {resized_height}x{resized_width} must be divisible by {factor}"
+            ),
+        });
+    }
+
+    // Qwen's fast image processor defaults to bicubic when the checkpoint
+    // does not include an explicit PIL resampling enum.
+    let resize_filter = cfg
+        .resample
+        .and_then(pil_resample_to_filter_type)
+        .unwrap_or(FilterType::CatmullRom);
+    let resized = if resized_height != height || resized_width != width {
+        image::imageops::resize(image, resized_width, resized_height, resize_filter)
+    } else {
+        image.clone()
+    };
+
+    let default_mean = [0.0_f32; 3];
+    let default_std = [1.0_f32; 3];
+    let mean = if cfg.do_normalize {
+        cfg.image_mean.as_slice()
+    } else {
+        &default_mean
+    };
+    let std = if cfg.do_normalize {
+        cfg.image_std.as_slice()
+    } else {
+        &default_std
+    };
+    let rescale_factor = cfg.do_rescale.then_some(cfg.rescale_factor);
+    let frame = image_to_chw(&resized, mean, std, rescale_factor);
+
+    // The image processor represents a still image as one temporal grid cell
+    // whose frame is repeated to fill the Conv3D temporal kernel.
+    let frames: Vec<&[f32]> =
+        std::iter::repeat_n(frame.as_slice(), cfg.temporal_patch_size).collect();
+    let grid_t = 1usize;
+    let grid_h = resized_height as usize / cfg.patch_size;
+    let grid_w = resized_width as usize / cfg.patch_size;
+    if !grid_h.is_multiple_of(cfg.merge_size) || !grid_w.is_multiple_of(cfg.merge_size) {
+        return Err(OCRError::ConfigError {
+            message: format!(
+                "OvisOCR2 patch grid {grid_h}x{grid_w} must be divisible by merge_size {}",
+                cfg.merge_size
+            ),
+        });
+    }
+
+    let flat = patchify_merge_grouped(
+        &frames,
+        vision_cfg.in_channels,
+        resized_height as usize,
+        resized_width as usize,
+        grid_t,
+        grid_h,
+        grid_w,
+        cfg.patch_size,
+        cfg.merge_size,
+        cfg.temporal_patch_size,
+    );
+    let patch_dim =
+        vision_cfg.in_channels * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size;
+    let num_patches = grid_t * grid_h * grid_w;
+    if flat.len() != num_patches * patch_dim {
+        return Err(OCRError::InvalidInput {
+            message: format!(
+                "OvisOCR2 patch extraction produced {} values, expected {}",
+                flat.len(),
+                num_patches * patch_dim
+            ),
+        });
+    }
+
+    let pixel_values = Tensor::from_vec(flat, (num_patches, patch_dim), device)
+        .map_err(|e| {
+            candle_to_ocr_processing(
+                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                "OvisOCR2: create pixel_values",
+                e,
+            )
+        })?
+        .to_dtype(dtype)
+        .map_err(|e| {
+            candle_to_ocr_processing(
+                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                "OvisOCR2: cast pixel_values",
+                e,
+            )
+        })?;
+    let num_image_tokens = num_patches / (cfg.merge_size * cfg.merge_size);
+
+    Ok(OvisOcr2ImageInputs {
+        pixel_values,
+        grid_thw: (grid_t, grid_h, grid_w),
+        num_image_tokens,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ovisocr2::config::OvisOcr2ImageProcessorSize;
+    use candle_nn::Activation;
+    use image::Rgb;
+
+    fn processor_config() -> OvisOcr2ImageProcessorConfig {
+        OvisOcr2ImageProcessorConfig {
+            size: OvisOcr2ImageProcessorSize {
+                shortest_edge: 256 * 256,
+                longest_edge: 4096 * 4096,
+            },
+            patch_size: 16,
+            temporal_patch_size: 2,
+            merge_size: 2,
+            image_mean: vec![0.5; 3],
+            image_std: vec![0.5; 3],
+            do_resize: true,
+            do_rescale: true,
+            do_normalize: true,
+            do_convert_rgb: true,
+            rescale_factor: 1.0 / 255.0,
+            resample: None,
+            processor_class: None,
+            image_processor_type: None,
+        }
+    }
+
+    fn vision_config() -> OvisOcr2VisionConfig {
+        OvisOcr2VisionConfig {
+            model_type: "qwen3_5".to_string(),
+            depth: 12,
+            hidden_size: 768,
+            intermediate_size: 3072,
+            num_heads: 12,
+            in_channels: 3,
+            patch_size: 16,
+            spatial_merge_size: 2,
+            temporal_patch_size: 2,
+            out_hidden_size: 1024,
+            num_position_embeddings: 2304,
+            hidden_act: Activation::GeluPytorchTanh,
+            initializer_range: 0.02,
+            deepstack_visual_indexes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn preprocess_uses_official_minimum_area_and_merge_order()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let image = RgbImage::from_pixel(32, 32, Rgb([255, 255, 255]));
+        let inputs = preprocess_image(
+            &image,
+            &processor_config(),
+            &vision_config(),
+            &Device::Cpu,
+            DType::F32,
+        )?;
+
+        assert_eq!(inputs.grid_thw, (1, 28, 28));
+        assert_eq!(inputs.num_image_tokens, 196);
+        assert_eq!(inputs.pixel_values.dims(), &[784, 1536]);
+        let first_patch = inputs.pixel_values.narrow(0, 0, 1)?.flatten_all()?;
+        assert!(
+            first_patch
+                .to_vec1::<f32>()?
+                .into_iter()
+                .all(|value| (value - 1.0).abs() < 1e-6)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn preprocess_rejects_processor_vision_mismatch() {
+        let image = RgbImage::new(448, 448);
+        let mut vision = vision_config();
+        vision.patch_size = 14;
+        let error = preprocess_image(
+            &image,
+            &processor_config(),
+            &vision,
+            &Device::Cpu,
+            DType::F32,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("patch_size mismatch"));
+    }
+
+    #[test]
+    fn preprocess_rejects_empty_image() {
+        let error = preprocess_image(
+            &RgbImage::new(0, 0),
+            &processor_config(),
+            &vision_config(),
+            &Device::Cpu,
+            DType::F32,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("must be non-empty"));
+    }
+}

--- a/oar-ocr-vl/src/ovisocr2/text.rs
+++ b/oar-ocr-vl/src/ovisocr2/text.rs
@@ -1,0 +1,1004 @@
+//! Qwen3.5 text decoder used by OvisOCR2.
+//!
+//! Qwen3.5 alternates three Gated DeltaNet layers with one full-attention
+//! layer. Its decoder RMSNorm checkpoints are zero-centred (`1 + weight`),
+//! while Gated DeltaNet's internal gated RMSNorm is conventionally centred at
+//! one. Its multimodal RoPE frequencies are interleaved T/H/W.
+
+use super::config::OvisOcr2TextConfig;
+use super::gated_delta::gated_delta_rule;
+use crate::attention::{RotaryEmbedding, flash_attention, scaled_dot_product_attention_gqa};
+use crate::kv_trim::TrimmableKvCache;
+use crate::utils::{candle_to_ocr_inference, rotate_half};
+use candle_core::{D, DType, Device, Tensor};
+use candle_nn::{
+    Conv1d, Conv1dConfig, Embedding, Linear, Module, RmsNorm, VarBuilder, embedding,
+    linear_no_bias, rms_norm,
+};
+use oar_ocr_core::core::OCRError;
+use std::cell::RefCell;
+
+const MODEL_NAME: &str = "OvisOCR2";
+
+#[derive(Debug, Clone)]
+struct AdditiveRmsNorm {
+    weight: Tensor,
+    eps: f64,
+}
+
+impl AdditiveRmsNorm {
+    fn load(dim: usize, eps: f64, vb: VarBuilder) -> Result<Self, OCRError> {
+        let weight = vb
+            .get(dim, "weight")
+            .and_then(|weight| weight.to_dtype(DType::F32))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load additive RMSNorm", e))?;
+        Ok(Self { weight, eps })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+        let dtype = xs.dtype();
+        let xs = xs
+            .to_dtype(DType::F32)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "RMSNorm input cast", e))?;
+        let variance = xs
+            .sqr()
+            .and_then(|xs| xs.mean_keepdim(D::Minus1))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "RMSNorm variance", e))?;
+        let normalized = xs
+            .broadcast_div(
+                &(variance + self.eps)
+                    .and_then(|variance| variance.sqrt())
+                    .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "RMSNorm rsqrt", e))?,
+            )
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "RMSNorm normalize", e))?;
+        let scale = (&self.weight + 1.0)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "RMSNorm scale", e))?;
+        normalized
+            .broadcast_mul(&scale)
+            .and_then(|xs| xs.to_dtype(dtype))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "RMSNorm output", e))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct OvisMlp {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+}
+
+impl OvisMlp {
+    fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let gate_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load MLP gate_proj", e))?;
+        let up_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load MLP up_proj", e))?;
+        let down_proj = linear_no_bias(cfg.intermediate_size, cfg.hidden_size, vb.pp("down_proj"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load MLP down_proj", e))?;
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+        let gate = self
+            .gate_proj
+            .forward(xs)
+            .and_then(|gate| candle_nn::ops::silu(&gate))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "MLP gate", e))?;
+        let up = self
+            .up_proj
+            .forward(xs)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "MLP up", e))?;
+        self.down_proj
+            .forward(
+                &(&gate * &up)
+                    .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "MLP gate product", e))?,
+            )
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "MLP down", e))
+    }
+}
+
+#[derive(Debug)]
+struct GatedDeltaNet {
+    in_proj_qkv: Linear,
+    in_proj_z: Linear,
+    in_proj_b: Linear,
+    in_proj_a: Linear,
+    conv1d: Conv1d,
+    decode_conv_weight: Tensor,
+    dt_bias: Tensor,
+    neg_a: Tensor,
+    norm: RmsNorm,
+    out_proj: Linear,
+    num_key_heads: usize,
+    num_value_heads: usize,
+    key_head_dim: usize,
+    value_head_dim: usize,
+    conv_kernel_size: usize,
+    conv_state: RefCell<Option<Tensor>>,
+    recurrent_state: RefCell<Option<Tensor>>,
+}
+
+fn cached_depthwise_conv_step(
+    state: &Tensor,
+    mixed: &Tensor,
+    weight: &Tensor,
+    kernel_size: usize,
+) -> candle_core::Result<(Tensor, Tensor)> {
+    let tail = state.narrow(2, 1, kernel_size - 1)?;
+    let new_state = Tensor::cat(&[&tail, mixed], 2)?;
+    let output = match mixed.dtype() {
+        DType::BF16 | DType::F16 => new_state
+            .to_dtype(DType::F32)?
+            .broadcast_mul(weight)?
+            .sum_keepdim(2)?
+            .to_dtype(mixed.dtype())?,
+        _ => new_state.broadcast_mul(weight)?.sum_keepdim(2)?,
+    };
+    Ok((output, new_state))
+}
+
+impl GatedDeltaNet {
+    fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let key_dim = cfg.linear_num_key_heads * cfg.linear_key_head_dim;
+        let value_dim = cfg.linear_num_value_heads * cfg.linear_value_head_dim;
+        let conv_dim = key_dim * 2 + value_dim;
+        if !cfg
+            .linear_num_value_heads
+            .is_multiple_of(cfg.linear_num_key_heads)
+        {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2: linear_num_value_heads ({}) must be divisible by linear_num_key_heads ({})",
+                    cfg.linear_num_value_heads, cfg.linear_num_key_heads
+                ),
+            });
+        }
+        if cfg.linear_key_head_dim != cfg.linear_value_head_dim {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2 currently requires equal Gated DeltaNet key/value head dims, got {}/{}",
+                    cfg.linear_key_head_dim, cfg.linear_value_head_dim
+                ),
+            });
+        }
+
+        let in_proj_qkv = linear_no_bias(cfg.hidden_size, conv_dim, vb.pp("in_proj_qkv"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load GDN in_proj_qkv", e))?;
+        let in_proj_z = linear_no_bias(cfg.hidden_size, value_dim, vb.pp("in_proj_z"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load GDN in_proj_z", e))?;
+        let in_proj_b = linear_no_bias(
+            cfg.hidden_size,
+            cfg.linear_num_value_heads,
+            vb.pp("in_proj_b"),
+        )
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load GDN in_proj_b", e))?;
+        let in_proj_a = linear_no_bias(
+            cfg.hidden_size,
+            cfg.linear_num_value_heads,
+            vb.pp("in_proj_a"),
+        )
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load GDN in_proj_a", e))?;
+        let conv_weight = vb
+            .get((conv_dim, 1, cfg.linear_conv_kernel_dim), "conv1d.weight")
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load GDN conv1d", e))?;
+        let decode_conv_weight = conv_weight
+            .to_dtype(DType::F32)
+            .and_then(|weight| weight.squeeze(1))
+            .and_then(|weight| weight.unsqueeze(0))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load GDN decode conv weight", e))?;
+        let conv1d = Conv1d::new(
+            conv_weight,
+            None,
+            Conv1dConfig {
+                padding: cfg.linear_conv_kernel_dim.saturating_sub(1),
+                groups: conv_dim,
+                ..Default::default()
+            },
+        );
+        let dt_bias = vb
+            .get(cfg.linear_num_value_heads, "dt_bias")
+            .and_then(|x| x.to_dtype(DType::F32))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load GDN dt_bias", e))?;
+        let neg_a = vb
+            .get(cfg.linear_num_value_heads, "A_log")
+            .and_then(|x| x.to_dtype(DType::F32))
+            .and_then(|x| x.exp())
+            .and_then(|x| x.neg())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load GDN A_log", e))?;
+        // Qwen3_5RMSNormGated initializes this weight to one and applies a
+        // plain RMSNorm before the SiLU gate. It intentionally differs from
+        // the zero-centred AdditiveRmsNorm used by the decoder layers.
+        let norm = rms_norm(cfg.linear_value_head_dim, cfg.rms_norm_eps, vb.pp("norm"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load GDN norm", e))?;
+        let out_proj = linear_no_bias(value_dim, cfg.hidden_size, vb.pp("out_proj"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load GDN out_proj", e))?;
+
+        Ok(Self {
+            in_proj_qkv,
+            in_proj_z,
+            in_proj_b,
+            in_proj_a,
+            conv1d,
+            decode_conv_weight,
+            dt_bias,
+            neg_a,
+            norm,
+            out_proj,
+            num_key_heads: cfg.linear_num_key_heads,
+            num_value_heads: cfg.linear_num_value_heads,
+            key_head_dim: cfg.linear_key_head_dim,
+            value_head_dim: cfg.linear_value_head_dim,
+            conv_kernel_size: cfg.linear_conv_kernel_dim,
+            conv_state: RefCell::new(None),
+            recurrent_state: RefCell::new(None),
+        })
+    }
+
+    fn causal_conv(&self, mixed: &Tensor) -> Result<Tensor, OCRError> {
+        let (batch, channels, seq_len) = mixed
+            .dims3()
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN convolution input", e))?;
+        let previous = self.conv_state.borrow().clone();
+        let (output, new_state) = match previous.as_ref() {
+            None => {
+                let output = self
+                    .conv1d
+                    .forward(mixed)
+                    .and_then(|output| output.narrow(2, 0, seq_len))
+                    .map_err(|e| {
+                        candle_to_ocr_inference(MODEL_NAME, "GDN causal convolution", e)
+                    })?;
+                let new_state = if seq_len >= self.conv_kernel_size {
+                    mixed.narrow(2, seq_len - self.conv_kernel_size, self.conv_kernel_size)
+                } else {
+                    let padding = Tensor::zeros(
+                        (batch, channels, self.conv_kernel_size - seq_len),
+                        mixed.dtype(),
+                        mixed.device(),
+                    )
+                    .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "pad GDN conv state", e))?;
+                    Tensor::cat(&[&padding, mixed], 2)
+                }
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN update conv state", e))?;
+                (output, new_state)
+            }
+            Some(state) if seq_len == 1 => {
+                // A grouped Conv1d launch with one group per channel is very
+                // expensive for autoregressive decoding. For a single token,
+                // the same depthwise convolution is just a weighted sum of the
+                // shifted cache and the new projection.
+                cached_depthwise_conv_step(
+                    state,
+                    mixed,
+                    &self.decode_conv_weight,
+                    self.conv_kernel_size,
+                )
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN decode convolution", e))?
+            }
+            Some(state) => {
+                let joined = Tensor::cat(&[state, mixed], 2).map_err(|e| {
+                    candle_to_ocr_inference(MODEL_NAME, "join GDN convolution context", e)
+                })?;
+                let conv = Conv1d::new(
+                    self.conv1d.weight().clone(),
+                    None,
+                    Conv1dConfig {
+                        groups: channels,
+                        ..Default::default()
+                    },
+                );
+                let output = conv
+                    .forward(&joined)
+                    .and_then(|output| output.narrow(2, 1, seq_len))
+                    .map_err(|e| {
+                        candle_to_ocr_inference(MODEL_NAME, "GDN causal convolution", e)
+                    })?;
+                let context_len = joined.dim(2).map_err(|e| {
+                    candle_to_ocr_inference(MODEL_NAME, "GDN convolution cache length", e)
+                })?;
+                let new_state = joined
+                    .narrow(
+                        2,
+                        context_len - self.conv_kernel_size,
+                        self.conv_kernel_size,
+                    )
+                    .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN update conv state", e))?;
+                (output, new_state)
+            }
+        };
+        *self.conv_state.borrow_mut() = Some(new_state);
+
+        candle_nn::ops::silu(&output)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN convolution SiLU", e))
+    }
+
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+        let (batch, seq_len, _) = hidden_states
+            .dims3()
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN input shape", e))?;
+        let mixed = self
+            .in_proj_qkv
+            .forward(hidden_states)
+            .and_then(|x| x.transpose(1, 2))
+            .and_then(|x| x.contiguous())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN qkv projection", e))?;
+        let mixed = self
+            .causal_conv(&mixed)?
+            .transpose(1, 2)
+            .and_then(|x| x.contiguous())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN qkv layout", e))?;
+
+        let key_dim = self.num_key_heads * self.key_head_dim;
+        let value_dim = self.num_value_heads * self.value_head_dim;
+        let query = mixed
+            .narrow(D::Minus1, 0, key_dim)
+            .and_then(|x| x.reshape((batch, seq_len, self.num_key_heads, self.key_head_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN query", e))?;
+        let key = mixed
+            .narrow(D::Minus1, key_dim, key_dim)
+            .and_then(|x| x.reshape((batch, seq_len, self.num_key_heads, self.key_head_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN key", e))?;
+        let value = mixed
+            .narrow(D::Minus1, key_dim * 2, value_dim)
+            .and_then(|x| x.reshape((batch, seq_len, self.num_value_heads, self.value_head_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN value", e))?;
+
+        let repeat = self.num_value_heads / self.num_key_heads;
+        let query = if repeat == 1 {
+            query
+        } else {
+            query
+                .unsqueeze(3)
+                .and_then(|x| x.repeat((1, 1, 1, repeat, 1)))
+                .and_then(|x| x.reshape((batch, seq_len, self.num_value_heads, self.key_head_dim)))
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN repeat query heads", e))?
+        };
+        let key = if repeat == 1 {
+            key
+        } else {
+            key.unsqueeze(3)
+                .and_then(|x| x.repeat((1, 1, 1, repeat, 1)))
+                .and_then(|x| x.reshape((batch, seq_len, self.num_value_heads, self.key_head_dim)))
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN repeat key heads", e))?
+        };
+        let packed_qkv = Tensor::cat(&[&query, &key, &value], D::Minus1)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN pack qkv", e))?;
+
+        let beta = self
+            .in_proj_b
+            .forward(hidden_states)
+            .and_then(|x| candle_nn::ops::sigmoid(&x))
+            .and_then(|x| x.to_dtype(DType::F32))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN beta", e))?;
+        let a = self
+            .in_proj_a
+            .forward(hidden_states)
+            .and_then(|x| x.to_dtype(DType::F32))
+            .and_then(|x| x.broadcast_add(&self.dt_bias))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN decay projection", e))?;
+        // Stable equivalent of log(1 + exp(a)), matching torch softplus
+        // without overflowing for large positive decay logits.
+        let softplus = a
+            .relu()
+            .and_then(|positive| {
+                a.abs()
+                    .and_then(|magnitude| magnitude.neg())
+                    .and_then(|negative| negative.exp())
+                    .and_then(|correction| correction + 1.0)
+                    .and_then(|correction| correction.log())
+                    .and_then(|correction| positive + correction)
+            })
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN softplus", e))?;
+        let g = softplus
+            .broadcast_mul(&self.neg_a)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN decay", e))?;
+        let gb = Tensor::stack(&[&g, &beta], D::Minus1)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN pack decay/beta", e))?;
+
+        let initial_state = match self.recurrent_state.borrow().as_ref() {
+            Some(state) => state.clone(),
+            None => Tensor::zeros(
+                (
+                    batch,
+                    self.num_value_heads,
+                    self.key_head_dim,
+                    self.value_head_dim,
+                ),
+                DType::F32,
+                hidden_states.device(),
+            )
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN initial state", e))?,
+        };
+        let (core, final_state) = gated_delta_rule(&packed_qkv, &gb, &initial_state)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN recurrence", e))?;
+        *self.recurrent_state.borrow_mut() = Some(final_state);
+
+        let z = self
+            .in_proj_z
+            .forward(hidden_states)
+            .and_then(|x| x.reshape((batch, seq_len, self.num_value_heads, self.value_head_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN z projection", e))?;
+        let core = self
+            .norm
+            .forward(&core)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN output norm", e))?;
+        let gate = z
+            .to_dtype(DType::F32)
+            .and_then(|z| candle_nn::ops::silu(&z))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN output gate", e))?;
+        let core = core
+            .to_dtype(DType::F32)
+            .and_then(|core| core.broadcast_mul(&gate))
+            .and_then(|core| core.to_dtype(hidden_states.dtype()))
+            .and_then(|core| core.reshape((batch, seq_len, value_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN gated output", e))?;
+        self.out_proj
+            .forward(&core)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN output projection", e))
+    }
+
+    fn clear_cache(&self) {
+        *self.conv_state.borrow_mut() = None;
+        *self.recurrent_state.borrow_mut() = None;
+    }
+}
+
+#[derive(Debug)]
+struct FullAttention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    q_norm: AdditiveRmsNorm,
+    k_norm: AdditiveRmsNorm,
+    num_heads: usize,
+    num_kv_heads: usize,
+    num_kv_groups: usize,
+    head_dim: usize,
+    scaling: f64,
+    kv_cache: RefCell<TrimmableKvCache>,
+}
+
+impl FullAttention {
+    fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        if !cfg
+            .num_attention_heads
+            .is_multiple_of(cfg.num_key_value_heads)
+        {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2: num_attention_heads ({}) must be divisible by num_key_value_heads ({})",
+                    cfg.num_attention_heads, cfg.num_key_value_heads
+                ),
+            });
+        }
+        let q_proj = linear_no_bias(
+            cfg.hidden_size,
+            cfg.num_attention_heads * cfg.head_dim * 2,
+            vb.pp("q_proj"),
+        )
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load attention q_proj", e))?;
+        let k_proj = linear_no_bias(
+            cfg.hidden_size,
+            cfg.num_key_value_heads * cfg.head_dim,
+            vb.pp("k_proj"),
+        )
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load attention k_proj", e))?;
+        let v_proj = linear_no_bias(
+            cfg.hidden_size,
+            cfg.num_key_value_heads * cfg.head_dim,
+            vb.pp("v_proj"),
+        )
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load attention v_proj", e))?;
+        let o_proj = linear_no_bias(
+            cfg.num_attention_heads * cfg.head_dim,
+            cfg.hidden_size,
+            vb.pp("o_proj"),
+        )
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load attention o_proj", e))?;
+        let q_norm = AdditiveRmsNorm::load(cfg.head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
+        let k_norm = AdditiveRmsNorm::load(cfg.head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            num_heads: cfg.num_attention_heads,
+            num_kv_heads: cfg.num_key_value_heads,
+            num_kv_groups: cfg.num_attention_heads / cfg.num_key_value_heads,
+            head_dim: cfg.head_dim,
+            scaling: 1.0 / (cfg.head_dim as f64).sqrt(),
+            kv_cache: RefCell::new(TrimmableKvCache::new(2, cfg.max_position_embeddings)),
+        })
+    }
+
+    fn apply_rope(&self, tensor: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, OCRError> {
+        let rotary_dim = cos
+            .dim(D::Minus1)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention rotary dimension", e))?;
+        let rotary = tensor
+            .narrow(D::Minus1, 0, rotary_dim)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention rotary slice", e))?;
+        let pass = tensor
+            .narrow(D::Minus1, rotary_dim, self.head_dim - rotary_dim)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention pass slice", e))?;
+        let cos = cos
+            .unsqueeze(1)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention cos layout", e))?;
+        let sin = sin
+            .unsqueeze(1)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention sin layout", e))?;
+        let rotated = rotate_half(&rotary)?;
+        let embedded = (rotary
+            .broadcast_mul(&cos)
+            .and_then(|lhs| rotated.broadcast_mul(&sin).and_then(|rhs| &lhs + &rhs)))
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "apply attention RoPE", e))?;
+        Tensor::cat(&[&embedded, &pass], D::Minus1)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention RoPE output", e))
+    }
+
+    fn forward(
+        &self,
+        hidden_states: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<Tensor, OCRError> {
+        let (batch, seq_len, _) = hidden_states
+            .dims3()
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention input", e))?;
+        let qg = self
+            .q_proj
+            .forward(hidden_states)
+            .and_then(|x| x.reshape((batch, seq_len, self.num_heads, self.head_dim * 2)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention q/g projection", e))?;
+        let q = qg
+            .narrow(D::Minus1, 0, self.head_dim)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention q slice", e))?;
+        let gate = qg
+            .narrow(D::Minus1, self.head_dim, self.head_dim)
+            .and_then(|x| x.reshape((batch, seq_len, self.num_heads * self.head_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention gate slice", e))?;
+        let q = self
+            .q_norm
+            .forward(&q)?
+            .transpose(1, 2)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention q layout", e))?;
+        let k = self
+            .k_proj
+            .forward(hidden_states)
+            .and_then(|x| x.reshape((batch, seq_len, self.num_kv_heads, self.head_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention k projection", e))?;
+        let k = self
+            .k_norm
+            .forward(&k)?
+            .transpose(1, 2)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention k layout", e))?;
+        let v = self
+            .v_proj
+            .forward(hidden_states)
+            .and_then(|x| x.reshape((batch, seq_len, self.num_kv_heads, self.head_dim)))
+            .and_then(|x| x.transpose(1, 2))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention v projection", e))?;
+        let q = self
+            .apply_rope(&q, cos, sin)?
+            .contiguous()
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention q contiguous", e))?;
+        let k = self
+            .apply_rope(&k, cos, sin)?
+            .contiguous()
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention k contiguous", e))?;
+        let v = v
+            .contiguous()
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention v contiguous", e))?;
+        let (k, v) = self
+            .kv_cache
+            .borrow_mut()
+            .append(&k, &v)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention KV cache", e))?;
+
+        let output = match flash_attention(&q, &k, &v, self.scaling, seq_len > 1)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "flash attention", e))?
+        {
+            Some(output) => output,
+            None => scaled_dot_product_attention_gqa(
+                &q,
+                &k,
+                &v,
+                None,
+                self.scaling,
+                true,
+                self.num_kv_groups,
+            )
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "grouped-query attention", e))?,
+        };
+        let output = output
+            .transpose(1, 2)
+            .and_then(|x| x.reshape((batch, seq_len, self.num_heads * self.head_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention output layout", e))?;
+        let gate = candle_nn::ops::sigmoid(&gate)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention output gate", e))?;
+        self.o_proj
+            .forward(
+                &(&output * &gate).map_err(|e| {
+                    candle_to_ocr_inference(MODEL_NAME, "attention gated output", e)
+                })?,
+            )
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention output projection", e))
+    }
+
+    fn clear_cache(&self) {
+        self.kv_cache.borrow_mut().reset();
+    }
+}
+
+#[derive(Debug)]
+enum TokenMixer {
+    Linear(GatedDeltaNet),
+    Full(FullAttention),
+}
+
+#[derive(Debug)]
+struct DecoderLayer {
+    mixer: TokenMixer,
+    mlp: OvisMlp,
+    input_layernorm: AdditiveRmsNorm,
+    post_attention_layernorm: AdditiveRmsNorm,
+}
+
+impl DecoderLayer {
+    fn load(cfg: &OvisOcr2TextConfig, layer_type: &str, vb: VarBuilder) -> Result<Self, OCRError> {
+        let mixer = match layer_type {
+            "linear_attention" => {
+                TokenMixer::Linear(GatedDeltaNet::load(cfg, vb.pp("linear_attn"))?)
+            }
+            "full_attention" => TokenMixer::Full(FullAttention::load(cfg, vb.pp("self_attn"))?),
+            other => {
+                return Err(OCRError::ConfigError {
+                    message: format!("OvisOCR2: unsupported decoder layer type '{other}'"),
+                });
+            }
+        };
+        Ok(Self {
+            mixer,
+            mlp: OvisMlp::load(cfg, vb.pp("mlp"))?,
+            input_layernorm: AdditiveRmsNorm::load(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("input_layernorm"),
+            )?,
+            post_attention_layernorm: AdditiveRmsNorm::load(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("post_attention_layernorm"),
+            )?,
+        })
+    }
+
+    fn forward(
+        &self,
+        hidden_states: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<Tensor, OCRError> {
+        let residual = hidden_states.clone();
+        let normalized = self.input_layernorm.forward(hidden_states)?;
+        let mixed = match &self.mixer {
+            TokenMixer::Linear(layer) => layer.forward(&normalized)?,
+            TokenMixer::Full(layer) => layer.forward(&normalized, cos, sin)?,
+        };
+        let hidden_states = (&residual + &mixed)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "decoder mixer residual", e))?;
+        let residual = hidden_states.clone();
+        let hidden_states = self.post_attention_layernorm.forward(&hidden_states)?;
+        let hidden_states = self.mlp.forward(&hidden_states)?;
+        (&residual + &hidden_states)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "decoder MLP residual", e))
+    }
+
+    fn clear_cache(&self) {
+        match &self.mixer {
+            TokenMixer::Linear(layer) => layer.clear_cache(),
+            TokenMixer::Full(layer) => layer.clear_cache(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TextRotaryEmbedding {
+    rotary: RotaryEmbedding,
+    axis_ids: Tensor,
+}
+
+impl TextRotaryEmbedding {
+    fn new(cfg: &OvisOcr2TextConfig, device: &Device) -> Result<Self, OCRError> {
+        let rotary_dim = (cfg.head_dim as f64 * cfg.rope_parameters.partial_rotary_factor) as usize;
+        if rotary_dim == 0 || !rotary_dim.is_multiple_of(2) {
+            return Err(OCRError::ConfigError {
+                message: format!("OvisOCR2: invalid rotary dimension {rotary_dim}"),
+            });
+        }
+        let half = rotary_dim / 2;
+        if cfg.rope_parameters.mrope_section.iter().sum::<usize>() != half {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2: mrope_section {:?} must sum to rotary_dim/2 ({half})",
+                    cfg.rope_parameters.mrope_section
+                ),
+            });
+        }
+        let rotary =
+            RotaryEmbedding::new_multi_axis(rotary_dim, cfg.rope_parameters.rope_theta, 3, device)?;
+        let axis_ids = Tensor::from_vec(
+            interleaved_axis_ids(rotary_dim, &cfg.rope_parameters.mrope_section),
+            (1, 1, rotary_dim, 1),
+            device,
+        )
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "create mRoPE axis map", e))?;
+        Ok(Self { rotary, axis_ids })
+    }
+
+    fn forward(&self, position_ids: &Tensor, dtype: DType) -> Result<(Tensor, Tensor), OCRError> {
+        let (cos, sin) = self.rotary.forward_multi_axis(position_ids, dtype)?;
+        Ok((self.select_axes(&cos)?, self.select_axes(&sin)?))
+    }
+
+    fn select_axes(&self, values: &Tensor) -> Result<Tensor, OCRError> {
+        let (_, batch, seq_len, rotary_dim) = values
+            .dims4()
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "mRoPE tensor shape", e))?;
+        let values = values
+            .permute((1, 2, 3, 0))
+            .and_then(|values| values.contiguous())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "mRoPE axis layout", e))?;
+        let axis_ids = self
+            .axis_ids
+            .expand((batch, seq_len, rotary_dim, 1))
+            .and_then(|axis_ids| axis_ids.contiguous())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "expand mRoPE axis map", e))?;
+        values
+            .gather(&axis_ids, 3)
+            .and_then(|values| values.squeeze(3))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "select mRoPE axes", e))
+    }
+}
+
+fn interleaved_axis_ids(rotary_dim: usize, mrope_section: &[usize]) -> Vec<u32> {
+    let half = rotary_dim / 2;
+    let h_limit = mrope_section[1] * 3;
+    let w_limit = mrope_section[2] * 3;
+    (0..rotary_dim)
+        .map(|dimension| {
+            let freq_idx = dimension % half;
+            if freq_idx % 3 == 1 && freq_idx < h_limit {
+                1
+            } else if freq_idx % 3 == 2 && freq_idx < w_limit {
+                2
+            } else {
+                0
+            }
+        })
+        .collect()
+}
+
+pub(crate) struct OvisOcr2TextModel {
+    embed_tokens: Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: AdditiveRmsNorm,
+    rotary_emb: TextRotaryEmbedding,
+}
+
+impl OvisOcr2TextModel {
+    pub(crate) fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        if cfg.layer_types.len() != cfg.num_hidden_layers {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "OvisOCR2: layer_types has {} entries, expected {}",
+                    cfg.layer_types.len(),
+                    cfg.num_hidden_layers
+                ),
+            });
+        }
+        let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("embed_tokens"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load token embeddings", e))?;
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        for (index, layer_type) in cfg.layer_types.iter().enumerate() {
+            layers.push(DecoderLayer::load(
+                cfg,
+                layer_type,
+                vb.pp(format!("layers.{index}")),
+            )?);
+        }
+        let norm = AdditiveRmsNorm::load(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("norm"))?;
+        let rotary_emb = TextRotaryEmbedding::new(cfg, vb.device())?;
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+            rotary_emb,
+        })
+    }
+
+    pub(crate) fn embed(&self, input_ids: &Tensor) -> Result<Tensor, OCRError> {
+        self.embed_tokens
+            .forward(input_ids)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "token embedding", e))
+    }
+
+    pub(crate) fn token_embedding_weight(&self) -> Tensor {
+        self.embed_tokens.embeddings().clone()
+    }
+
+    pub(crate) fn forward(
+        &self,
+        inputs_embeds: &Tensor,
+        position_ids: &Tensor,
+    ) -> Result<Tensor, OCRError> {
+        let (cos, sin) = self
+            .rotary_emb
+            .forward(position_ids, inputs_embeds.dtype())?;
+        let mut hidden_states = inputs_embeds.clone();
+        for layer in &self.layers {
+            hidden_states = layer.forward(&hidden_states, &cos, &sin)?;
+        }
+        self.norm.forward(&hidden_states)
+    }
+
+    pub(crate) fn clear_cache(&self) {
+        for layer in &self.layers {
+            layer.clear_cache();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::IndexOp;
+
+    #[test]
+    fn cached_depthwise_step_matches_grouped_convolution() -> candle_core::Result<()> {
+        let state = Tensor::from_vec(
+            vec![1f32, 2., 3., 4., 5., 6., 7., 8.],
+            (1, 2, 4),
+            &Device::Cpu,
+        )?;
+        let mixed = Tensor::from_vec(vec![9f32, 10.], (1, 2, 1), &Device::Cpu)?;
+        let weight = Tensor::from_vec(
+            vec![0.1f32, 0.2, 0.3, 0.4, -0.5, 0.25, 0.75, 1.0],
+            (2, 1, 4),
+            &Device::Cpu,
+        )?;
+        let decode_weight = weight.squeeze(1)?.unsqueeze(0)?;
+        let (actual, new_state) = cached_depthwise_conv_step(&state, &mixed, &decode_weight, 4)?;
+
+        let joined = Tensor::cat(&[&state, &mixed], 2)?;
+        let conv = Conv1d::new(
+            weight,
+            None,
+            Conv1dConfig {
+                groups: 2,
+                ..Default::default()
+            },
+        );
+        let expected = conv.forward(&joined)?.narrow(2, 1, 1)?;
+        assert_eq!(actual.to_vec3::<f32>()?, expected.to_vec3::<f32>()?);
+        assert_eq!(
+            new_state.to_vec3::<f32>()?,
+            joined.narrow(2, 1, 4)?.to_vec3::<f32>()?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cached_depthwise_step_matches_low_precision_convolution() -> candle_core::Result<()> {
+        for dtype in [DType::BF16, DType::F16] {
+            let state = Tensor::from_vec(
+                vec![1f32, 2., 3., 4., 5., 6., 7., 8.],
+                (1, 2, 4),
+                &Device::Cpu,
+            )?
+            .to_dtype(dtype)?;
+            let mixed =
+                Tensor::from_vec(vec![9f32, 10.], (1, 2, 1), &Device::Cpu)?.to_dtype(dtype)?;
+            let weight = Tensor::from_vec(
+                vec![0.1f32, 0.2, 0.3, 0.4, -0.5, 0.25, 0.75, 1.0],
+                (2, 1, 4),
+                &Device::Cpu,
+            )?
+            .to_dtype(dtype)?;
+            let decode_weight = weight.to_dtype(DType::F32)?.squeeze(1)?.unsqueeze(0)?;
+            let (actual, _) = cached_depthwise_conv_step(&state, &mixed, &decode_weight, 4)?;
+            let expected = match dtype {
+                DType::BF16 => vec![vec![vec![5.59375f32], vec![14.75]]],
+                DType::F16 => vec![vec![vec![5.597_656_3f32], vec![14.75]]],
+                _ => unreachable!(),
+            };
+            assert_eq!(actual.dtype(), dtype);
+            assert_eq!(
+                actual.to_dtype(DType::F32)?.to_vec3::<f32>()?,
+                expected,
+                "cached convolution mismatch for {dtype:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn cached_depthwise_step_matches_cuda_low_precision_convolution() -> candle_core::Result<()> {
+        let Ok(device) = Device::new_cuda(0) else {
+            return Ok(());
+        };
+        for dtype in [DType::BF16, DType::F16] {
+            let state =
+                Tensor::from_vec(vec![1f32, 2., 3., 4., 5., 6., 7., 8.], (1, 2, 4), &device)?
+                    .to_dtype(dtype)?;
+            let mixed = Tensor::from_vec(vec![9f32, 10.], (1, 2, 1), &device)?.to_dtype(dtype)?;
+            let weight = Tensor::from_vec(
+                vec![0.1f32, 0.2, 0.3, 0.4, -0.5, 0.25, 0.75, 1.0],
+                (2, 1, 4),
+                &device,
+            )?
+            .to_dtype(dtype)?;
+            let decode_weight = weight.to_dtype(DType::F32)?.squeeze(1)?.unsqueeze(0)?;
+            let (actual, _) = cached_depthwise_conv_step(&state, &mixed, &decode_weight, 4)?;
+
+            let joined = Tensor::cat(&[&state, &mixed], 2)?;
+            let conv = Conv1d::new(
+                weight,
+                None,
+                Conv1dConfig {
+                    groups: 2,
+                    ..Default::default()
+                },
+            );
+            let expected = conv.forward(&joined)?.narrow(2, 1, 1)?;
+            assert_eq!(actual.dtype(), dtype);
+            assert_eq!(
+                actual
+                    .to_dtype(DType::F32)?
+                    .to_device(&Device::Cpu)?
+                    .to_vec3::<f32>()?,
+                expected
+                    .to_dtype(DType::F32)?
+                    .to_device(&Device::Cpu)?
+                    .to_vec3::<f32>()?,
+                "cached convolution mismatch for {dtype:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn qwen35_mrope_axes_are_interleaved() {
+        let rotary_dim = 64;
+        let sections = [11, 11, 10];
+        let rope = TextRotaryEmbedding {
+            rotary: RotaryEmbedding::new_multi_axis(rotary_dim, 1.0, 3, &Device::Cpu).unwrap(),
+            axis_ids: Tensor::from_vec(
+                interleaved_axis_ids(rotary_dim, &sections),
+                (1, 1, rotary_dim, 1),
+                &Device::Cpu,
+            )
+            .unwrap(),
+        };
+        let ids = Tensor::from_vec(
+            [vec![10i64; 32], vec![20i64; 32], vec![30i64; 32]].concat(),
+            (3, 1, 32),
+            &Device::Cpu,
+        )
+        .unwrap();
+        let (cos, _) = rope.forward(&ids, DType::F32).unwrap();
+        let values = cos.i((0, 0)).unwrap().to_vec1::<f32>().unwrap();
+        assert!((values[0] - 10f32.cos()).abs() < 1e-6);
+        assert!((values[1] - 20f32.cos()).abs() < 1e-6);
+        assert!((values[2] - 30f32.cos()).abs() < 1e-6);
+        assert!((values[31] - 20f32.cos()).abs() < 1e-6);
+    }
+}

--- a/oar-ocr-vl/src/ovisocr2/vision.rs
+++ b/oar-ocr-vl/src/ovisocr2/vision.rs
@@ -1,0 +1,762 @@
+use super::config::OvisOcr2VisionConfig;
+use crate::attention::{
+    VISION_CHUNKED_ATTN_CHUNK_SIZE, VISION_CHUNKED_ATTN_SEQ_THRESHOLD, chunked_vision_attention,
+    flash_attention, on_compute_device, scaled_dot_product_attention,
+};
+use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
+use candle_core::{DType, Device, IndexOp, Tensor};
+use candle_nn::{
+    Activation, LayerNorm, LayerNormConfig, Linear, Module, VarBuilder, layer_norm, linear,
+};
+use oar_ocr_core::core::OCRError;
+
+#[derive(Debug, Clone)]
+struct VisionPatchEmbed {
+    weight: Tensor,
+    bias: Tensor,
+}
+
+impl VisionPatchEmbed {
+    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let vb = vb.pp("patch_embed").pp("proj");
+        let patch_dim = cfg.in_channels * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size;
+        let weight = vb
+            .get(
+                (
+                    cfg.hidden_size,
+                    cfg.in_channels,
+                    cfg.temporal_patch_size,
+                    cfg.patch_size,
+                    cfg.patch_size,
+                ),
+                "weight",
+            )
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision patch weight", e))?
+            .reshape((cfg.hidden_size, patch_dim))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "reshape vision patch weight", e))?;
+        let bias = vb
+            .get(cfg.hidden_size, "bias")
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision patch bias", e))?;
+        Ok(Self { weight, bias })
+    }
+
+    fn forward(&self, patches: &Tensor) -> Result<Tensor, OCRError> {
+        let patches = patches
+            .to_dtype(self.weight.dtype())
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "cast vision patches", e))?;
+        let weight_t = self
+            .weight
+            .transpose(0, 1)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "transpose patch weight", e))?;
+        patches
+            .matmul(&weight_t)
+            .and_then(|output| output.broadcast_add(&self.bias))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision patch embedding", e))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VisionRotaryEmbedding {
+    inv_freq: Tensor,
+}
+
+impl VisionRotaryEmbedding {
+    fn new(dim: usize, device: &Device) -> Result<Self, OCRError> {
+        let inv_freq = crate::utils::vision_inv_freq(dim, 10_000.0, "OvisOCR2", device)?;
+        Ok(Self { inv_freq })
+    }
+
+    fn forward(&self, sequence_length: usize) -> Result<Tensor, OCRError> {
+        let device = self.inv_freq.device();
+        on_compute_device(device, |compute_device| {
+            let positions = Tensor::arange(0u32, sequence_length as u32, compute_device)?
+                .to_dtype(DType::F32)?;
+            let inv_freq = self
+                .inv_freq
+                .to_device(compute_device)?
+                .to_dtype(DType::F32)?;
+            positions.unsqueeze(1)?.matmul(&inv_freq.unsqueeze(0)?)
+        })
+        .map_err(|e| {
+            candle_to_ocr_processing(
+                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                "OvisOCR2: build vision rotary frequency table",
+                e,
+            )
+        })
+    }
+}
+
+fn apply_rotary_pos_emb_vision(
+    q: &Tensor,
+    k: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+) -> Result<(Tensor, Tensor), OCRError> {
+    let q_dtype = q.dtype();
+    let k_dtype = k.dtype();
+    let q = q
+        .to_dtype(DType::F32)
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "cast vision query", e))?;
+    let k = k
+        .to_dtype(DType::F32)
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "cast vision key", e))?;
+    let cos = cos
+        .unsqueeze(1)
+        .and_then(|value| value.to_dtype(DType::F32))
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "prepare vision rotary cos", e))?;
+    let sin = sin
+        .unsqueeze(1)
+        .and_then(|value| value.to_dtype(DType::F32))
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "prepare vision rotary sin", e))?;
+
+    let rotate_q = crate::utils::rotate_half(&q)?;
+    let rotate_k = crate::utils::rotate_half(&k)?;
+    let q = q
+        .broadcast_mul(&cos)
+        .and_then(|value| value.broadcast_add(&rotate_q.broadcast_mul(&sin)?))
+        .and_then(|value| value.to_dtype(q_dtype))
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "apply query vision rotary", e))?;
+    let k = k
+        .broadcast_mul(&cos)
+        .and_then(|value| value.broadcast_add(&rotate_k.broadcast_mul(&sin)?))
+        .and_then(|value| value.to_dtype(k_dtype))
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "apply key vision rotary", e))?;
+    Ok((q, k))
+}
+
+#[derive(Debug, Clone)]
+struct VisionAttention {
+    qkv: Linear,
+    proj: Linear,
+    num_heads: usize,
+    head_dim: usize,
+    scale: f64,
+}
+
+impl VisionAttention {
+    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let head_dim = cfg.head_dim()?;
+        let qkv = linear(
+            cfg.hidden_size,
+            cfg.hidden_size * 3,
+            vb.pp("attn").pp("qkv"),
+        )
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision qkv", e))?;
+        let proj = linear(cfg.hidden_size, cfg.hidden_size, vb.pp("attn").pp("proj"))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision projection", e))?;
+        Ok(Self {
+            qkv,
+            proj,
+            num_heads: cfg.num_heads,
+            head_dim,
+            scale: 1.0 / (head_dim as f64).sqrt(),
+        })
+    }
+
+    fn forward(
+        &self,
+        hidden_states: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<Tensor, OCRError> {
+        let sequence_length = hidden_states
+            .dim(0)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision sequence length", e))?;
+        let qkv = self
+            .qkv
+            .forward(hidden_states)
+            .and_then(|qkv| qkv.reshape((sequence_length, 3, self.num_heads, self.head_dim)))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision qkv projection", e))?;
+        let q = qkv
+            .i((.., 0, .., ..))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "slice vision query", e))?;
+        let k = qkv
+            .i((.., 1, .., ..))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "slice vision key", e))?;
+        let v = qkv
+            .i((.., 2, .., ..))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "slice vision value", e))?;
+        let (q, k) = apply_rotary_pos_emb_vision(&q, &k, cos, sin)?;
+
+        let q = q
+            .transpose(0, 1)
+            .and_then(|value| value.unsqueeze(0))
+            .and_then(|value| value.contiguous())
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "layout vision query", e))?;
+        let k = k
+            .transpose(0, 1)
+            .and_then(|value| value.unsqueeze(0))
+            .and_then(|value| value.contiguous())
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "layout vision key", e))?;
+        let v = v
+            .transpose(0, 1)
+            .and_then(|value| value.unsqueeze(0))
+            .and_then(|value| value.contiguous())
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "layout vision value", e))?;
+
+        let attention = match flash_attention(&q, &k, &v, self.scale, false)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision flash attention", e))?
+        {
+            Some(output) => output,
+            None if sequence_length > VISION_CHUNKED_ATTN_SEQ_THRESHOLD => {
+                chunked_vision_attention(&q, &k, &v, self.scale, VISION_CHUNKED_ATTN_CHUNK_SIZE)
+                    .map_err(|e| {
+                        candle_to_ocr_inference("OvisOCR2", "chunked vision attention", e)
+                    })?
+            }
+            None => scaled_dot_product_attention(&q, &k, &v, None, self.scale, false)
+                .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision attention", e))?,
+        };
+        let attention = attention
+            .transpose(1, 2)
+            .and_then(|value| value.reshape((sequence_length, self.num_heads * self.head_dim)))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "reshape vision attention", e))?;
+        self.proj
+            .forward(&attention)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision output projection", e))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VisionMlp {
+    linear_fc1: Linear,
+    linear_fc2: Linear,
+    activation: Activation,
+}
+
+impl VisionMlp {
+    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let linear_fc1 = linear(
+            cfg.hidden_size,
+            cfg.intermediate_size,
+            vb.pp("mlp").pp("linear_fc1"),
+        )
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision MLP fc1", e))?;
+        let linear_fc2 = linear(
+            cfg.intermediate_size,
+            cfg.hidden_size,
+            vb.pp("mlp").pp("linear_fc2"),
+        )
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision MLP fc2", e))?;
+        Ok(Self {
+            linear_fc1,
+            linear_fc2,
+            activation: cfg.hidden_act,
+        })
+    }
+
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+        let hidden_states = self
+            .linear_fc1
+            .forward(hidden_states)
+            .and_then(|value| self.activation.forward(&value))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision MLP fc1", e))?;
+        self.linear_fc2
+            .forward(&hidden_states)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision MLP fc2", e))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VisionBlock {
+    norm1: LayerNorm,
+    norm2: LayerNorm,
+    attention: VisionAttention,
+    mlp: VisionMlp,
+}
+
+impl VisionBlock {
+    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let norm_cfg = LayerNormConfig {
+            eps: 1e-6,
+            ..Default::default()
+        };
+        let norm1 = layer_norm(cfg.hidden_size, norm_cfg, vb.pp("norm1"))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision norm1", e))?;
+        let norm2 = layer_norm(cfg.hidden_size, norm_cfg, vb.pp("norm2"))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision norm2", e))?;
+        let attention = VisionAttention::load(cfg, vb.clone())?;
+        let mlp = VisionMlp::load(cfg, vb)?;
+        Ok(Self {
+            norm1,
+            norm2,
+            attention,
+            mlp,
+        })
+    }
+
+    fn forward(
+        &self,
+        hidden_states: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<Tensor, OCRError> {
+        let normed = self
+            .norm1
+            .forward(hidden_states)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision norm1", e))?;
+        let attention = self.attention.forward(&normed, cos, sin)?;
+        let hidden_states = (hidden_states + attention).map_err(|e| {
+            candle_to_ocr_processing(
+                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                "OvisOCR2: vision attention residual",
+                e,
+            )
+        })?;
+        let normed = self
+            .norm2
+            .forward(&hidden_states)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision norm2", e))?;
+        let mlp = self.mlp.forward(&normed)?;
+        (hidden_states + mlp).map_err(|e| {
+            candle_to_ocr_processing(
+                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                "OvisOCR2: vision MLP residual",
+                e,
+            )
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VisionPatchMerger {
+    norm: LayerNorm,
+    linear_fc1: Linear,
+    linear_fc2: Linear,
+    merged_hidden_size: usize,
+    merge_group: usize,
+}
+
+impl VisionPatchMerger {
+    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let vb = vb.pp("merger");
+        let norm_cfg = LayerNormConfig {
+            eps: 1e-6,
+            ..Default::default()
+        };
+        let norm = layer_norm(cfg.hidden_size, norm_cfg, vb.pp("norm"))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision merger norm", e))?;
+        let merge_group = cfg.spatial_merge_size * cfg.spatial_merge_size;
+        let merged_hidden_size = cfg.hidden_size * merge_group;
+        let linear_fc1 = linear(merged_hidden_size, merged_hidden_size, vb.pp("linear_fc1"))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision merger fc1", e))?;
+        let linear_fc2 = linear(merged_hidden_size, cfg.out_hidden_size, vb.pp("linear_fc2"))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "load vision merger fc2", e))?;
+        Ok(Self {
+            norm,
+            linear_fc1,
+            linear_fc2,
+            merged_hidden_size,
+            merge_group,
+        })
+    }
+
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+        let num_patches = hidden_states
+            .dim(0)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision merger patch count", e))?;
+        if !num_patches.is_multiple_of(self.merge_group) {
+            return Err(OCRError::InvalidInput {
+                message: format!(
+                    "OvisOCR2 vision merger expected patch count divisible by {}, got {num_patches}",
+                    self.merge_group
+                ),
+            });
+        }
+        let hidden_states = self
+            .norm
+            .forward(hidden_states)
+            .and_then(|value| {
+                value.reshape((num_patches / self.merge_group, self.merged_hidden_size))
+            })
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision merger norm/reshape", e))?;
+        let hidden_states = self
+            .linear_fc1
+            .forward(&hidden_states)
+            .and_then(|value| value.gelu_erf())
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision merger fc1", e))?;
+        self.linear_fc2
+            .forward(&hidden_states)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision merger fc2", e))
+    }
+}
+
+pub struct OvisOcr2VisionModel {
+    patch_embed: VisionPatchEmbed,
+    position_embedding: Tensor,
+    position_grid_size: usize,
+    blocks: Vec<VisionBlock>,
+    merger: VisionPatchMerger,
+    rotary_embedding: VisionRotaryEmbedding,
+    spatial_merge_size: usize,
+}
+
+impl OvisOcr2VisionModel {
+    pub fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        cfg.validate()?;
+        let patch_embed = VisionPatchEmbed::load(cfg, vb.clone())?;
+        let position_embedding = vb
+            .get(
+                (cfg.num_position_embeddings, cfg.hidden_size),
+                "pos_embed.weight",
+            )
+            .map_err(|e| {
+                candle_to_ocr_inference("OvisOCR2", "load vision position embedding", e)
+            })?;
+        let position_grid_size = cfg.position_grid_size()?;
+        let mut blocks = Vec::with_capacity(cfg.depth);
+        for index in 0..cfg.depth {
+            blocks.push(VisionBlock::load(cfg, vb.pp("blocks").pp(index))?);
+        }
+        let merger = VisionPatchMerger::load(cfg, vb.clone())?;
+        let rotary_embedding = VisionRotaryEmbedding::new(cfg.head_dim()? / 2, vb.device())?;
+        Ok(Self {
+            patch_embed,
+            position_embedding,
+            position_grid_size,
+            blocks,
+            merger,
+            rotary_embedding,
+            spatial_merge_size: cfg.spatial_merge_size,
+        })
+    }
+
+    pub fn forward(
+        &self,
+        pixel_values: &Tensor,
+        grid_thw: (usize, usize, usize),
+    ) -> Result<Tensor, OCRError> {
+        let (grid_t, grid_h, grid_w) = grid_thw;
+        if grid_t == 0 || grid_h == 0 || grid_w == 0 {
+            return Err(OCRError::InvalidInput {
+                message: format!("OvisOCR2 vision grid must be non-zero, got {grid_thw:?}"),
+            });
+        }
+        if !grid_h.is_multiple_of(self.spatial_merge_size)
+            || !grid_w.is_multiple_of(self.spatial_merge_size)
+        {
+            return Err(OCRError::InvalidInput {
+                message: format!(
+                    "OvisOCR2 vision grid {grid_h}x{grid_w} must be divisible by merge_size {}",
+                    self.spatial_merge_size
+                ),
+            });
+        }
+        let num_patches = grid_t
+            .checked_mul(grid_h)
+            .and_then(|value| value.checked_mul(grid_w))
+            .ok_or_else(|| OCRError::InvalidInput {
+                message: "OvisOCR2 vision patch count overflow".to_string(),
+            })?;
+        if pixel_values.dim(0).map_err(|e| {
+            candle_to_ocr_inference("OvisOCR2", "read vision pixel_values length", e)
+        })? != num_patches
+        {
+            return Err(OCRError::InvalidInput {
+                message: format!(
+                    "OvisOCR2 pixel_values patch count ({}) does not match grid {grid_thw:?} ({num_patches})",
+                    pixel_values.dims().first().copied().unwrap_or(0)
+                ),
+            });
+        }
+
+        let mut hidden_states = self.patch_embed.forward(pixel_values)?;
+        let position_embedding = interpolate_position_embedding(
+            &self.position_embedding,
+            self.position_grid_size,
+            grid_thw,
+            self.spatial_merge_size,
+        )?;
+        hidden_states = hidden_states
+            .broadcast_add(&position_embedding)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "add vision position embedding", e))?;
+
+        let (cos, sin) = build_vision_rotary_embeddings(
+            &self.rotary_embedding,
+            grid_thw,
+            self.spatial_merge_size,
+            pixel_values.device(),
+        )?;
+        for block in &self.blocks {
+            hidden_states = block.forward(&hidden_states, &cos, &sin)?;
+        }
+        self.merger.forward(&hidden_states)
+    }
+}
+
+fn merge_grouped_spatial_coordinates(
+    grid_thw: (usize, usize, usize),
+    merge_size: usize,
+) -> Result<Vec<(usize, usize)>, OCRError> {
+    let (grid_t, grid_h, grid_w) = grid_thw;
+    if grid_t == 0
+        || grid_h == 0
+        || grid_w == 0
+        || merge_size == 0
+        || !grid_h.is_multiple_of(merge_size)
+        || !grid_w.is_multiple_of(merge_size)
+    {
+        return Err(OCRError::InvalidInput {
+            message: format!(
+                "OvisOCR2 invalid merge-grouped grid: grid={grid_thw:?}, merge={merge_size}"
+            ),
+        });
+    }
+    let num_patches = grid_t
+        .checked_mul(grid_h)
+        .and_then(|value| value.checked_mul(grid_w))
+        .ok_or_else(|| OCRError::InvalidInput {
+            message: "OvisOCR2 merge-grouped patch count overflow".to_string(),
+        })?;
+    let mut coordinates = Vec::with_capacity(num_patches);
+    for _ in 0..grid_t {
+        for height_block in 0..(grid_h / merge_size) {
+            for width_block in 0..(grid_w / merge_size) {
+                for height_inner in 0..merge_size {
+                    for width_inner in 0..merge_size {
+                        coordinates.push((
+                            height_block * merge_size + height_inner,
+                            width_block * merge_size + width_inner,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    Ok(coordinates)
+}
+
+fn interpolate_position_embedding(
+    position_embedding: &Tensor,
+    base_grid_size: usize,
+    grid_thw: (usize, usize, usize),
+    merge_size: usize,
+) -> Result<Tensor, OCRError> {
+    let (_, grid_h, grid_w) = grid_thw;
+    if base_grid_size == 0 {
+        return Err(OCRError::InvalidInput {
+            message: format!(
+                "OvisOCR2 invalid learned-position grid: base={base_grid_size}, grid={grid_thw:?}, merge={merge_size}"
+            ),
+        });
+    }
+    let (num_positions, hidden_size) = position_embedding
+        .dims2()
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "position embedding shape", e))?;
+    if num_positions != base_grid_size * base_grid_size {
+        return Err(OCRError::ConfigError {
+            message: format!(
+                "OvisOCR2 position embedding rows ({num_positions}) do not match base grid {base_grid_size}x{base_grid_size}"
+            ),
+        });
+    }
+
+    let coordinates = merge_grouped_spatial_coordinates(grid_thw, merge_size)?;
+    let num_patches = coordinates.len();
+    let mut index00 = Vec::with_capacity(num_patches);
+    let mut index01 = Vec::with_capacity(num_patches);
+    let mut index10 = Vec::with_capacity(num_patches);
+    let mut index11 = Vec::with_capacity(num_patches);
+    let mut weight00 = Vec::with_capacity(num_patches);
+    let mut weight01 = Vec::with_capacity(num_patches);
+    let mut weight10 = Vec::with_capacity(num_patches);
+    let mut weight11 = Vec::with_capacity(num_patches);
+
+    for (height, width) in coordinates {
+        let source_h = if grid_h == 1 {
+            0.0
+        } else {
+            height as f32 * (base_grid_size - 1) as f32 / (grid_h - 1) as f32
+        };
+        let source_w = if grid_w == 1 {
+            0.0
+        } else {
+            width as f32 * (base_grid_size - 1) as f32 / (grid_w - 1) as f32
+        };
+        let h0 = source_h.floor() as usize;
+        let w0 = source_w.floor() as usize;
+        let h1 = (h0 + 1).min(base_grid_size - 1);
+        let w1 = (w0 + 1).min(base_grid_size - 1);
+        let dh = source_h - h0 as f32;
+        let dw = source_w - w0 as f32;
+
+        index00.push((h0 * base_grid_size + w0) as u32);
+        index01.push((h0 * base_grid_size + w1) as u32);
+        index10.push((h1 * base_grid_size + w0) as u32);
+        index11.push((h1 * base_grid_size + w1) as u32);
+        weight00.push((1.0 - dh) * (1.0 - dw));
+        weight01.push((1.0 - dh) * dw);
+        weight10.push(dh * (1.0 - dw));
+        weight11.push(dh * dw);
+    }
+
+    let weighted = |indices: Vec<u32>, weights: Vec<f32>| -> Result<Tensor, OCRError> {
+        let indices =
+            Tensor::from_vec(indices, num_patches, position_embedding.device()).map_err(|e| {
+                candle_to_ocr_inference("OvisOCR2", "position interpolation indices", e)
+            })?;
+        let weights = Tensor::from_vec(weights, (num_patches, 1), position_embedding.device())
+            .and_then(|weights| weights.to_dtype(position_embedding.dtype()))
+            .and_then(|weights| weights.broadcast_as((num_patches, hidden_size)))
+            .map_err(|e| {
+                candle_to_ocr_inference("OvisOCR2", "position interpolation weights", e)
+            })?;
+        position_embedding
+            .index_select(&indices, 0)
+            .and_then(|selected| selected.broadcast_mul(&weights))
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "interpolate position embedding", e))
+    };
+
+    let output00 = weighted(index00, weight00)?;
+    let output01 = weighted(index01, weight01)?;
+    let output10 = weighted(index10, weight10)?;
+    let output11 = weighted(index11, weight11)?;
+    ((&output00 + &output01)
+        .and_then(|output| &output + &output10)
+        .and_then(|output| &output + &output11))
+    .map_err(|e| candle_to_ocr_inference("OvisOCR2", "sum interpolated position embedding", e))
+}
+
+fn build_vision_rotary_embeddings(
+    rotary_embedding: &VisionRotaryEmbedding,
+    grid_thw: (usize, usize, usize),
+    merge_size: usize,
+    device: &Device,
+) -> Result<(Tensor, Tensor), OCRError> {
+    let (_, grid_h, grid_w) = grid_thw;
+    let coordinates = merge_grouped_spatial_coordinates(grid_thw, merge_size)?;
+    let max_grid = grid_h.max(grid_w);
+    let frequency_table = rotary_embedding.forward(max_grid)?;
+    let num_patches = coordinates.len();
+    let (height_ids, width_ids): (Vec<u32>, Vec<u32>) = coordinates
+        .into_iter()
+        .map(|(height, width)| (height as u32, width as u32))
+        .unzip();
+    let height_ids = Tensor::from_vec(height_ids, num_patches, device)
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision height positions", e))?;
+    let width_ids = Tensor::from_vec(width_ids, num_patches, device)
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision width positions", e))?;
+    let height_frequencies = frequency_table
+        .index_select(&height_ids, 0)
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "gather vision height frequencies", e))?;
+    let width_frequencies = frequency_table
+        .index_select(&width_ids, 0)
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "gather vision width frequencies", e))?;
+    let rotary = Tensor::cat(&[&height_frequencies, &width_frequencies], 1)
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "join vision rotary frequencies", e))?;
+    let embedding = Tensor::cat(&[&rotary, &rotary], 1)
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "expand vision rotary frequencies", e))?;
+    let cos = embedding
+        .cos()
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision rotary cos", e))?;
+    let sin = embedding
+        .sin()
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision rotary sin", e))?;
+    Ok((cos, sin))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn learned_position_interpolation_matches_bilinear_reference() -> Result<(), OCRError> {
+        let weights = Tensor::from_vec(vec![0.0f32, 1.0, 2.0, 3.0], (4, 1), &Device::Cpu)
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "test position tensor", e))?;
+        let output = interpolate_position_embedding(&weights, 2, (1, 3, 3), 1)?;
+        let values = output
+            .flatten_all()
+            .and_then(|output| output.to_vec1::<f32>())
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "test position values", e))?;
+        let expected = [0.0, 0.5, 1.0, 1.0, 1.5, 2.0, 2.0, 2.5, 3.0];
+        for (actual, expected) in values.iter().zip(expected) {
+            assert!((actual - expected).abs() < 1e-6, "{actual} != {expected}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn learned_positions_follow_spatial_merge_group_order() -> Result<(), OCRError> {
+        let weights = Tensor::from_vec(
+            (0..16).map(|value| value as f32).collect::<Vec<_>>(),
+            (16, 1),
+            &Device::Cpu,
+        )
+        .map_err(|e| candle_to_ocr_inference("OvisOCR2", "test merge position tensor", e))?;
+        let output = interpolate_position_embedding(&weights, 4, (1, 4, 4), 2)?;
+        let values = output
+            .flatten_all()
+            .and_then(|output| output.to_vec1::<f32>())
+            .map_err(|e| candle_to_ocr_inference("OvisOCR2", "test merge position values", e))?;
+        assert_eq!(
+            values,
+            [
+                0.0, 1.0, 4.0, 5.0, 2.0, 3.0, 6.0, 7.0, 8.0, 9.0, 12.0, 13.0, 10.0, 11.0, 14.0,
+                15.0,
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn loads_qwen35_weight_names_and_forwards_tiny_tower() -> Result<(), OCRError> {
+        let cfg = OvisOcr2VisionConfig {
+            model_type: "qwen3_5".to_string(),
+            depth: 0,
+            hidden_size: 4,
+            intermediate_size: 8,
+            num_heads: 1,
+            in_channels: 3,
+            patch_size: 1,
+            spatial_merge_size: 1,
+            temporal_patch_size: 1,
+            out_hidden_size: 4,
+            num_position_embeddings: 4,
+            hidden_act: Activation::GeluPytorchTanh,
+            initializer_range: 0.02,
+            deepstack_visual_indexes: Vec::new(),
+        };
+        let device = Device::Cpu;
+        let mut tensors = HashMap::new();
+        tensors.insert(
+            "patch_embed.proj.weight".to_string(),
+            Tensor::zeros((4, 3, 1, 1, 1), DType::F32, &device).unwrap(),
+        );
+        tensors.insert(
+            "patch_embed.proj.bias".to_string(),
+            Tensor::zeros(4, DType::F32, &device).unwrap(),
+        );
+        tensors.insert(
+            "pos_embed.weight".to_string(),
+            Tensor::zeros((4, 4), DType::F32, &device).unwrap(),
+        );
+        tensors.insert(
+            "merger.norm.weight".to_string(),
+            Tensor::ones(4, DType::F32, &device).unwrap(),
+        );
+        tensors.insert(
+            "merger.norm.bias".to_string(),
+            Tensor::zeros(4, DType::F32, &device).unwrap(),
+        );
+        for name in ["merger.linear_fc1", "merger.linear_fc2"] {
+            tensors.insert(
+                format!("{name}.weight"),
+                Tensor::zeros((4, 4), DType::F32, &device).unwrap(),
+            );
+            tensors.insert(
+                format!("{name}.bias"),
+                Tensor::zeros(4, DType::F32, &device).unwrap(),
+            );
+        }
+        let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
+        let model = OvisOcr2VisionModel::load(&cfg, vb)?;
+        let output = model.forward(
+            &Tensor::zeros((4, 3), DType::F32, &device).unwrap(),
+            (1, 2, 2),
+        )?;
+        assert_eq!(output.dims(), &[4, 4]);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- add native OvisOCR2 support to `oar-ocr-vl`, including the Qwen3.5 text decoder, vision tower, image preprocessing, prompt construction, generation, and post-processing
- implement Gated DeltaNet recurrence for CPU and CUDA, with cached autoregressive convolution/state handling
- add a public API, CLI example, and user documentation for full-page document-to-Markdown parsing
- share chunked vision attention with MinerU, compute text MRoPE on-device, and use stable CUDA greedy argmax
- automatically discover CUDA sources during builds and validate that the PTX aggregation unit includes every model-specific kernel

## Why

OAR-OCR did not have a native Candle backend for OvisOCR2. This adds end-to-end inference while preserving the official model's preprocessing, Qwen3.5 normalization conventions, multimodal rotary layout, stopping behavior, and truncated-repeat cleanup.

The implementation also addresses review findings that would otherwise add decode-time device round trips, repeated fixed-weight computation, duplicated vision traversal/attention code, and unstable greedy tie-breaking.

## User impact

Users can load a Hugging Face-format OvisOCR2 directory and parse one or more document pages into Markdown on CPU or CUDA through the Rust API or the new `ovisocr2` example.

## Validation

- `cargo test -p oar-ocr-vl --features download-binaries --lib` — 133 passed
- `cargo test -p oar-ocr-vl --features cuda,download-binaries --lib` — 145 passed
- `cargo clippy -p oar-ocr-vl --features download-binaries --lib --tests -- -D warnings`
- CUDA clippy passes when allowing the two pre-existing HunyuanOCR lint categories (`unnecessary_unwrap` and `too_many_arguments`)
- CUDA inference on `.oar/images/layout.jpg` produced the expected 64-token golden output exactly
