### PR TITLE
Add MonkeyOCRv2 S/B Parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,13 @@ The [`oar-ocr-vl`](oar-ocr-vl/README.md) crate provides native [Candle](https://
 | [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) | 0.9B | Page parsing, text, table, and formula recognition |
 | [OvisOCR2](https://huggingface.co/ATH-MaaS/OvisOCR2) | 0.8B | Model-native full-page document-to-Markdown parsing |
 | [MonkeyOCRv2-S-Parsing](https://huggingface.co/zenosai/MonkeyOCRv2-S-Parsing) | 0.6B | Model-native layout, end-to-end parsing, text, formula, and OTSL-table recognition |
+| [MonkeyOCRv2-B-Parsing](https://huggingface.co/zenosai/MonkeyOCRv2-B-Parsing) | 0.7B | Higher-capacity ViT-B variant with the same parsing and recognition tasks |
 | [HunyuanOCR 1.5 / 1.0](https://huggingface.co/tencent/HunyuanOCR) | 1B | Prompt-driven full-page parsing, text spotting, table, formula, and chart recognition, with optional DFlash decoding for 1.5 |
 | [MinerU2.5-2509](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) | 1.2B | Model-native two-step layout detection and content extraction |
 | [MinerU2.5-Pro-2605](https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B) | 1.2B | Newer MinerU2.5 checkpoint using the same two-step pipeline |
 | [MinerU-Diffusion-V1-0320](https://huggingface.co/opendatalab/MinerU-Diffusion-V1-0320-2.5B) | 2.5B | Block-diffusion OCR with structured two-step extraction or single-pass text recognition |
 
-PaddleOCR-VL variants and GLM-OCR integrate with the external-layout [`DocParser`](oar-ocr-vl/README.md#document-parsing-pipeline). OvisOCR2 and MonkeyOCRv2-S-Parsing instead provide model-native full-page paths through dedicated examples. HunyuanOCR and the MinerU models also use their model-native parsing pipelines.
+PaddleOCR-VL variants and GLM-OCR integrate with the external-layout [`DocParser`](oar-ocr-vl/README.md#document-parsing-pipeline). OvisOCR2 and the MonkeyOCRv2 S/B parsing models instead provide model-native full-page paths through dedicated examples. HunyuanOCR and the MinerU models also use their model-native parsing pipelines.
 
 See the [`oar-ocr-vl` guide](oar-ocr-vl/README.md) for setup and [`oar-ocr-vl/examples`](oar-ocr-vl/examples) for runnable examples.
 

--- a/README.md
+++ b/README.md
@@ -124,12 +124,13 @@ The [`oar-ocr-vl`](oar-ocr-vl/README.md) crate provides native [Candle](https://
 | [PaddleOCR-VL-1.6](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6) | 0.9B | Region-aware page parsing and task-specific recognition |
 | [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) | 0.9B | Page parsing, text, table, and formula recognition |
 | [OvisOCR2](https://huggingface.co/ATH-MaaS/OvisOCR2) | 0.8B | Model-native full-page document-to-Markdown parsing |
+| [MonkeyOCRv2-S-Parsing](https://huggingface.co/zenosai/MonkeyOCRv2-S-Parsing) | 0.6B | Model-native layout, end-to-end parsing, text, formula, and OTSL-table recognition |
 | [HunyuanOCR 1.5 / 1.0](https://huggingface.co/tencent/HunyuanOCR) | 1B | Prompt-driven full-page parsing, text spotting, table, formula, and chart recognition, with optional DFlash decoding for 1.5 |
 | [MinerU2.5-2509](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) | 1.2B | Model-native two-step layout detection and content extraction |
 | [MinerU2.5-Pro-2605](https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B) | 1.2B | Newer MinerU2.5 checkpoint using the same two-step pipeline |
 | [MinerU-Diffusion-V1-0320](https://huggingface.co/opendatalab/MinerU-Diffusion-V1-0320-2.5B) | 2.5B | Block-diffusion OCR with structured two-step extraction or single-pass text recognition |
 
-PaddleOCR-VL variants and GLM-OCR integrate with the external-layout [`DocParser`](oar-ocr-vl/README.md#document-parsing-pipeline). OvisOCR2 is instead a model-native full-page parser: its dedicated example applies the official fixed prompt, pixel preprocessing, and output cleanup and does not use DocParser. HunyuanOCR and the MinerU models also use their model-native parsing pipelines.
+PaddleOCR-VL variants and GLM-OCR integrate with the external-layout [`DocParser`](oar-ocr-vl/README.md#document-parsing-pipeline). OvisOCR2 and MonkeyOCRv2-S-Parsing instead provide model-native full-page paths through dedicated examples. HunyuanOCR and the MinerU models also use their model-native parsing pipelines.
 
 See the [`oar-ocr-vl` guide](oar-ocr-vl/README.md) for setup and [`oar-ocr-vl/examples`](oar-ocr-vl/examples) for runnable examples.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -36,7 +36,7 @@ OAR_HOME=/data/oar-models cargo run --release --example ocr -- doc.jpg
 
 ## `OAR_VL_DTYPE`
 
-Overrides the automatic weight/compute dtype selection for Vision-Language models (PaddleOCR-VL, GLM-OCR, OvisOCR2, HunyuanOCR, MinerU2.5/Pro, and MinerU-Diffusion).
+Overrides the automatic weight/compute dtype selection for Vision-Language models (PaddleOCR-VL, GLM-OCR, OvisOCR2, MonkeyOCRv2, HunyuanOCR, MinerU2.5/Pro, and MinerU-Diffusion).
 
 Accepted values (case-insensitive):
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -441,6 +441,57 @@ cargo run -p oar-ocr-vl --features cuda,download-binaries --example ovisocr2 -- 
 
 Add `--keep-image-tags` to retain visual-region image-tag references, or use `--max-tokens` to override the 16,384-token default. The example does not create the referenced bounding-box crop files.
 
+## MonkeyOCRv2-S-Parsing
+
+[MonkeyOCRv2-S-Parsing](https://huggingface.co/zenosai/MonkeyOCRv2-S-Parsing) is a 0.6B document parser with a Monkey ViT-S vision encoder and Qwen3-0.6B decoder. The native Candle implementation supports the checkpoint's five official tasks: `Layout`, `EndToEnd`, `Text`, `Formula`, and `Table`.
+
+### Downloading the Model
+
+```bash
+git lfs install
+git clone https://huggingface.co/zenosai/MonkeyOCRv2-S-Parsing
+
+# Or using hf
+hf download zenosai/MonkeyOCRv2-S-Parsing --local-dir MonkeyOCRv2-S-Parsing
+```
+
+### Basic Usage
+
+```rust,no_run
+use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::parse_device;
+use oar_ocr_vl::{MonkeyOcrV2, MonkeyOcrV2Task};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let image = load_image("document.jpg")?;
+    let model = MonkeyOcrV2::from_dir(
+        "MonkeyOCRv2-S-Parsing",
+        parse_device("cuda:0")?,
+    )?;
+    let output = model
+        .generate(&[image], &[MonkeyOcrV2Task::EndToEnd], 10_000)
+        .into_iter()
+        .next()
+        .expect("one result")?;
+    println!("{output}");
+    Ok(())
+}
+```
+
+`EndToEnd` returns a Python/JSON-like reading-order list of `{bbox, label, content}` items; box coordinates are normalized to `[0, 1000]`. `Layout` returns `{bbox, label}` items and applies the official layout-pass minimum area of 1,003,520 pixels. `Table` emits OTSL, while `Formula` emits LaTeX. `generate_with_prompts` is available for custom instructions.
+
+### Running the Example
+
+```bash
+cargo run -p oar-ocr-vl --features cuda,download-binaries --example monkeyocrv2 -- \
+    --model-dir MonkeyOCRv2-S-Parsing \
+    --device cuda:0 \
+    --task end-to-end \
+    document.jpg
+```
+
+The other `--task` values are `layout`, `text`, `formula`, and `table`. The model also implements `RecognitionBackend` for external-layout crop recognition, although its native tasks are the preferred full-page path.
+
 ## HunyuanOCR 1.5
 
 [HunyuanOCR 1.5](https://huggingface.co/tencent/HunyuanOCR) is a lightweight OCR expert VLM. It is available in the `oar-ocr-vl` crate and supports prompt-driven image-to-text OCR. `HunyuanOcr::from_dir` automatically detects 1.5 at the model repository root and remains compatible with archived 1.0 weights under `v1.0/`.
@@ -677,9 +728,9 @@ cargo run -p oar-ocr-vl --features cuda,download-binaries \
 
 ## DocParser
 
-DocParser provides a unified API for external layout-first document parsing with VL-based recognition. The `doc_parser` example supports PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR.
+DocParser provides a unified API for external layout-first document parsing with VL-based recognition. The `doc_parser` example supports PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR. MonkeyOCRv2 also implements `RecognitionBackend`, but uses its dedicated model-native example for complete pages.
 
-Use `parse(&layout, image)` with an ONNX layout detector. OvisOCR2 deliberately does not implement `RecognitionBackend`; use its full-page `OvisOcr2::parse` API instead. The library also implements `RecognitionBackend` for HunyuanOCR and MinerU2.5/Pro, but they are intentionally not exposed by the CLI example because their reference-quality paths are prompt-driven full-page parsing and model-native two-step extraction, respectively. MinerU-Diffusion uses its dedicated example.
+Use `parse(&layout, image)` with an ONNX layout detector. OvisOCR2 deliberately does not implement `RecognitionBackend`; use its full-page `OvisOcr2::parse` API instead. The library also implements `RecognitionBackend` for MonkeyOCRv2, HunyuanOCR, and MinerU2.5/Pro, but they are intentionally not exposed by the CLI example because their reference-quality paths are model-native parsing. MinerU-Diffusion uses its dedicated example.
 
 ### Basic Usage
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -441,9 +441,9 @@ cargo run -p oar-ocr-vl --features cuda,download-binaries --example ovisocr2 -- 
 
 Add `--keep-image-tags` to retain visual-region image-tag references, or use `--max-tokens` to override the 16,384-token default. The example does not create the referenced bounding-box crop files.
 
-## MonkeyOCRv2-S-Parsing
+## MonkeyOCRv2-S/B-Parsing
 
-[MonkeyOCRv2-S-Parsing](https://huggingface.co/zenosai/MonkeyOCRv2-S-Parsing) is a 0.6B document parser with a Monkey ViT-S vision encoder and Qwen3-0.6B decoder. The native Candle implementation supports the checkpoint's five official tasks: `Layout`, `EndToEnd`, `Text`, `Formula`, and `Table`.
+[MonkeyOCRv2-S-Parsing](https://huggingface.co/zenosai/MonkeyOCRv2-S-Parsing) and [MonkeyOCRv2-B-Parsing](https://huggingface.co/zenosai/MonkeyOCRv2-B-Parsing) are 0.6B and 0.7B document parsers. They pair Monkey ViT-S and ViT-B vision encoders, respectively, with the same Qwen3-0.6B decoder. The native Candle implementation reads either checkpoint's dimensions from its configuration and supports the five official tasks: `Layout`, `EndToEnd`, `Text`, `Formula`, and `Table`.
 
 ### Downloading the Model
 
@@ -453,6 +453,9 @@ git clone https://huggingface.co/zenosai/MonkeyOCRv2-S-Parsing
 
 # Or using hf
 hf download zenosai/MonkeyOCRv2-S-Parsing --local-dir MonkeyOCRv2-S-Parsing
+
+# Use MonkeyOCRv2-B-Parsing instead for the ViT-B variant
+hf download zenosai/MonkeyOCRv2-B-Parsing --local-dir MonkeyOCRv2-B-Parsing
 ```
 
 ### Basic Usage
@@ -491,6 +494,8 @@ cargo run -p oar-ocr-vl --features cuda,download-binaries --example monkeyocrv2 
 ```
 
 The other `--task` values are `layout`, `text`, `formula`, and `table`. The model also implements `RecognitionBackend` for external-layout crop recognition, although its native tasks are the preferred full-page path.
+
+The same API and example accept `MonkeyOCRv2-B-Parsing`; select it by changing `--model-dir` to that checkpoint directory.
 
 ## HunyuanOCR 1.5
 

--- a/oar-ocr-vl/README.md
+++ b/oar-ocr-vl/README.md
@@ -14,6 +14,7 @@ This crate provides native Rust inference for document VLMs using [Candle](https
 | [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) | 0.9B | External-layout page parsing, text, table, and formula recognition |
 | [OvisOCR2](https://huggingface.co/ATH-MaaS/OvisOCR2) | 0.8B | Model-native full-page document-to-Markdown parsing |
 | [MonkeyOCRv2-S-Parsing](https://huggingface.co/zenosai/MonkeyOCRv2-S-Parsing) | 0.6B | Model-native layout, end-to-end parsing, text, formula, and OTSL-table recognition |
+| [MonkeyOCRv2-B-Parsing](https://huggingface.co/zenosai/MonkeyOCRv2-B-Parsing) | 0.7B | Higher-capacity ViT-B variant with the same parsing and recognition tasks |
 | [HunyuanOCR 1.5 / 1.0](https://huggingface.co/tencent/HunyuanOCR) | 1B | Model-native prompt-driven parsing with optional DFlash decoding for 1.5 |
 | [MinerU2.5-2509](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) | 1.2B | Model-native two-step layout detection and content extraction |
 | [MinerU2.5-Pro-2605](https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B) | 1.2B | Newer compatible checkpoint using the MinerU2.5 two-step pipeline |
@@ -126,9 +127,9 @@ println!("{markdown}");
 
 The official runtime resizes RGB input with bicubic antialiasing to a 32-pixel-aligned area between `448²` and `2880²` pixels. Its fixed prompt requests reading-order Markdown, LaTeX formulas, HTML tables, and bounding-box `<img>` tags for visual regions. `parse` removes those visual-region blocks by default before applying truncated-repeat cleanup; call `parse_with_image_tags(..., true)` or `generate` to retain the references. The library does not create the referenced bounding-box crop files.
 
-### MonkeyOCRv2-S-Parsing
+### MonkeyOCRv2-S/B-Parsing
 
-MonkeyOCRv2-S-Parsing uses its native Monkey ViT-S encoder and Qwen3-0.6B decoder. The API exposes the official full-page layout and end-to-end prompts as well as cropped text, formula, and OTSL-table recognition.
+MonkeyOCRv2-S-Parsing and MonkeyOCRv2-B-Parsing use native Monkey ViT-S and ViT-B encoders, respectively, with the same Qwen3-0.6B decoder. The API reads either checkpoint's dimensions from its configuration and exposes the official full-page layout and end-to-end prompts as well as cropped text, formula, and OTSL-table recognition.
 
 ```rust
 use oar_ocr_core::utils::load_image;
@@ -286,7 +287,7 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example ov
     document-1.jpg document-2.jpg
 ```
 
-### MonkeyOCRv2-S-Parsing Direct Inference
+### MonkeyOCRv2-S/B-Parsing Direct Inference
 
 Run the official end-to-end prompt over a complete page:
 
@@ -298,7 +299,7 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example mo
     document.jpg
 ```
 
-Other task values are `layout`, `text`, `formula`, and `table`. Use `--prompt` to supply a custom instruction.
+Pass `MonkeyOCRv2-B-Parsing` to `--model-dir` to use the ViT-B checkpoint. Other task values are `layout`, `text`, `formula`, and `table`. Use `--prompt` to supply a custom instruction.
 
 ### MinerU2.5 and MinerU2.5-Pro Direct Inference
 

--- a/oar-ocr-vl/README.md
+++ b/oar-ocr-vl/README.md
@@ -13,6 +13,7 @@ This crate provides native Rust inference for document VLMs using [Candle](https
 | [PaddleOCR-VL-1.6](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.6) | 0.9B | Region-aware refinement, drop-in compatible with the 1.5 loader |
 | [GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) | 0.9B | External-layout page parsing, text, table, and formula recognition |
 | [OvisOCR2](https://huggingface.co/ATH-MaaS/OvisOCR2) | 0.8B | Model-native full-page document-to-Markdown parsing |
+| [MonkeyOCRv2-S-Parsing](https://huggingface.co/zenosai/MonkeyOCRv2-S-Parsing) | 0.6B | Model-native layout, end-to-end parsing, text, formula, and OTSL-table recognition |
 | [HunyuanOCR 1.5 / 1.0](https://huggingface.co/tencent/HunyuanOCR) | 1B | Model-native prompt-driven parsing with optional DFlash decoding for 1.5 |
 | [MinerU2.5-2509](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) | 1.2B | Model-native two-step layout detection and content extraction |
 | [MinerU2.5-Pro-2605](https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B) | 1.2B | Newer compatible checkpoint using the MinerU2.5 two-step pipeline |
@@ -27,7 +28,7 @@ See [`examples`](examples) for runnable examples.
 1. **Layout detection** (ONNX models like PP-DocLayoutV3) to identify document regions
 2. **VL-based recognition** to extract content from each region
 
-Use DocParser with PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR. OvisOCR2 is an end-to-end full-page parser and deliberately does not use DocParser. HunyuanOCR should be used with its model-native full-page prompts. MinerU2.5, MinerU2.5-Pro, and MinerU-Diffusion should use their model-native two-step extraction examples.
+Use DocParser with PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, GLM-OCR, and optionally MonkeyOCRv2 for externally detected crops. MonkeyOCRv2's native `Layout` and `EndToEnd` tasks are preferable for complete pages. OvisOCR2 is an end-to-end full-page parser and deliberately does not use DocParser. HunyuanOCR should be used with its model-native full-page prompts. MinerU2.5, MinerU2.5-Pro, and MinerU-Diffusion should use their model-native two-step extraction examples.
 
 ## Installation
 
@@ -125,6 +126,30 @@ println!("{markdown}");
 
 The official runtime resizes RGB input with bicubic antialiasing to a 32-pixel-aligned area between `448²` and `2880²` pixels. Its fixed prompt requests reading-order Markdown, LaTeX formulas, HTML tables, and bounding-box `<img>` tags for visual regions. `parse` removes those visual-region blocks by default before applying truncated-repeat cleanup; call `parse_with_image_tags(..., true)` or `generate` to retain the references. The library does not create the referenced bounding-box crop files.
 
+### MonkeyOCRv2-S-Parsing
+
+MonkeyOCRv2-S-Parsing uses its native Monkey ViT-S encoder and Qwen3-0.6B decoder. The API exposes the official full-page layout and end-to-end prompts as well as cropped text, formula, and OTSL-table recognition.
+
+```rust
+use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::parse_device;
+use oar_ocr_vl::{MonkeyOcrV2, MonkeyOcrV2Task};
+
+let image = load_image("document.png")?;
+let model = MonkeyOcrV2::from_dir(
+    "MonkeyOCRv2-S-Parsing",
+    parse_device("cuda:0")?,
+)?;
+let parsed = model
+    .generate(&[image], &[MonkeyOcrV2Task::EndToEnd], 10_000)
+    .into_iter()
+    .next()
+    .expect("one result")?;
+println!("{parsed}");
+```
+
+`EndToEnd` emits a reading-order list whose items contain normalized `bbox`, `label`, and `content` fields. `Layout` emits `bbox` and `label`; its preprocessing follows the official one-megapixel minimum used by the reference layout pass. `Text`, `Formula`, and `Table` can be used directly or through `RecognitionBackend`; table output is OTSL and is converted by `DocParser`.
+
 ### DocParser
 
 Parse an entire page into Markdown with a layout predictor. This path is intended for external layout-first backends such as PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR.
@@ -191,7 +216,7 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example do
     document.jpg
 ```
 
-OvisOCR2, HunyuanOCR, and the MinerU models are intentionally not exposed by this example because their reference-quality paths are model-native full-page parsing, prompt-driven full-page parsing, and model-native two-step extraction, respectively.
+OvisOCR2, HunyuanOCR, and the MinerU models are intentionally not exposed by this example because their reference-quality paths are model-native full-page parsing, prompt-driven full-page parsing, and model-native two-step extraction, respectively. MonkeyOCRv2 implements `RecognitionBackend`, but its dedicated example is the preferred complete-page path.
 
 ### PaddleOCR-VL Direct Inference
 
@@ -260,6 +285,20 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example ov
     --device cuda:0 \
     document-1.jpg document-2.jpg
 ```
+
+### MonkeyOCRv2-S-Parsing Direct Inference
+
+Run the official end-to-end prompt over a complete page:
+
+```bash
+cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example monkeyocrv2 -- \
+    --model-dir MonkeyOCRv2-S-Parsing \
+    --device cuda:0 \
+    --task end-to-end \
+    document.jpg
+```
+
+Other task values are `layout`, `text`, `formula`, and `table`. Use `--prompt` to supply a custom instruction.
 
 ### MinerU2.5 and MinerU2.5-Pro Direct Inference
 

--- a/oar-ocr-vl/examples/monkeyocrv2.rs
+++ b/oar-ocr-vl/examples/monkeyocrv2.rs
@@ -1,0 +1,135 @@
+//! MonkeyOCRv2-S-Parsing inference example (Candle-based).
+//!
+//! ```bash
+//! cargo run --release -p oar-ocr-vl --features cuda,download-binaries \
+//!   --example monkeyocrv2 -- \
+//!   --model-dir /path/to/MonkeyOCRv2-S-Parsing \
+//!   --device cuda:0 --task end-to-end document.jpg
+//! ```
+
+mod utils;
+
+use clap::{Parser, ValueEnum};
+use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::monkeyocrv2::DEFAULT_MAX_NEW_TOKENS;
+use oar_ocr_vl::utils::parse_device;
+use oar_ocr_vl::{MonkeyOcrV2, MonkeyOcrV2Task};
+use std::path::PathBuf;
+use std::time::Instant;
+use tracing::{error, info};
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Task {
+    Layout,
+    EndToEnd,
+    Text,
+    Formula,
+    Table,
+}
+
+impl From<Task> for MonkeyOcrV2Task {
+    fn from(task: Task) -> Self {
+        match task {
+            Task::Layout => Self::Layout,
+            Task::EndToEnd => Self::EndToEnd,
+            Task::Text => Self::Text,
+            Task::Formula => Self::Formula,
+            Task::Table => Self::Table,
+        }
+    }
+}
+
+#[derive(Parser)]
+#[command(name = "monkeyocrv2")]
+#[command(about = "MonkeyOCRv2-S-Parsing native Candle inference")]
+struct Args {
+    /// Path to the MonkeyOCRv2-S-Parsing model directory
+    #[arg(short, long)]
+    model_dir: PathBuf,
+
+    /// Paths to one or more input images
+    #[arg(required = true)]
+    images: Vec<PathBuf>,
+
+    /// Official inference task
+    #[arg(short, long, value_enum, default_value = "end-to-end")]
+    task: Task,
+
+    /// Device: cpu, cuda, cuda:N, or metal
+    #[arg(short, long, default_value = "cpu")]
+    device: String,
+
+    /// Maximum generated tokens per image
+    #[arg(long, default_value_t = DEFAULT_MAX_NEW_TOKENS)]
+    max_tokens: usize,
+
+    /// Override the official task prompt
+    #[arg(long)]
+    prompt: Option<String>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    utils::init_tracing();
+    let args = Args::parse();
+    if !args.model_dir.exists() {
+        return Err(format!("Model directory not found: {}", args.model_dir.display()).into());
+    }
+
+    let mut paths = Vec::new();
+    let mut images = Vec::new();
+    for path in args.images {
+        if !path.exists() {
+            error!("Image not found: {}", path.display());
+            continue;
+        }
+        match load_image(&path) {
+            Ok(image) => {
+                paths.push(path);
+                images.push(image);
+            }
+            Err(err) => error!("Failed to load {}: {err}", path.display()),
+        }
+    }
+    if images.is_empty() {
+        return Err("No valid input images".into());
+    }
+
+    let device = parse_device(&args.device)?;
+    info!("Loading {}", args.model_dir.display());
+    let started = Instant::now();
+    let model = MonkeyOcrV2::from_dir(&args.model_dir, device)?;
+    info!("Model loaded in {:.2}s", started.elapsed().as_secs_f64());
+
+    let started = Instant::now();
+    let results = if let Some(prompt) = args.prompt {
+        let prompts = vec![prompt; images.len()];
+        model.generate_with_prompts(&images, &prompts, args.max_tokens)
+    } else {
+        let tasks = vec![MonkeyOcrV2Task::from(args.task); images.len()];
+        model.generate(&images, &tasks, args.max_tokens)
+    };
+    info!(
+        "Processed {} image(s) in {:.2}s",
+        images.len(),
+        started.elapsed().as_secs_f64()
+    );
+
+    let mut failed = false;
+    for (path, result) in paths.iter().zip(results) {
+        match result {
+            Ok(text) => {
+                println!("<!-- MonkeyOCRv2 source: {} -->", path.display());
+                println!("{text}");
+            }
+            Err(err) => {
+                error!("Inference failed for {}: {err}", path.display());
+                failed = true;
+            }
+        }
+    }
+    if failed {
+        Err("One or more MonkeyOCRv2 inferences failed".into())
+    } else {
+        Ok(())
+    }
+}

--- a/oar-ocr-vl/examples/monkeyocrv2.rs
+++ b/oar-ocr-vl/examples/monkeyocrv2.rs
@@ -1,4 +1,4 @@
-//! MonkeyOCRv2-S-Parsing inference example (Candle-based).
+//! MonkeyOCRv2-S/B-Parsing inference example (Candle-based).
 //!
 //! ```bash
 //! cargo run --release -p oar-ocr-vl --features cuda,download-binaries \
@@ -41,9 +41,9 @@ impl From<Task> for MonkeyOcrV2Task {
 
 #[derive(Parser)]
 #[command(name = "monkeyocrv2")]
-#[command(about = "MonkeyOCRv2-S-Parsing native Candle inference")]
+#[command(about = "MonkeyOCRv2-S/B-Parsing native Candle inference")]
 struct Args {
-    /// Path to the MonkeyOCRv2-S-Parsing model directory
+    /// Path to a MonkeyOCRv2-S-Parsing or MonkeyOCRv2-B-Parsing model directory
     #[arg(short, long)]
     model_dir: PathBuf,
 

--- a/oar-ocr-vl/src/lib.rs
+++ b/oar-ocr-vl/src/lib.rs
@@ -12,6 +12,7 @@
 //!   backbone)
 //! - `mineru_diffusion` - MinerU-Diffusion-V1 block-diffusion document OCR
 //!   (Qwen2-VL vision + SDAR decoder)
+//! - `monkeyocrv2` - MonkeyOCRv2-S-Parsing full-page and region parsing
 //! - `ovisocr2` - OvisOCR2 end-to-end page-to-Markdown parser (Qwen3.5)
 //! - `doc_parser` - Unified document parsing with pluggable recognition backends
 //! - `utils` - Device parsing, candle helpers, markdown, OTSL conversion
@@ -36,6 +37,7 @@ pub mod glmocr;
 pub mod hunyuanocr;
 pub mod mineru;
 pub mod mineru_diffusion;
+pub mod monkeyocrv2;
 pub mod ovisocr2;
 pub mod paddleocr_vl;
 pub mod utils;
@@ -65,6 +67,7 @@ pub use glmocr::GlmOcr;
 pub use hunyuanocr::{DFlashConfig, DFlashTargetConfig, HunyuanOcr, HunyuanOcrVersion};
 pub use mineru::MinerU;
 pub use mineru_diffusion::{DiffusionGenerationConfig, MinerUDiffusion};
+pub use monkeyocrv2::{MonkeyOcrV2, MonkeyOcrV2Task};
 pub use ovisocr2::OvisOcr2;
 
 pub use doc_parser::{DocParser, DocParserConfig, RecognitionBackend, RecognitionTask};

--- a/oar-ocr-vl/src/lib.rs
+++ b/oar-ocr-vl/src/lib.rs
@@ -12,7 +12,7 @@
 //!   backbone)
 //! - `mineru_diffusion` - MinerU-Diffusion-V1 block-diffusion document OCR
 //!   (Qwen2-VL vision + SDAR decoder)
-//! - `monkeyocrv2` - MonkeyOCRv2-S-Parsing full-page and region parsing
+//! - `monkeyocrv2` - MonkeyOCRv2-S/B-Parsing full-page and region parsing
 //! - `ovisocr2` - OvisOCR2 end-to-end page-to-Markdown parser (Qwen3.5)
 //! - `doc_parser` - Unified document parsing with pluggable recognition backends
 //! - `utils` - Device parsing, candle helpers, markdown, OTSL conversion

--- a/oar-ocr-vl/src/mineru_diffusion/mod.rs
+++ b/oar-ocr-vl/src/mineru_diffusion/mod.rs
@@ -12,7 +12,7 @@
 mod config;
 mod model;
 mod projector;
-mod text;
+pub(crate) mod text;
 
 pub use config::{MinerUDiffusionConfig, SdarConfig};
 pub use model::{DEFAULT_PROMPT, DiffusionGenerationConfig, MinerUDiffusion};

--- a/oar-ocr-vl/src/mineru_diffusion/text.rs
+++ b/oar-ocr-vl/src/mineru_diffusion/text.rs
@@ -16,6 +16,7 @@
 
 use super::config::SdarConfig;
 use crate::attention::{RotaryEmbedding, flash_attention, scaled_dot_product_attention_gqa};
+use crate::kv_trim::TrimmableKvCache;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing, rotate_half};
 use candle_core::{DType, Device, Tensor};
 use candle_nn::{
@@ -33,10 +34,37 @@ fn proc_err(msg: &'static str, e: candle_core::Error) -> OCRError {
 
 /// Per-layer committed KV (rope already applied to keys).
 /// Shape `(batch=1, num_kv_heads, len, head_dim)`.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 struct LayerKvCache {
-    k: Option<Tensor>,
-    v: Option<Tensor>,
+    committed: TrimmableKvCache,
+}
+
+impl LayerKvCache {
+    fn new() -> Self {
+        Self {
+            // Grow organically so diffusion inference does not reserve the
+            // checkpoint's full context length for every layer up front.
+            committed: TrimmableKvCache::new(2, 0),
+        }
+    }
+
+    fn full_kv(
+        &mut self,
+        k: &Tensor,
+        v: &Tensor,
+        store_kv: bool,
+    ) -> candle_core::Result<(Tensor, Tensor)> {
+        if store_kv {
+            return self.committed.append(k, v);
+        }
+        match (self.committed.k(), self.committed.v()) {
+            (Some(committed_k), Some(committed_v)) => Ok((
+                Tensor::cat(&[committed_k, k], 2)?,
+                Tensor::cat(&[committed_v, v], 2)?,
+            )),
+            _ => Ok((k.clone(), v.clone())),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -54,7 +82,7 @@ pub struct SdarKvCache {
 impl SdarKvCache {
     pub fn new(num_layers: usize) -> Self {
         Self {
-            layers: vec![LayerKvCache::default(); num_layers],
+            layers: (0..num_layers).map(|_| LayerKvCache::new()).collect(),
         }
     }
 }
@@ -169,20 +197,12 @@ impl SdarAttention {
         let q = apply_rope(&q, cos, sin)?;
         let k = apply_rope(&k, cos, sin)?;
 
-        // Concatenate the committed cache (already rope-applied) with the
-        // current segment's KV. Only persist when committing the block.
-        let (full_k, full_v) = match (&cache.k, &cache.v) {
-            (Some(ck), Some(cv)) => {
-                let fk = Tensor::cat(&[ck, &k], 2).map_err(|e| proc_err("SDAR kv cat k", e))?;
-                let fv = Tensor::cat(&[cv, &v], 2).map_err(|e| proc_err("SDAR kv cat v", e))?;
-                (fk, fv)
-            }
-            _ => (k, v),
-        };
-        if mode.store_kv {
-            cache.k = Some(full_k.clone());
-            cache.v = Some(full_v.clone());
-        }
+        // Committed causal/decode KV uses appendable backing storage. SDAR's
+        // in-flight denoising block remains transient and is concatenated only
+        // for that attention pass.
+        let (full_k, full_v) = cache
+            .full_kv(&k, &v, mode.store_kv)
+            .map_err(|e| proc_err("SDAR kv cache update", e))?;
 
         let n_rep = self.num_heads / self.num_kv_heads;
         let flash = if mask.is_none() {
@@ -426,5 +446,36 @@ impl SdarModel {
         self.lm_head
             .forward(hidden)
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "lm_head", e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn committed_cache_appends_in_place_between_growths() -> candle_core::Result<()> {
+        let device = Device::Cpu;
+        let mut cache = LayerKvCache::new();
+        let prompt = Tensor::zeros((1, 2, 3, 4), DType::F32, &device)?;
+        let token = Tensor::ones((1, 2, 1, 4), DType::F32, &device)?;
+
+        let (prompt_k, _) = cache.full_kv(&prompt, &prompt, true)?;
+        assert_eq!(prompt_k.dims(), &[1, 2, 3, 4]);
+        assert_eq!(cache.committed.storage_capacity(), 3);
+
+        let (first_decode_k, _) = cache.full_kv(&token, &token, true)?;
+        assert_eq!(first_decode_k.dims(), &[1, 2, 4, 4]);
+        assert_eq!(cache.committed.storage_capacity(), 6);
+
+        let (second_decode_k, _) = cache.full_kv(&token, &token, true)?;
+        assert_eq!(second_decode_k.dims(), &[1, 2, 5, 4]);
+        assert_eq!(cache.committed.storage_capacity(), 6);
+
+        let transient = Tensor::zeros((1, 2, 2, 4), DType::F32, &device)?;
+        let (transient_k, _) = cache.full_kv(&transient, &transient, false)?;
+        assert_eq!(transient_k.dims(), &[1, 2, 7, 4]);
+        assert_eq!(cache.committed.current_seq_len(), 5);
+        Ok(())
     }
 }

--- a/oar-ocr-vl/src/mineru_diffusion/text.rs
+++ b/oar-ocr-vl/src/mineru_diffusion/text.rs
@@ -39,6 +39,12 @@ struct LayerKvCache {
     v: Option<Tensor>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct AttentionMode {
+    store_kv: bool,
+    is_causal: bool,
+}
+
 /// Committed KV cache across all decoder layers.
 #[derive(Debug, Clone)]
 pub struct SdarKvCache {
@@ -130,7 +136,7 @@ impl SdarAttention {
         sin: &Tensor,
         mask: Option<&Tensor>,
         cache: &mut LayerKvCache,
-        store_kv: bool,
+        mode: AttentionMode,
     ) -> Result<Tensor, OCRError> {
         let (b, s, _) = hidden
             .dims3()
@@ -173,14 +179,14 @@ impl SdarAttention {
             }
             _ => (k, v),
         };
-        if store_kv {
+        if mode.store_kv {
             cache.k = Some(full_k.clone());
             cache.v = Some(full_v.clone());
         }
 
         let n_rep = self.num_heads / self.num_kv_heads;
         let flash = if mask.is_none() {
-            flash_attention(&q, &full_k, &full_v, self.scale, false)
+            flash_attention(&q, &full_k, &full_v, self.scale, mode.is_causal)
                 .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "flash attention", e))?
         } else {
             None
@@ -188,7 +194,13 @@ impl SdarAttention {
         let attn = match flash {
             Some(attn) => attn,
             None => scaled_dot_product_attention_gqa(
-                &q, &full_k, &full_v, mask, self.scale, false, n_rep,
+                &q,
+                &full_k,
+                &full_v,
+                mask,
+                self.scale,
+                mode.is_causal,
+                n_rep,
             )
             .map_err(|e| {
                 candle_to_ocr_inference("MinerU-Diffusion", "grouped-query attention", e)
@@ -275,7 +287,7 @@ impl SdarLayer {
         sin: &Tensor,
         mask: Option<&Tensor>,
         cache: &mut LayerKvCache,
-        store_kv: bool,
+        mode: AttentionMode,
     ) -> Result<Tensor, OCRError> {
         let normed = self
             .input_layernorm
@@ -283,7 +295,7 @@ impl SdarLayer {
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "input_layernorm", e))?;
         let attn = self
             .self_attn
-            .forward(&normed, cos, sin, mask, cache, store_kv)?;
+            .forward(&normed, cos, sin, mask, cache, mode)?;
         let hidden = (hidden + attn).map_err(|e| proc_err("SDAR attn residual", e))?;
         let normed = self
             .post_attention_layernorm
@@ -367,10 +379,42 @@ impl SdarModel {
         cache: &mut SdarKvCache,
         store_kv: bool,
     ) -> Result<Tensor, OCRError> {
+        self.forward_inner(inputs_embeds, positions, mask, cache, store_kv, false)
+    }
+
+    /// Run the same Qwen3 decoder in ordinary autoregressive causal mode.
+    ///
+    /// SDAR itself uses block-level masks and therefore calls [`Self::forward`]
+    /// with non-causal attention. Multimodal models that share its Qwen3 +
+    /// QK-norm backbone can use this path for flash-attention prefill and
+    /// token-by-token decoding without duplicating the decoder stack.
+    pub(crate) fn forward_causal(
+        &self,
+        inputs_embeds: &Tensor,
+        positions: &[i64],
+        cache: &mut SdarKvCache,
+        store_kv: bool,
+    ) -> Result<Tensor, OCRError> {
+        self.forward_inner(inputs_embeds, positions, None, cache, store_kv, true)
+    }
+
+    fn forward_inner(
+        &self,
+        inputs_embeds: &Tensor,
+        positions: &[i64],
+        mask: Option<&Tensor>,
+        cache: &mut SdarKvCache,
+        store_kv: bool,
+        is_causal: bool,
+    ) -> Result<Tensor, OCRError> {
         let (cos, sin) = self.rope_for(positions)?;
         let mut hidden = inputs_embeds.clone();
+        let mode = AttentionMode {
+            store_kv,
+            is_causal,
+        };
         for (layer, layer_cache) in self.layers.iter().zip(cache.layers.iter_mut()) {
-            hidden = layer.forward(&hidden, &cos, &sin, mask, layer_cache, store_kv)?;
+            hidden = layer.forward(&hidden, &cos, &sin, mask, layer_cache, mode)?;
         }
         self.norm
             .forward(&hidden)

--- a/oar-ocr-vl/src/monkeyocrv2/config.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/config.rs
@@ -276,4 +276,29 @@ mod tests {
         assert_eq!(config.text_config.head_dim().unwrap(), 128);
         assert_eq!(config.vision_config.head_dim().unwrap(), 64);
     }
+
+    #[test]
+    fn parses_shipped_b_config_shape() {
+        let config: MonkeyOcrV2Config = serde_json::from_str(
+            r#"{
+              "model_type":"monkeyocrv2","vocab_size":151936,"hidden_size":1024,
+              "intermediate_size":3072,"num_hidden_layers":28,"num_attention_heads":16,
+              "num_key_value_heads":8,"head_dim":128,"max_position_embeddings":40960,
+              "attention_bias":false,"tie_word_embeddings":true,"rope_theta":1000000,
+              "rms_norm_eps":0.000001,"hidden_act":"silu","image_token_id":151655,
+              "video_token_id":151656,
+              "vision_config":{"embed_dim":768,"hidden_size":1024,
+                "intermediate_size":3072,"num_hidden_layers":12,"num_attention_heads":12,
+                "num_channels":3,"patch_size":14,"spatial_merge_size":2,
+                "temporal_patch_size":1,"rms_norm_eps":0.00001,"use_bias":false,
+                "post_norm":true}
+            }"#,
+        )
+        .unwrap();
+        config.validate().unwrap();
+        assert_eq!(config.text_config.head_dim().unwrap(), 128);
+        assert_eq!(config.vision_config.embed_dim, 768);
+        assert_eq!(config.vision_config.num_attention_heads, 12);
+        assert_eq!(config.vision_config.head_dim().unwrap(), 64);
+    }
 }

--- a/oar-ocr-vl/src/monkeyocrv2/config.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/config.rs
@@ -1,0 +1,279 @@
+use crate::mineru_diffusion::SdarConfig;
+use oar_ocr_core::core::OCRError;
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MonkeyOcrV2VisionConfig {
+    pub embed_dim: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    #[serde(default = "default_num_channels")]
+    pub num_channels: usize,
+    pub patch_size: usize,
+    pub spatial_merge_size: usize,
+    pub temporal_patch_size: usize,
+    pub rms_norm_eps: f64,
+    #[serde(default)]
+    pub use_bias: bool,
+    #[serde(default = "crate::utils::default_true")]
+    pub post_norm: bool,
+}
+
+fn default_num_channels() -> usize {
+    3
+}
+
+impl MonkeyOcrV2VisionConfig {
+    pub fn head_dim(&self) -> Result<usize, OCRError> {
+        if self.num_attention_heads == 0 || !self.embed_dim.is_multiple_of(self.num_attention_heads)
+        {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "MonkeyOCRv2 vision embed_dim {} must be divisible by num_attention_heads {}",
+                    self.embed_dim, self.num_attention_heads
+                ),
+            });
+        }
+        Ok(self.embed_dim / self.num_attention_heads)
+    }
+
+    pub fn validate(&self) -> Result<(), OCRError> {
+        if self.embed_dim == 0
+            || self.hidden_size == 0
+            || self.intermediate_size == 0
+            || self.num_hidden_layers == 0
+            || self.patch_size == 0
+            || self.spatial_merge_size == 0
+            || self.temporal_patch_size == 0
+        {
+            return Err(OCRError::ConfigError {
+                message: "MonkeyOCRv2 vision dimensions must be non-zero".to_string(),
+            });
+        }
+        if self.num_channels != 3 {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "MonkeyOCRv2 currently supports RGB checkpoints, got num_channels={}",
+                    self.num_channels
+                ),
+            });
+        }
+        if self.temporal_patch_size != 1 {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "MonkeyOCRv2 image checkpoints require temporal_patch_size=1, got {}",
+                    self.temporal_patch_size
+                ),
+            });
+        }
+        if self.use_bias {
+            return Err(OCRError::ConfigError {
+                message: "MonkeyOCRv2 vision transformer use_bias=true is unsupported".to_string(),
+            });
+        }
+        let head_dim = self.head_dim()?;
+        if !head_dim.is_multiple_of(4) {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "MonkeyOCRv2 vision head_dim {head_dim} must be divisible by 4 for 2D RoPE"
+                ),
+            });
+        }
+        if !self.rms_norm_eps.is_finite() || self.rms_norm_eps <= 0.0 {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "MonkeyOCRv2 vision rms_norm_eps must be positive, got {}",
+                    self.rms_norm_eps
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MonkeyOcrV2Config {
+    #[serde(flatten)]
+    pub text_config: SdarConfig,
+    pub vision_config: MonkeyOcrV2VisionConfig,
+    pub image_token_id: u32,
+    pub video_token_id: u32,
+    pub model_type: String,
+}
+
+impl MonkeyOcrV2Config {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+        let config: Self = crate::utils::load_json_config(path, "MonkeyOCRv2", "config.json")?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> Result<(), OCRError> {
+        if self.model_type != "monkeyocrv2" {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "MonkeyOCRv2 expected model_type 'monkeyocrv2', got '{}'",
+                    self.model_type
+                ),
+            });
+        }
+        if self.text_config.hidden_act != "silu" {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "MonkeyOCRv2 supports Qwen3 hidden_act 'silu', got '{}'",
+                    self.text_config.hidden_act
+                ),
+            });
+        }
+        if self.text_config.attention_bias {
+            return Err(OCRError::ConfigError {
+                message: "MonkeyOCRv2 attention_bias=true is unsupported".to_string(),
+            });
+        }
+        if self.text_config.vocab_size == 0
+            || self.text_config.hidden_size == 0
+            || self.text_config.num_hidden_layers == 0
+            || self.text_config.num_attention_heads == 0
+            || self.text_config.num_key_value_heads == 0
+            || self.text_config.max_position_embeddings == 0
+        {
+            return Err(OCRError::ConfigError {
+                message: "MonkeyOCRv2 text dimensions must be non-zero".to_string(),
+            });
+        }
+        if self.text_config.head_dim()? == 0 {
+            return Err(OCRError::ConfigError {
+                message: "MonkeyOCRv2 text head_dim must be non-zero".to_string(),
+            });
+        }
+        if !self
+            .text_config
+            .num_attention_heads
+            .is_multiple_of(self.text_config.num_key_value_heads)
+        {
+            return Err(OCRError::ConfigError {
+                message: "MonkeyOCRv2 attention heads must be divisible by KV heads".to_string(),
+            });
+        }
+        if self.text_config.hidden_size != self.vision_config.hidden_size {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "MonkeyOCRv2 vision merger output {} != text hidden size {}",
+                    self.vision_config.hidden_size, self.text_config.hidden_size
+                ),
+            });
+        }
+        self.vision_config.validate()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MonkeyOcrV2ImageProcessorConfig {
+    pub min_pixels: u32,
+    pub max_pixels: u32,
+    pub patch_size: usize,
+    pub temporal_patch_size: usize,
+    pub merge_size: usize,
+    pub image_mean: Vec<f32>,
+    pub image_std: Vec<f32>,
+    #[serde(default = "crate::utils::default_true")]
+    pub do_resize: bool,
+    #[serde(default = "crate::utils::default_true")]
+    pub do_rescale: bool,
+    #[serde(default = "crate::utils::default_true")]
+    pub do_normalize: bool,
+    #[serde(default = "crate::utils::default_rescale_factor")]
+    pub rescale_factor: f32,
+    #[serde(default)]
+    pub resample: Option<u32>,
+}
+
+impl MonkeyOcrV2ImageProcessorConfig {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+        let config: Self =
+            crate::utils::load_json_config(path, "MonkeyOCRv2", "preprocessor_config.json")?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> Result<(), OCRError> {
+        crate::utils::validate_patch_merge_temporal(
+            "MonkeyOCRv2",
+            self.patch_size,
+            self.merge_size,
+            self.temporal_patch_size,
+        )?;
+        if self.min_pixels == 0 || self.max_pixels == 0 || self.min_pixels > self.max_pixels {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "MonkeyOCRv2 invalid pixel bounds: {}..{}",
+                    self.min_pixels, self.max_pixels
+                ),
+            });
+        }
+        if self.do_normalize {
+            crate::utils::validate_image_mean_std(
+                "MonkeyOCRv2",
+                &self.image_mean,
+                &self.image_std,
+            )?;
+            if self.image_std.contains(&0.0) {
+                return Err(OCRError::ConfigError {
+                    message: "MonkeyOCRv2 image_std values must be non-zero".to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub fn validate_vision(&self, vision: &MonkeyOcrV2VisionConfig) -> Result<(), OCRError> {
+        if self.patch_size != vision.patch_size
+            || self.temporal_patch_size != vision.temporal_patch_size
+            || self.merge_size != vision.spatial_merge_size
+        {
+            return Err(OCRError::ConfigError {
+                message: format!(
+                    "MonkeyOCRv2 processor/vision mismatch: patch {}/{}, temporal {}/{}, merge {}/{}",
+                    self.patch_size,
+                    vision.patch_size,
+                    self.temporal_patch_size,
+                    vision.temporal_patch_size,
+                    self.merge_size,
+                    vision.spatial_merge_size
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_shipped_s_config_shape() {
+        let config: MonkeyOcrV2Config = serde_json::from_str(
+            r#"{
+              "model_type":"monkeyocrv2","vocab_size":151936,"hidden_size":1024,
+              "intermediate_size":3072,"num_hidden_layers":28,"num_attention_heads":16,
+              "num_key_value_heads":8,"head_dim":128,"max_position_embeddings":40960,
+              "attention_bias":false,"tie_word_embeddings":true,"rope_theta":1000000,
+              "rms_norm_eps":0.000001,"hidden_act":"silu","image_token_id":151655,
+              "video_token_id":151656,
+              "vision_config":{"embed_dim":384,"hidden_size":1024,
+                "intermediate_size":1536,"num_hidden_layers":12,"num_attention_heads":6,
+                "num_channels":3,"patch_size":14,"spatial_merge_size":2,
+                "temporal_patch_size":1,"rms_norm_eps":0.00001,"use_bias":false,
+                "post_norm":true}
+            }"#,
+        )
+        .unwrap();
+        config.validate().unwrap();
+        assert_eq!(config.text_config.head_dim().unwrap(), 128);
+        assert_eq!(config.vision_config.head_dim().unwrap(), 64);
+    }
+}

--- a/oar-ocr-vl/src/monkeyocrv2/mod.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/mod.rs
@@ -1,0 +1,13 @@
+//! MonkeyOCRv2-S-Parsing document VLM.
+//!
+//! The checkpoint combines a MonkeyOCRv2 ViT-S encoder with a Qwen3-0.6B
+//! causal decoder. This module provides native Candle inference for the
+//! official layout, end-to-end, text, formula, and OTSL-table prompts.
+
+mod config;
+mod model;
+mod processing;
+mod vision;
+
+pub use config::{MonkeyOcrV2Config, MonkeyOcrV2ImageProcessorConfig, MonkeyOcrV2VisionConfig};
+pub use model::{DEFAULT_MAX_NEW_TOKENS, LAYOUT_MIN_PIXELS, MonkeyOcrV2, MonkeyOcrV2Task};

--- a/oar-ocr-vl/src/monkeyocrv2/mod.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/mod.rs
@@ -1,8 +1,8 @@
-//! MonkeyOCRv2-S-Parsing document VLM.
+//! MonkeyOCRv2-S/B-Parsing document VLM.
 //!
-//! The checkpoint combines a MonkeyOCRv2 ViT-S encoder with a Qwen3-0.6B
-//! causal decoder. This module provides native Candle inference for the
-//! official layout, end-to-end, text, formula, and OTSL-table prompts.
+//! The checkpoints combine MonkeyOCRv2 ViT-S or ViT-B encoders with a
+//! Qwen3-0.6B causal decoder. This module provides native Candle inference
+//! for the official layout, end-to-end, text, formula, and OTSL-table prompts.
 
 mod config;
 mod model;

--- a/oar-ocr-vl/src/monkeyocrv2/model.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/model.rs
@@ -237,7 +237,7 @@ impl MonkeyOcrV2 {
             if step + 1 == max_new_tokens {
                 break;
             }
-            let token_ids = Tensor::from_vec(vec![token], (1, 1), &self.device)
+            let token_ids = Tensor::new(&[[token]], &self.device)
                 .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "create decode token", e))?;
             let token_embed = self.text.embed(&token_ids)?;
             let hidden = self.text.forward_causal(
@@ -261,7 +261,8 @@ impl MonkeyOcrV2 {
         image_inputs: &MonkeyOcrV2ImageInputs,
     ) -> Result<Tensor, OCRError> {
         let seq_len = input_ids.len();
-        let token_ids = Tensor::from_vec(input_ids.to_vec(), (1, seq_len), &self.device)
+        let token_ids = Tensor::new(input_ids, &self.device)
+            .and_then(|tensor| tensor.unsqueeze(0))
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "create prompt token ids", e))?;
         let token_embeds = self.text.embed(&token_ids)?;
         let image_embeds = self

--- a/oar-ocr-vl/src/monkeyocrv2/model.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/model.rs
@@ -17,7 +17,7 @@ const MODEL_NAME: &str = "MonkeyOCRv2";
 pub const DEFAULT_MAX_NEW_TOKENS: usize = 10_000;
 pub const LAYOUT_MIN_PIXELS: u32 = 1_003_520;
 
-/// Official MonkeyOCRv2-S-Parsing inference tasks and prompts.
+/// Official MonkeyOCRv2-S/B-Parsing inference tasks and prompts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MonkeyOcrV2Task {
     /// Detect document elements in reading order, returning normalized boxes and labels.
@@ -52,7 +52,7 @@ impl MonkeyOcrV2Task {
     }
 }
 
-/// Candle-native MonkeyOCRv2-S-Parsing model (Monkey ViT-S + Qwen3-0.6B).
+/// Candle-native MonkeyOCRv2-S/B-Parsing model (Monkey ViT-S/B + Qwen3-0.6B).
 pub struct MonkeyOcrV2 {
     device: Device,
     dtype: DType,

--- a/oar-ocr-vl/src/monkeyocrv2/model.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/model.rs
@@ -1,0 +1,480 @@
+use super::config::{MonkeyOcrV2Config, MonkeyOcrV2ImageProcessorConfig};
+use super::processing::{MonkeyOcrV2ImageInputs, preprocess_image};
+use super::vision::MonkeyOcrV2VisionModel;
+#[cfg(feature = "cuda")]
+use crate::cuda_kernels::{ArgmaxFirstBf16, ArgmaxFirstF32};
+use crate::doc_parser::{RecognitionBackend, RecognitionTask};
+use crate::mineru_diffusion::text::{SdarKvCache, SdarModel};
+use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
+use candle_core::{DType, Device, IndexOp, Tensor};
+use image::RgbImage;
+use oar_ocr_core::core::OCRError;
+use std::path::Path;
+use tokenizers::Tokenizer;
+
+const MODEL_NAME: &str = "MonkeyOCRv2";
+
+pub const DEFAULT_MAX_NEW_TOKENS: usize = 10_000;
+pub const LAYOUT_MIN_PIXELS: u32 = 1_003_520;
+
+/// Official MonkeyOCRv2-S-Parsing inference tasks and prompts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonkeyOcrV2Task {
+    /// Detect document elements in reading order, returning normalized boxes and labels.
+    Layout,
+    /// Parse a full page in one pass, returning labels, boxes, and content.
+    EndToEnd,
+    /// Recognize ordinary text in an image or cropped document region.
+    Text,
+    /// Recognize a formula as LaTeX.
+    Formula,
+    /// Recognize a table in OTSL format.
+    Table,
+}
+
+impl MonkeyOcrV2Task {
+    pub fn prompt(self) -> &'static str {
+        match self {
+            Self::Layout => {
+                "Please output the categories and coordinates of the document elements in reading order."
+            }
+            Self::EndToEnd => {
+                "List the document elements in reading order, including their categories, coordinates, and the content of each element."
+            }
+            Self::Text => "Please output the text content from the image.",
+            Self::Formula => {
+                "Please write out the expression of the formula in the image using LaTeX format."
+            }
+            Self::Table => {
+                "Please extract the table from the image and represent it in OTSL format."
+            }
+        }
+    }
+}
+
+/// Candle-native MonkeyOCRv2-S-Parsing model (Monkey ViT-S + Qwen3-0.6B).
+pub struct MonkeyOcrV2 {
+    device: Device,
+    dtype: DType,
+    cfg: MonkeyOcrV2Config,
+    image_cfg: MonkeyOcrV2ImageProcessorConfig,
+    tokenizer: Tokenizer,
+    vision: MonkeyOcrV2VisionModel,
+    text: SdarModel,
+    stop_token_ids: Vec<u32>,
+    image_token_id: u32,
+}
+
+impl MonkeyOcrV2 {
+    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, OCRError> {
+        let model_dir = model_dir.as_ref();
+        let cfg = MonkeyOcrV2Config::from_path(model_dir.join("config.json"))?;
+        let image_cfg =
+            MonkeyOcrV2ImageProcessorConfig::from_path(model_dir.join("preprocessor_config.json"))?;
+        image_cfg.validate_vision(&cfg.vision_config)?;
+        let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| {
+            OCRError::ConfigError {
+                message: format!("MonkeyOCRv2 failed to load tokenizer.json: {e}"),
+            }
+        })?;
+        require_token(&tokenizer, "<|image_pad|>", Some(cfg.image_token_id))?;
+        require_token(&tokenizer, "<|vision_start|>", None)?;
+        require_token(&tokenizer, "<|vision_end|>", None)?;
+        require_token(&tokenizer, "<|im_start|>", None)?;
+        let im_end = require_token(&tokenizer, "<|im_end|>", None)?;
+        let end_of_text = require_token(&tokenizer, "<|endoftext|>", None)?;
+
+        let dtype = crate::utils::select_dtype(&device);
+        let weight_files = crate::utils::collect_safetensors(model_dir, MODEL_NAME)?;
+        // SAFETY: the mapped checkpoint files must not be modified while this model is alive.
+        let vb = unsafe {
+            candle_nn::VarBuilder::from_mmaped_safetensors(&weight_files, dtype, &device)
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load safetensors", e))?
+        };
+        let vision = MonkeyOcrV2VisionModel::load(&cfg.vision_config, vb.pp("vision_tower"))?;
+        let text = SdarModel::load(&cfg.text_config, vb, dtype)?;
+        let mut stop_token_ids = vec![im_end, end_of_text];
+        if let Some(eos) = cfg.text_config.eos_token_id {
+            stop_token_ids.push(eos);
+        }
+        if let Some(pad) = cfg.text_config.pad_token_id {
+            stop_token_ids.push(pad);
+        }
+        stop_token_ids.sort_unstable();
+        stop_token_ids.dedup();
+        let image_token_id = cfg.image_token_id;
+        Ok(Self {
+            device,
+            dtype,
+            cfg,
+            image_cfg,
+            tokenizer,
+            vision,
+            text,
+            stop_token_ids,
+            image_token_id,
+        })
+    }
+
+    /// Run official task prompts for one or more images.
+    pub fn generate(
+        &self,
+        images: &[RgbImage],
+        tasks: &[MonkeyOcrV2Task],
+        max_new_tokens: usize,
+    ) -> Vec<Result<String, OCRError>> {
+        self.generate_tokens(images, tasks, max_new_tokens)
+            .into_iter()
+            .map(|result| result.and_then(|tokens| self.decode_tokens(&tokens)))
+            .collect()
+    }
+
+    /// Run the model with caller-provided instructions.
+    pub fn generate_with_prompts(
+        &self,
+        images: &[RgbImage],
+        prompts: &[impl AsRef<str>],
+        max_new_tokens: usize,
+    ) -> Vec<Result<String, OCRError>> {
+        if images.len() != prompts.len() {
+            return vec![Err(length_mismatch(images.len(), prompts.len()))];
+        }
+        images
+            .iter()
+            .zip(prompts)
+            .map(|(image, prompt)| {
+                self.generate_one(image, prompt.as_ref(), max_new_tokens, None)
+                    .and_then(|tokens| self.decode_tokens(&tokens))
+            })
+            .collect()
+    }
+
+    /// Generate raw token ids with official task prompts.
+    pub fn generate_tokens(
+        &self,
+        images: &[RgbImage],
+        tasks: &[MonkeyOcrV2Task],
+        max_new_tokens: usize,
+    ) -> Vec<Result<Vec<u32>, OCRError>> {
+        if images.len() != tasks.len() {
+            return vec![Err(length_mismatch(images.len(), tasks.len()))];
+        }
+        images
+            .iter()
+            .zip(tasks)
+            .map(|(image, &task)| {
+                let min_pixels = (task == MonkeyOcrV2Task::Layout).then_some(LAYOUT_MIN_PIXELS);
+                self.generate_one(image, task.prompt(), max_new_tokens, min_pixels)
+            })
+            .collect()
+    }
+
+    fn generate_one(
+        &self,
+        image: &RgbImage,
+        instruction: &str,
+        max_new_tokens: usize,
+        min_pixels_override: Option<u32>,
+    ) -> Result<Vec<u32>, OCRError> {
+        if max_new_tokens == 0 {
+            return Ok(Vec::new());
+        }
+        let mut image_cfg = self.image_cfg.clone();
+        if let Some(min_pixels) = min_pixels_override {
+            image_cfg.min_pixels = image_cfg.min_pixels.max(min_pixels);
+            image_cfg.min_pixels = image_cfg.min_pixels.min(image_cfg.max_pixels);
+        }
+        let image_inputs = preprocess_image(image, &image_cfg, &self.device, self.dtype)?;
+        let prompt = build_prompt(instruction, image_inputs.num_image_tokens);
+        let encoding =
+            self.tokenizer
+                .encode(prompt, false)
+                .map_err(|e| OCRError::InvalidInput {
+                    message: format!("MonkeyOCRv2 tokenizer encode failed: {e}"),
+                })?;
+        let input_ids = encoding.get_ids();
+        if input_ids.is_empty() {
+            return Err(OCRError::InvalidInput {
+                message: "MonkeyOCRv2 prompt tokenization produced no tokens".to_string(),
+            });
+        }
+        validate_generation_length(
+            input_ids.len(),
+            max_new_tokens,
+            self.cfg.text_config.max_position_embeddings,
+        )?;
+        let inputs_embeds = self.prepare_inputs(input_ids, &image_inputs)?;
+        let positions: Vec<i64> = (0..input_ids.len() as i64).collect();
+        let mut cache = SdarKvCache::new(self.text.num_layers());
+        let hidden = self
+            .text
+            .forward_causal(&inputs_embeds, &positions, &mut cache, true)?;
+        let prompt_len = input_ids.len();
+        let mut logits = self
+            .text
+            .lm_logits(
+                &hidden
+                    .i((.., prompt_len - 1..prompt_len, ..))
+                    .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "select prompt hidden", e))?,
+            )?
+            .i((0, 0, ..))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "select prompt logits", e))?;
+
+        let mut generated = Vec::new();
+        generated
+            .try_reserve_exact(max_new_tokens)
+            .map_err(|e| OCRError::InvalidInput {
+                message: format!(
+                    "MonkeyOCRv2 cannot reserve output for {max_new_tokens} tokens: {e}"
+                ),
+            })?;
+        for step in 0..max_new_tokens {
+            let token = select_greedy_token(&logits)?;
+            if self.stop_token_ids.contains(&token) {
+                break;
+            }
+            generated.push(token);
+            if step + 1 == max_new_tokens {
+                break;
+            }
+            let token_ids = Tensor::from_vec(vec![token], (1, 1), &self.device)
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "create decode token", e))?;
+            let token_embed = self.text.embed(&token_ids)?;
+            let hidden = self.text.forward_causal(
+                &token_embed,
+                &[prompt_len as i64 + step as i64],
+                &mut cache,
+                true,
+            )?;
+            logits = self
+                .text
+                .lm_logits(&hidden)?
+                .i((0, 0, ..))
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "select decode logits", e))?;
+        }
+        Ok(generated)
+    }
+
+    fn prepare_inputs(
+        &self,
+        input_ids: &[u32],
+        image_inputs: &MonkeyOcrV2ImageInputs,
+    ) -> Result<Tensor, OCRError> {
+        let seq_len = input_ids.len();
+        let token_ids = Tensor::from_vec(input_ids.to_vec(), (1, seq_len), &self.device)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "create prompt token ids", e))?;
+        let token_embeds = self.text.embed(&token_ids)?;
+        let image_embeds = self
+            .vision
+            .forward(&image_inputs.pixel_values, image_inputs.grid_thw)?
+            .to_dtype(self.dtype)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "cast image embeddings", e))?;
+        let positions: Vec<usize> = input_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &token)| (token == self.image_token_id).then_some(index))
+            .collect();
+        let image_len = image_embeds
+            .dim(0)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read image embedding count", e))?;
+        if positions.len() != image_len || positions.is_empty() {
+            return Err(OCRError::InvalidInput {
+                message: format!(
+                    "MonkeyOCRv2 image placeholder count {} != image embedding count {image_len}",
+                    positions.len()
+                ),
+            });
+        }
+        let start = positions[0];
+        if positions
+            .iter()
+            .enumerate()
+            .any(|(offset, &position)| position != start + offset)
+        {
+            return Err(OCRError::InvalidInput {
+                message: "MonkeyOCRv2 image placeholders must be contiguous".to_string(),
+            });
+        }
+        let end = start + image_len;
+        let prefix = token_embeds
+            .narrow(1, 0, start)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "select embedding prefix", e))?;
+        let image_embeds = image_embeds
+            .unsqueeze(0)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "batch image embeddings", e))?;
+        let suffix = token_embeds
+            .narrow(1, end, seq_len - end)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "select embedding suffix", e))?;
+        Tensor::cat(&[&prefix, &image_embeds, &suffix], 1)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "merge multimodal embeddings", e))
+    }
+
+    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+        self.tokenizer
+            .decode(tokens, true)
+            .map(|text| text.trim().to_string())
+            .map_err(|e| OCRError::InvalidInput {
+                message: format!("MonkeyOCRv2 tokenizer decode failed: {e}"),
+            })
+    }
+
+    pub fn tokenizer(&self) -> &Tokenizer {
+        &self.tokenizer
+    }
+
+    pub fn config(&self) -> &MonkeyOcrV2Config {
+        &self.cfg
+    }
+
+    pub fn image_processor_config(&self) -> &MonkeyOcrV2ImageProcessorConfig {
+        &self.image_cfg
+    }
+}
+
+impl RecognitionBackend for MonkeyOcrV2 {
+    fn recognize(
+        &self,
+        image: RgbImage,
+        task: RecognitionTask,
+        max_tokens: usize,
+    ) -> Result<String, OCRError> {
+        let monkey_task = match task {
+            RecognitionTask::Ocr | RecognitionTask::Chart => MonkeyOcrV2Task::Text,
+            RecognitionTask::Table => MonkeyOcrV2Task::Table,
+            RecognitionTask::Formula => MonkeyOcrV2Task::Formula,
+        };
+        self.generate(&[image], &[monkey_task], max_tokens)
+            .pop()
+            .expect("one MonkeyOCRv2 recognition result")
+    }
+
+    fn needs_table_postprocess(&self) -> bool {
+        true
+    }
+
+    fn needs_repetition_truncation(&self) -> bool {
+        true
+    }
+}
+
+fn build_prompt(instruction: &str, num_image_tokens: usize) -> String {
+    let mut prompt = String::with_capacity(instruction.len() + num_image_tokens * 13 + 128);
+    prompt.push_str("<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n");
+    prompt.push_str("<|im_start|>user\n<|vision_start|>");
+    for _ in 0..num_image_tokens {
+        prompt.push_str("<|image_pad|>");
+    }
+    prompt.push_str("<|vision_end|>");
+    prompt.push_str(instruction);
+    prompt.push_str("<|im_end|>\n<|im_start|>assistant\n");
+    prompt
+}
+
+fn require_token(
+    tokenizer: &Tokenizer,
+    token: &str,
+    expected: Option<u32>,
+) -> Result<u32, OCRError> {
+    let id = tokenizer
+        .token_to_id(token)
+        .ok_or_else(|| OCRError::ConfigError {
+            message: format!("MonkeyOCRv2 tokenizer is missing {token:?}"),
+        })?;
+    if let Some(expected) = expected
+        && id != expected
+    {
+        return Err(OCRError::ConfigError {
+            message: format!(
+                "MonkeyOCRv2 token {token:?} id mismatch: tokenizer {id} != config {expected}"
+            ),
+        });
+    }
+    Ok(id)
+}
+
+fn length_mismatch(images: usize, tasks: usize) -> OCRError {
+    OCRError::InvalidInput {
+        message: format!("MonkeyOCRv2 image count {images} != task/prompt count {tasks}"),
+    }
+}
+
+fn validate_generation_length(
+    prompt_len: usize,
+    max_new_tokens: usize,
+    context_limit: usize,
+) -> Result<(), OCRError> {
+    let requested =
+        prompt_len
+            .checked_add(max_new_tokens)
+            .ok_or_else(|| OCRError::InvalidInput {
+                message: "MonkeyOCRv2 requested sequence length overflows usize".to_string(),
+            })?;
+    if requested > context_limit {
+        return Err(OCRError::InvalidInput {
+            message: format!(
+                "MonkeyOCRv2 prompt ({prompt_len}) plus max_new_tokens ({max_new_tokens}) exceeds context limit {context_limit}"
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn select_greedy_token(logits: &Tensor) -> Result<u32, OCRError> {
+    #[cfg(feature = "cuda")]
+    if logits.device().is_cuda() && matches!(logits.dtype(), DType::BF16 | DType::F32) {
+        let vocab_size = logits.elem_count();
+        let logits = logits
+            .reshape((1, vocab_size))
+            .and_then(|logits| logits.contiguous())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "reshape GPU logits", e))?;
+        let tokens = match logits.dtype() {
+            DType::BF16 => logits.apply_op1_no_bwd(&ArgmaxFirstBf16),
+            DType::F32 => logits.apply_op1_no_bwd(&ArgmaxFirstF32),
+            _ => unreachable!("dtype checked above"),
+        }
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "stable GPU argmax", e))?;
+        return tokens
+            .i(0)
+            .and_then(|token| token.to_scalar::<u32>())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "copy selected token", e));
+    }
+
+    logits
+        .argmax(candle_core::D::Minus1)
+        .and_then(|token| token.to_scalar::<u32>())
+        .map_err(|e| {
+            candle_to_ocr_processing(
+                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                "MonkeyOCRv2 greedy argmax",
+                e,
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_matches_official_template() {
+        assert_eq!(
+            build_prompt("Question", 2),
+            "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n<|vision_start|><|image_pad|><|image_pad|><|vision_end|>Question<|im_end|>\n<|im_start|>assistant\n"
+        );
+    }
+
+    #[test]
+    fn tasks_match_reference_prompts() {
+        assert_eq!(
+            MonkeyOcrV2Task::Table.prompt(),
+            "Please extract the table from the image and represent it in OTSL format."
+        );
+        assert!(MonkeyOcrV2Task::EndToEnd.prompt().contains("reading order"));
+    }
+
+    #[test]
+    fn greedy_argmax_prefers_first_tie() {
+        let logits = Tensor::from_vec(vec![1f32, 3., 3., 2.], 4, &Device::Cpu).unwrap();
+        assert_eq!(select_greedy_token(&logits).unwrap(), 1);
+    }
+}

--- a/oar-ocr-vl/src/monkeyocrv2/processing.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/processing.rs
@@ -28,7 +28,7 @@ pub fn preprocess_image(
 
     let factor = (cfg.patch_size * cfg.merge_size) as u32;
     let (height, width) = (image.height(), image.width());
-    if cfg.do_resize && (height < factor || width < factor) {
+    if height < factor || width < factor {
         return Err(OCRError::InvalidInput {
             message: format!(
                 "MonkeyOCRv2 image dimensions must be at least {factor}x{factor}, got {width}x{height}"
@@ -44,10 +44,12 @@ pub fn preprocess_image(
         .resample
         .and_then(pil_resample_to_filter_type)
         .unwrap_or(FilterType::CatmullRom);
+    let resized_holder;
     let resized = if resized_height != height || resized_width != width {
-        image::imageops::resize(image, resized_width, resized_height, filter)
+        resized_holder = image::imageops::resize(image, resized_width, resized_height, filter);
+        &resized_holder
     } else {
-        image.clone()
+        image
     };
 
     let default_mean = [0.0_f32; 3];
@@ -63,7 +65,7 @@ pub fn preprocess_image(
         &default_std
     };
     let rescale = cfg.do_rescale.then_some(cfg.rescale_factor);
-    let frame = image_to_chw(&resized, mean, std, rescale);
+    let frame = image_to_chw(resized, mean, std, rescale);
     let frames: Vec<&[f32]> =
         std::iter::repeat_n(frame.as_slice(), cfg.temporal_patch_size).collect();
 
@@ -143,5 +145,19 @@ mod tests {
         assert_eq!(inputs.grid_thw, (1, 4, 6));
         assert_eq!(inputs.num_image_tokens, 6);
         assert_eq!(inputs.pixel_values.dims(), &[24, 588]);
+    }
+
+    #[test]
+    fn rejects_too_small_image_when_resize_is_disabled() {
+        let image = RgbImage::new(27, 28);
+        let mut cfg = config();
+        cfg.do_resize = false;
+
+        let error = preprocess_image(&image, &cfg, &Device::Cpu, DType::F32).unwrap_err();
+        assert!(matches!(
+            error,
+            OCRError::InvalidInput { message }
+                if message.contains("at least 28x28, got 27x28")
+        ));
     }
 }

--- a/oar-ocr-vl/src/monkeyocrv2/processing.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/processing.rs
@@ -1,0 +1,147 @@
+use super::config::MonkeyOcrV2ImageProcessorConfig;
+use crate::utils::image::{
+    image_to_chw, patchify_merge_grouped, pil_resample_to_filter_type, smart_resize,
+};
+use candle_core::{DType, Device, Tensor};
+use image::{RgbImage, imageops::FilterType};
+use oar_ocr_core::core::OCRError;
+
+#[derive(Debug, Clone)]
+pub struct MonkeyOcrV2ImageInputs {
+    pub pixel_values: Tensor,
+    pub grid_thw: (usize, usize, usize),
+    pub num_image_tokens: usize,
+}
+
+pub fn preprocess_image(
+    image: &RgbImage,
+    cfg: &MonkeyOcrV2ImageProcessorConfig,
+    device: &Device,
+    dtype: DType,
+) -> Result<MonkeyOcrV2ImageInputs, OCRError> {
+    cfg.validate()?;
+    if image.width() == 0 || image.height() == 0 {
+        return Err(OCRError::InvalidInput {
+            message: "MonkeyOCRv2 cannot process an empty image".to_string(),
+        });
+    }
+
+    let factor = (cfg.patch_size * cfg.merge_size) as u32;
+    let (height, width) = (image.height(), image.width());
+    if cfg.do_resize && (height < factor || width < factor) {
+        return Err(OCRError::InvalidInput {
+            message: format!(
+                "MonkeyOCRv2 image dimensions must be at least {factor}x{factor}, got {width}x{height}"
+            ),
+        });
+    }
+    let (resized_height, resized_width) = if cfg.do_resize {
+        smart_resize(height, width, factor, cfg.min_pixels, cfg.max_pixels)?
+    } else {
+        (height, width)
+    };
+    let filter = cfg
+        .resample
+        .and_then(pil_resample_to_filter_type)
+        .unwrap_or(FilterType::CatmullRom);
+    let resized = if resized_height != height || resized_width != width {
+        image::imageops::resize(image, resized_width, resized_height, filter)
+    } else {
+        image.clone()
+    };
+
+    let default_mean = [0.0_f32; 3];
+    let default_std = [1.0_f32; 3];
+    let mean = if cfg.do_normalize {
+        cfg.image_mean.as_slice()
+    } else {
+        &default_mean
+    };
+    let std = if cfg.do_normalize {
+        cfg.image_std.as_slice()
+    } else {
+        &default_std
+    };
+    let rescale = cfg.do_rescale.then_some(cfg.rescale_factor);
+    let frame = image_to_chw(&resized, mean, std, rescale);
+    let frames: Vec<&[f32]> =
+        std::iter::repeat_n(frame.as_slice(), cfg.temporal_patch_size).collect();
+
+    let grid_t = 1;
+    let grid_h = resized_height as usize / cfg.patch_size;
+    let grid_w = resized_width as usize / cfg.patch_size;
+    if !grid_h.is_multiple_of(cfg.merge_size) || !grid_w.is_multiple_of(cfg.merge_size) {
+        return Err(OCRError::ConfigError {
+            message: format!(
+                "MonkeyOCRv2 resized grid {grid_h}x{grid_w} is not divisible by merge_size {}",
+                cfg.merge_size
+            ),
+        });
+    }
+
+    let patches = patchify_merge_grouped(
+        &frames,
+        3,
+        resized_height as usize,
+        resized_width as usize,
+        grid_t,
+        grid_h,
+        grid_w,
+        cfg.patch_size,
+        cfg.merge_size,
+        cfg.temporal_patch_size,
+    );
+    let patch_dim = 3 * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size;
+    let num_patches = grid_t * grid_h * grid_w;
+    if patches.len() != num_patches * patch_dim {
+        return Err(OCRError::InvalidInput {
+            message: format!(
+                "MonkeyOCRv2 patch extraction produced {} values, expected {}",
+                patches.len(),
+                num_patches * patch_dim
+            ),
+        });
+    }
+    let pixel_values = Tensor::from_vec(patches, (num_patches, patch_dim), device)
+        .and_then(|tensor| tensor.to_dtype(dtype))
+        .map_err(|e| {
+            crate::utils::candle_to_ocr_inference("MonkeyOCRv2", "create image patch tensor", e)
+        })?;
+    let num_image_tokens = num_patches / (cfg.merge_size * cfg.merge_size);
+    Ok(MonkeyOcrV2ImageInputs {
+        pixel_values,
+        grid_thw: (grid_t, grid_h, grid_w),
+        num_image_tokens,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> MonkeyOcrV2ImageProcessorConfig {
+        MonkeyOcrV2ImageProcessorConfig {
+            min_pixels: 28 * 28,
+            max_pixels: 1024 * 1024,
+            patch_size: 14,
+            temporal_patch_size: 1,
+            merge_size: 2,
+            image_mean: vec![0.48145466, 0.4578275, 0.40821073],
+            image_std: vec![0.26862954, 0.261_302_6, 0.275_777_1],
+            do_resize: true,
+            do_rescale: true,
+            do_normalize: true,
+            rescale_factor: 1.0 / 255.0,
+            resample: Some(3),
+        }
+    }
+
+    #[test]
+    fn creates_merge_grouped_patches() {
+        let image = RgbImage::new(84, 56);
+        let inputs = preprocess_image(&image, &config(), &Device::Cpu, DType::F32).unwrap();
+        assert_eq!(inputs.grid_thw, (1, 4, 6));
+        assert_eq!(inputs.num_image_tokens, 6);
+        assert_eq!(inputs.pixel_values.dims(), &[24, 588]);
+    }
+}

--- a/oar-ocr-vl/src/monkeyocrv2/processing.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/processing.rs
@@ -35,6 +35,13 @@ pub fn preprocess_image(
             ),
         });
     }
+    if !cfg.do_resize && (!height.is_multiple_of(factor) || !width.is_multiple_of(factor)) {
+        return Err(OCRError::InvalidInput {
+            message: format!(
+                "MonkeyOCRv2 image dimensions must be divisible by {factor} when resizing is disabled, got {width}x{height}"
+            ),
+        });
+    }
     let (resized_height, resized_width) = if cfg.do_resize {
         smart_resize(height, width, factor, cfg.min_pixels, cfg.max_pixels)?
     } else {
@@ -158,6 +165,20 @@ mod tests {
             error,
             OCRError::InvalidInput { message }
                 if message.contains("at least 28x28, got 27x28")
+        ));
+    }
+
+    #[test]
+    fn rejects_unaligned_image_when_resize_is_disabled() {
+        let image = RgbImage::new(85, 56);
+        let mut cfg = config();
+        cfg.do_resize = false;
+
+        let error = preprocess_image(&image, &cfg, &Device::Cpu, DType::F32).unwrap_err();
+        assert!(matches!(
+            error,
+            OCRError::InvalidInput { message }
+                if message.contains("divisible by 28") && message.contains("85x56")
         ));
     }
 }

--- a/oar-ocr-vl/src/monkeyocrv2/processing.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/processing.rs
@@ -28,7 +28,7 @@ pub fn preprocess_image(
 
     let factor = (cfg.patch_size * cfg.merge_size) as u32;
     let (height, width) = (image.height(), image.width());
-    if height < factor || width < factor {
+    if !cfg.do_resize && (height < factor || width < factor) {
         return Err(OCRError::InvalidInput {
             message: format!(
                 "MonkeyOCRv2 image dimensions must be at least {factor}x{factor}, got {width}x{height}"
@@ -152,6 +152,15 @@ mod tests {
         assert_eq!(inputs.grid_thw, (1, 4, 6));
         assert_eq!(inputs.num_image_tokens, 6);
         assert_eq!(inputs.pixel_values.dims(), &[24, 588]);
+    }
+
+    #[test]
+    fn upscales_small_crop_when_resize_is_enabled() {
+        let image = RgbImage::new(84, 20);
+        let inputs = preprocess_image(&image, &config(), &Device::Cpu, DType::F32).unwrap();
+        assert_eq!(inputs.grid_thw, (1, 2, 6));
+        assert_eq!(inputs.num_image_tokens, 3);
+        assert_eq!(inputs.pixel_values.dims(), &[12, 588]);
     }
 
     #[test]

--- a/oar-ocr-vl/src/monkeyocrv2/vision.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/vision.rs
@@ -465,4 +465,27 @@ mod tests {
         let first = cos.i((0, 0, ..)).unwrap().to_vec1::<f32>().unwrap();
         assert!(first.iter().all(|value| (*value - 1.0).abs() < 1e-6));
     }
+
+    #[test]
+    fn rope_interleaves_axes_before_rotate_half_duplication() {
+        let like = Tensor::zeros((4, 588), DType::F32, &candle_core::Device::Cpu).unwrap();
+        let (cos, _) = build_vision_rope((1, 2, 2), 1, 8, &like).unwrap();
+        let bottom_right = cos.i((3, 0, ..)).unwrap().to_vec1::<f32>().unwrap();
+        let expected = [
+            1.0_f32.cos(),
+            1.0_f32.cos(),
+            0.01_f32.cos(),
+            0.01_f32.cos(),
+            1.0_f32.cos(),
+            1.0_f32.cos(),
+            0.01_f32.cos(),
+            0.01_f32.cos(),
+        ];
+        assert!(
+            bottom_right
+                .iter()
+                .zip(expected)
+                .all(|(actual, expected)| (*actual - expected).abs() < 1e-6)
+        );
+    }
 }

--- a/oar-ocr-vl/src/monkeyocrv2/vision.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/vision.rs
@@ -1,0 +1,468 @@
+use super::config::MonkeyOcrV2VisionConfig;
+use crate::attention::{
+    VISION_CHUNKED_ATTN_CHUNK_SIZE, VISION_CHUNKED_ATTN_SEQ_THRESHOLD, chunked_vision_attention,
+    flash_attention, scaled_dot_product_attention,
+};
+use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
+use candle_core::{DType, IndexOp, Tensor};
+use candle_nn::{
+    LayerNorm, LayerNormConfig, Linear, Module, RmsNorm, VarBuilder, layer_norm, linear,
+    linear_no_bias, rms_norm,
+};
+use oar_ocr_core::core::OCRError;
+
+const MODEL_NAME: &str = "MonkeyOCRv2";
+
+#[derive(Debug, Clone)]
+struct PatchEmbed {
+    weight: Tensor,
+    bias: Tensor,
+    norm: RmsNorm,
+}
+
+impl PatchEmbed {
+    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let patch_dim = cfg.num_channels * cfg.patch_size * cfg.patch_size;
+        let vb = vb.pp("patch_embed").pp("patchifier");
+        let weight = vb
+            .get(
+                (
+                    cfg.embed_dim,
+                    cfg.num_channels,
+                    cfg.patch_size,
+                    cfg.patch_size,
+                ),
+                "proj.weight",
+            )
+            .and_then(|weight| weight.reshape((cfg.embed_dim, patch_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load patch projection", e))?;
+        let bias = vb
+            .get(cfg.embed_dim, "proj.bias")
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load patch bias", e))?;
+        let norm = rms_norm(cfg.embed_dim, cfg.rms_norm_eps, vb.pp("norm"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load patch RMSNorm", e))?;
+        Ok(Self { weight, bias, norm })
+    }
+
+    fn forward(&self, patches: &Tensor) -> Result<Tensor, OCRError> {
+        let patches = patches
+            .to_dtype(self.weight.dtype())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "cast image patches", e))?;
+        let hidden =
+            patches
+                .matmul(&self.weight.transpose(0, 1).map_err(|e| {
+                    candle_to_ocr_inference(MODEL_NAME, "transpose patch weight", e)
+                })?)
+                .and_then(|hidden| hidden.broadcast_add(&self.bias))
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "patch projection", e))?;
+        self.norm
+            .forward(&hidden)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "patch RMSNorm", e))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VisionAttention {
+    qkv: Linear,
+    proj: Linear,
+    num_heads: usize,
+    head_dim: usize,
+    scale: f64,
+}
+
+impl VisionAttention {
+    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let qkv = linear_no_bias(cfg.embed_dim, cfg.embed_dim * 3, vb.pp("attn").pp("qkv"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision QKV", e))?;
+        let proj = linear_no_bias(cfg.embed_dim, cfg.embed_dim, vb.pp("attn").pp("proj"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision projection", e))?;
+        let head_dim = cfg.head_dim()?;
+        Ok(Self {
+            qkv,
+            proj,
+            num_heads: cfg.num_attention_heads,
+            head_dim,
+            scale: 1.0 / (head_dim as f64).sqrt(),
+        })
+    }
+
+    fn forward(&self, hidden: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, OCRError> {
+        let seq_len = hidden
+            .dim(0)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read vision sequence length", e))?;
+        let qkv = self
+            .qkv
+            .forward(hidden)
+            .and_then(|qkv| qkv.reshape((seq_len, 3, self.num_heads, self.head_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision QKV projection", e))?;
+        let q = qkv
+            .i((.., 0, .., ..))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "slice vision query", e))?;
+        let k = qkv
+            .i((.., 1, .., ..))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "slice vision key", e))?;
+        let v = qkv
+            .i((.., 2, .., ..))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "slice vision value", e))?;
+        let (q, k) = apply_vision_rope(&q, &k, cos, sin)?;
+        let q = q
+            .transpose(0, 1)
+            .and_then(|q| q.unsqueeze(0))
+            .and_then(|q| q.contiguous())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "layout vision query", e))?;
+        let k = k
+            .transpose(0, 1)
+            .and_then(|k| k.unsqueeze(0))
+            .and_then(|k| k.contiguous())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "layout vision key", e))?;
+        let v = v
+            .transpose(0, 1)
+            .and_then(|v| v.unsqueeze(0))
+            .and_then(|v| v.contiguous())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "layout vision value", e))?;
+
+        let attention = match flash_attention(&q, &k, &v, self.scale, false)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision flash attention", e))?
+        {
+            Some(output) => output,
+            None if seq_len > VISION_CHUNKED_ATTN_SEQ_THRESHOLD => {
+                chunked_vision_attention(&q, &k, &v, self.scale, VISION_CHUNKED_ATTN_CHUNK_SIZE)
+                    .map_err(|e| {
+                        candle_to_ocr_inference(MODEL_NAME, "chunked vision attention", e)
+                    })?
+            }
+            None => scaled_dot_product_attention(&q, &k, &v, None, self.scale, false)
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision attention", e))?,
+        };
+        let attention = attention
+            .transpose(1, 2)
+            .and_then(|output| output.reshape((seq_len, self.num_heads * self.head_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "reshape vision attention", e))?;
+        self.proj
+            .forward(&attention)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision output projection", e))
+    }
+}
+
+fn apply_vision_rope(
+    q: &Tensor,
+    k: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+) -> Result<(Tensor, Tensor), OCRError> {
+    let q_dtype = q.dtype();
+    let k_dtype = k.dtype();
+    let q = q
+        .to_dtype(DType::F32)
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "cast vision query", e))?;
+    let k = k
+        .to_dtype(DType::F32)
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "cast vision key", e))?;
+    let cos = cos
+        .to_dtype(DType::F32)
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "cast vision cosine", e))?;
+    let sin = sin
+        .to_dtype(DType::F32)
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "cast vision sine", e))?;
+    let q_rotated = crate::utils::rotate_half(&q)?;
+    let k_rotated = crate::utils::rotate_half(&k)?;
+    let q = q
+        .broadcast_mul(&cos)
+        .and_then(|value| value.broadcast_add(&q_rotated.broadcast_mul(&sin)?))
+        .and_then(|value| value.to_dtype(q_dtype))
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "apply query vision RoPE", e))?;
+    let k = k
+        .broadcast_mul(&cos)
+        .and_then(|value| value.broadcast_add(&k_rotated.broadcast_mul(&sin)?))
+        .and_then(|value| value.to_dtype(k_dtype))
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "apply key vision RoPE", e))?;
+    Ok((q, k))
+}
+
+#[derive(Debug, Clone)]
+struct VisionMlp {
+    fc1: Linear,
+    fc2: Linear,
+    fc3: Linear,
+}
+
+impl VisionMlp {
+    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let vb = vb.pp("mlp");
+        let fc1 = linear_no_bias(cfg.embed_dim, cfg.intermediate_size, vb.pp("fc1"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision MLP fc1", e))?;
+        let fc2 = linear_no_bias(cfg.intermediate_size, cfg.embed_dim, vb.pp("fc2"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision MLP fc2", e))?;
+        let fc3 = linear_no_bias(cfg.embed_dim, cfg.intermediate_size, vb.pp("fc3"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision MLP fc3", e))?;
+        Ok(Self { fc1, fc2, fc3 })
+    }
+
+    fn forward(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+        let gate = self
+            .fc1
+            .forward(hidden)
+            .and_then(|gate| candle_nn::ops::silu(&gate))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision MLP gate", e))?;
+        let up = self
+            .fc3
+            .forward(hidden)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision MLP up", e))?;
+        let hidden =
+            (gate * up).map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision MLP SwiGLU", e))?;
+        self.fc2
+            .forward(&hidden)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision MLP down", e))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VisionBlock {
+    norm1: RmsNorm,
+    norm2: RmsNorm,
+    attention: VisionAttention,
+    mlp: VisionMlp,
+}
+
+impl VisionBlock {
+    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let norm1 = rms_norm(cfg.embed_dim, cfg.rms_norm_eps, vb.pp("norm1"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision norm1", e))?;
+        let norm2 = rms_norm(cfg.embed_dim, cfg.rms_norm_eps, vb.pp("norm2"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision norm2", e))?;
+        let attention = VisionAttention::load(cfg, vb.clone())?;
+        let mlp = VisionMlp::load(cfg, vb)?;
+        Ok(Self {
+            norm1,
+            norm2,
+            attention,
+            mlp,
+        })
+    }
+
+    fn forward(&self, hidden: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, OCRError> {
+        let normed = self
+            .norm1
+            .forward(hidden)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision norm1", e))?;
+        let attention = self.attention.forward(&normed, cos, sin)?;
+        let hidden = (hidden + attention).map_err(|e| {
+            candle_to_ocr_processing(
+                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                "MonkeyOCRv2 vision attention residual",
+                e,
+            )
+        })?;
+        let normed = self
+            .norm2
+            .forward(&hidden)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision norm2", e))?;
+        let mlp = self.mlp.forward(&normed)?;
+        (hidden + mlp).map_err(|e| {
+            candle_to_ocr_processing(
+                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                "MonkeyOCRv2 vision MLP residual",
+                e,
+            )
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PatchMerger {
+    norm: LayerNorm,
+    mlp1: Linear,
+    mlp2: Linear,
+    merged_dim: usize,
+    merge_group: usize,
+}
+
+impl PatchMerger {
+    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        let vb = vb.pp("merger");
+        let norm = layer_norm(
+            cfg.embed_dim,
+            LayerNormConfig {
+                eps: 1e-6,
+                ..Default::default()
+            },
+            vb.pp("ln_q"),
+        )
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load merger LayerNorm", e))?;
+        let merge_group = cfg.spatial_merge_size * cfg.spatial_merge_size;
+        let merged_dim = cfg.embed_dim * merge_group;
+        let mlp1 = linear(merged_dim, merged_dim, vb.pp("mlp").pp("0"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load merger MLP 0", e))?;
+        let mlp2 = linear(merged_dim, cfg.hidden_size, vb.pp("mlp").pp("2"))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load merger MLP 2", e))?;
+        Ok(Self {
+            norm,
+            mlp1,
+            mlp2,
+            merged_dim,
+            merge_group,
+        })
+    }
+
+    fn forward(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+        let num_patches = hidden
+            .dim(0)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read merger patch count", e))?;
+        if !num_patches.is_multiple_of(self.merge_group) {
+            return Err(OCRError::InvalidInput {
+                message: format!(
+                    "MonkeyOCRv2 merger patch count {num_patches} is not divisible by {}",
+                    self.merge_group
+                ),
+            });
+        }
+        let hidden = self
+            .norm
+            .forward(hidden)
+            .and_then(|hidden| hidden.reshape((num_patches / self.merge_group, self.merged_dim)))
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "merger norm/reshape", e))?;
+        let hidden = self
+            .mlp1
+            .forward(&hidden)
+            .and_then(|hidden| hidden.gelu_erf())
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "merger MLP 0", e))?;
+        self.mlp2
+            .forward(&hidden)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "merger MLP 2", e))
+    }
+}
+
+pub struct MonkeyOcrV2VisionModel {
+    patch_embed: PatchEmbed,
+    blocks: Vec<VisionBlock>,
+    post_norm: Option<RmsNorm>,
+    merger: PatchMerger,
+    head_dim: usize,
+    merge_size: usize,
+}
+
+impl MonkeyOcrV2VisionModel {
+    pub fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+        cfg.validate()?;
+        let patch_embed = PatchEmbed::load(cfg, vb.clone())?;
+        let mut blocks = Vec::with_capacity(cfg.num_hidden_layers);
+        for index in 0..cfg.num_hidden_layers {
+            blocks.push(VisionBlock::load(cfg, vb.pp("blocks").pp(index))?);
+        }
+        let post_norm = cfg
+            .post_norm
+            .then(|| rms_norm(cfg.embed_dim, cfg.rms_norm_eps, vb.pp("post_trunk_norm")))
+            .transpose()
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision post norm", e))?;
+        let merger = PatchMerger::load(cfg, vb.clone())?;
+        Ok(Self {
+            patch_embed,
+            blocks,
+            post_norm,
+            merger,
+            head_dim: cfg.head_dim()?,
+            merge_size: cfg.spatial_merge_size,
+        })
+    }
+
+    pub fn forward(
+        &self,
+        pixel_values: &Tensor,
+        grid_thw: (usize, usize, usize),
+    ) -> Result<Tensor, OCRError> {
+        let (grid_t, grid_h, grid_w) = grid_thw;
+        if grid_t != 1
+            || grid_h == 0
+            || grid_w == 0
+            || !grid_h.is_multiple_of(self.merge_size)
+            || !grid_w.is_multiple_of(self.merge_size)
+        {
+            return Err(OCRError::InvalidInput {
+                message: format!(
+                    "MonkeyOCRv2 invalid image grid {grid_thw:?} for merge_size {}",
+                    self.merge_size
+                ),
+            });
+        }
+        let expected = grid_t * grid_h * grid_w;
+        let actual = pixel_values
+            .dim(0)
+            .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read pixel patch count", e))?;
+        if actual != expected {
+            return Err(OCRError::InvalidInput {
+                message: format!(
+                    "MonkeyOCRv2 pixel patch count {actual} does not match grid {grid_thw:?} ({expected})"
+                ),
+            });
+        }
+        let (cos, sin) = build_vision_rope(grid_thw, self.merge_size, self.head_dim, pixel_values)?;
+        let mut hidden = self.patch_embed.forward(pixel_values)?;
+        for block in &self.blocks {
+            hidden = block.forward(&hidden, &cos, &sin)?;
+        }
+        if let Some(norm) = &self.post_norm {
+            hidden = norm
+                .forward(&hidden)
+                .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "vision post norm", e))?;
+        }
+        self.merger.forward(&hidden)
+    }
+}
+
+fn build_vision_rope(
+    grid_thw: (usize, usize, usize),
+    merge_size: usize,
+    head_dim: usize,
+    like: &Tensor,
+) -> Result<(Tensor, Tensor), OCRError> {
+    let (grid_t, grid_h, grid_w) = grid_thw;
+    let mut frequencies = Vec::with_capacity(grid_t * grid_h * grid_w * head_dim);
+    for _ in 0..grid_t {
+        for height_block in 0..(grid_h / merge_size) {
+            for width_block in 0..(grid_w / merge_size) {
+                for height_inner in 0..merge_size {
+                    for width_inner in 0..merge_size {
+                        let height = height_block * merge_size + height_inner;
+                        let width = width_block * merge_size + width_inner;
+                        let mut half = Vec::with_capacity(head_dim / 2);
+                        for index in (0..head_dim / 2).step_by(2) {
+                            let inv =
+                                1.0_f32 / 10_000_f32.powf(index as f32 / (head_dim / 2) as f32);
+                            half.push(height as f32 * inv);
+                            half.push(width as f32 * inv);
+                        }
+                        frequencies.extend_from_slice(&half);
+                        frequencies.extend_from_slice(&half);
+                    }
+                }
+            }
+        }
+    }
+    let num_patches = grid_t * grid_h * grid_w;
+    let frequencies = Tensor::from_vec(frequencies, (num_patches, 1, head_dim), like.device())
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "build vision RoPE frequencies", e))?;
+    let cos = frequencies
+        .cos()
+        .and_then(|value| value.to_dtype(like.dtype()))
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "build vision RoPE cosine", e))?;
+    let sin = frequencies
+        .sin()
+        .and_then(|value| value.to_dtype(like.dtype()))
+        .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "build vision RoPE sine", e))?;
+    Ok((cos, sin))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rope_follows_merge_grouped_patch_order() {
+        let like = Tensor::zeros((24, 588), DType::F32, &candle_core::Device::Cpu).unwrap();
+        let (cos, sin) = build_vision_rope((1, 4, 6), 2, 64, &like).unwrap();
+        assert_eq!(cos.dims(), &[24, 1, 64]);
+        assert_eq!(sin.dims(), &[24, 1, 64]);
+        let first = cos.i((0, 0, ..)).unwrap().to_vec1::<f32>().unwrap();
+        assert!(first.iter().all(|value| (*value - 1.0).abs() < 1e-6));
+    }
+}


### PR DESCRIPTION
## Summary

- add native Candle support for MonkeyOCRv2-S-Parsing and MonkeyOCRv2-B-Parsing, including the Monkey ViT-S/ViT-B vision towers and causal Qwen3 decoder integration
- expose layout, end-to-end, text, formula, table, and custom-prompt inference through `RecognitionBackend`
- load both checkpoint sizes dynamically from their official configurations
- add a CLI example, S/B configuration tests, and documentation for both variants

## Why

This adds a native Rust inference path for both MonkeyOCRv2 parsing checkpoints so document parsing can run through the existing OAR-OCR VL APIs without a Python/Transformers runtime.

## Impact

The new backend is opt-in. Existing MinerU diffusion decoding keeps its prior behavior; the shared Qwen3 decoder now selects bidirectional or causal attention explicitly. Users can select the 0.6B ViT-S or higher-capacity 0.7B ViT-B parsing checkpoint with the same API and task set.

## Validation

- `cargo test -p oar-ocr-vl --features download-binaries` — 140 tests passed; 2 doctests passed, 1 ignored
- S and B official configuration-shape tests
- `cargo check -p oar-ocr-vl --all-targets --features cuda,download-binaries`
- `cargo fmt --all -- --check`
- `cargo clippy -p oar-ocr-vl --all-targets --features cuda,download-binaries -- -D warnings -A clippy::unnecessary_unwrap -A clippy::too_many_arguments`
- CUDA inference with both local checkpoint variants
- MonkeyOCRv2-B-Parsing text smoke test produced `绿洲仕格维花园公寓`
- 128-token MonkeyOCRv2-S-Parsing end-to-end output matched the official Transformers 4.57.6 reference byte-for-byte