### PR TITLE
Improve Metal and CoreML inference performance

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -11,6 +11,9 @@ Runtime environment variables read by the oar-ocr crates. Project-specific varia
 | [`OAR_VL_ATTN_FULL_SEQ_THRESHOLD`](#oar_vl_attn_full_seq_threshold) | `oar-ocr-vl` | `8192` | PaddleOCR-VL vision attention path selection |
 | [`OAR_VL_DISABLE_FLASH_ATTN`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable CUDA FlashAttention |
 | [`OAR_VL_DISABLE_GQA`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Use expanded-K/V GQA fallback |
+| [`OAR_VL_METAL_NATIVE_SOFTMAX`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Use native F16/BF16 softmax on Metal eager attention |
+| [`OAR_VL_METAL_F32_SOFTMAX`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Keep F32 softmax on Metal eager attention |
+| [`OAR_VL_DISABLE_METAL_SDPA`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable fused Metal grouped-query attention |
 | [`OAR_VL_DISABLE_CUDA_GRAPH`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable shared decoder CUDA graphs |
 | [`OAR_VL_DISABLE_SPECULATIVE`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable GLM-OCR speculative decoding |
 | [`OAR_PADDLEOCR_VL_DISABLE_CUDA_GRAPH`](#vl-performance-and-debug-overrides) | `oar-ocr-vl` | unset | Disable PaddleOCR-VL CUDA graphs |
@@ -68,6 +71,9 @@ The following presence-based switches select portable fallbacks or disable optio
 |---|---|---|
 | `OAR_VL_DISABLE_FLASH_ATTN` | All CUDA VLM backends | Use the eager attention fallback instead of FlashAttention |
 | `OAR_VL_DISABLE_GQA` | Backends using grouped-query attention | Expand K/V heads before eager attention instead of using the grouped implementation |
+| `OAR_VL_METAL_NATIVE_SOFTMAX` | Metal VLM backends | Keep F16/BF16 eager-attention softmax in its input dtype instead of converting to F32 |
+| `OAR_VL_METAL_F32_SOFTMAX` | Metal VLM backends | Keep the default F32 round trip for eager attention; this takes precedence over `OAR_VL_METAL_NATIVE_SOFTMAX` |
+| `OAR_VL_DISABLE_METAL_SDPA` | Metal VLM backends | Disable fused Metal SDPA and use the portable grouped-query attention path |
 | `OAR_VL_DISABLE_CUDA_GRAPH` | PaddleOCR-VL, GLM-OCR, MinerU2.5/Pro | Disable decoder CUDA graph capture and replay |
 | `OAR_VL_DISABLE_SPECULATIVE` | GLM-OCR | Disable MTP speculative decoding |
 | `OAR_PADDLEOCR_VL_DISABLE_CUDA_GRAPH` | PaddleOCR-VL variants | Disable decoder CUDA graphs only for PaddleOCR-VL |

--- a/docs/features.md
+++ b/docs/features.md
@@ -116,6 +116,21 @@ cargo add oar-ocr --features coreml
 
 This feature controls the ONNX Runtime Core ML provider used by the classic pipeline. The `metal` feature in `oar-ocr-vl` is separate.
 
+`OrtExecutionProvider::CoreML` retains its original `ane_only` and `subgraphs`
+fields. `OrtSessionConfig::with_coreml_config` adds compute-unit selection,
+MLProgram versus legacy NeuralNetwork format, static-input filtering,
+specialization strategy, low-precision GPU accumulation, profiling, and a
+compiled-model cache path without changing that provider variant's shape.
+The OCR example accepts `coreml[:gpu|ane|cpu]`, `coreml-nn[:...]`, and
+`coreml-static[:...]`.
+
+`static_input_shapes` only controls which graphs Core ML will claim. It does
+not turn a dynamic ONNX model into a fixed-shape model: the ONNX input itself
+must contain concrete dimensions, and preprocessing must produce that exact
+shape. Static Core ML is most useful for larger models processing repeated,
+fixed-size pages; compilation and provider handoff can outweigh the benefit
+for small mobile models or one-off requests.
+
 ### `webgpu`
 
 Enables the ONNX Runtime WebGPU execution provider. Target and binary support depends on the ONNX Runtime distribution used for the build.

--- a/examples/ocr.rs
+++ b/examples/ocr.rs
@@ -50,7 +50,7 @@ use oar_ocr::utils::load_image;
 use std::path::PathBuf;
 use std::time::Instant;
 use tracing::{error, info, warn};
-use utils::device_config::parse_device_config;
+use utils::device_config::{apply_ort_overrides, parse_device_config};
 use utils::visualization::{VisualizationConfig, create_ocr_visualization};
 
 /// Command-line arguments for the OCR pipeline example
@@ -90,7 +90,7 @@ struct Args {
     #[arg(long, default_value_t = false)]
     return_word_box: bool,
 
-    /// Device to use for inference (cpu, cuda, cuda:0, etc.)
+    /// Device (cpu, cuda:N, coreml[:gpu|ane|cpu], coreml-nn[:...])
     #[arg(long, default_value = "cpu")]
     device: String,
 
@@ -133,6 +133,22 @@ struct Args {
     /// Recognition session pool size (batching cropped regions)
     #[arg(long)]
     region_batch_size: Option<usize>,
+
+    /// Repeat inference to expose warm-up and steady-state latency.
+    #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u32).range(1..))]
+    repeat: u32,
+
+    /// ONNX Runtime intra-op worker threads (CPU tuning experiment).
+    #[arg(long)]
+    ort_intra_threads: Option<usize>,
+
+    /// ONNX Runtime inter-op worker threads (only useful with parallel execution).
+    #[arg(long)]
+    ort_inter_threads: Option<usize>,
+
+    /// Enable ONNX Runtime parallel graph execution.
+    #[arg(long)]
+    ort_parallel_execution: bool,
 
     /// Directory to save output results (visualizations, etc.)
     #[arg(short = 'o', long = "output-dir")]
@@ -189,8 +205,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Build device/ORT configuration
-    let ort_config = parse_device_config(&args.device)?;
-
+    let ort_config = apply_ort_overrides(
+        parse_device_config(&args.device)?,
+        args.ort_intra_threads,
+        args.ort_inter_threads,
+        args.ort_parallel_execution,
+    )?;
     // Prepare model configs
     let det_config = TextDetectionConfig {
         score_threshold: args.det_score_thresh,
@@ -227,7 +247,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(config) = ort_config.clone() {
         builder = builder.ort_session(config);
     }
-
     if let Some(size) = args.image_batch_size {
         builder = builder.image_batch_size(size);
     }
@@ -264,13 +283,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Err("No images could be loaded".into());
     }
 
-    // Run inference
-    let start = Instant::now();
-    let results = ocr.predict(images)?;
-    info!(
-        "OCR completed in {:.2}ms",
-        start.elapsed().as_secs_f64() * 1000.0
-    );
+    // Run inference. Repetition is useful when CoreML compiles or specializes
+    // graph partitions lazily on the first prediction.
+    let mut results = None;
+    for iteration in 1..=args.repeat {
+        let iteration_images = images.clone();
+        let start = Instant::now();
+        let iteration_results = ocr.predict(iteration_images)?;
+        info!(
+            "OCR completed (run {}/{}) in {:.2}ms",
+            iteration,
+            args.repeat,
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+        results = Some(iteration_results);
+    }
+    let results = results.expect("repeat is validated as at least one");
 
     // Report results
     info!("\n=== OCR Results ===");

--- a/examples/ocr.rs
+++ b/examples/ocr.rs
@@ -284,21 +284,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Run inference. Repetition is useful when CoreML compiles or specializes
-    // graph partitions lazily on the first prediction.
-    let mut results = None;
-    for iteration in 1..=args.repeat {
-        let iteration_images = images.clone();
+    // graph partitions lazily on the first prediction. Only the warm-up runs
+    // need a cloned image set; the final (or only) run can move `images`
+    // directly, so `--repeat 1` (the default) never pays a clone.
+    for iteration in 1..args.repeat {
         let start = Instant::now();
-        let iteration_results = ocr.predict(iteration_images)?;
+        ocr.predict(images.clone())?;
         info!(
             "OCR completed (run {}/{}) in {:.2}ms",
             iteration,
             args.repeat,
             start.elapsed().as_secs_f64() * 1000.0
         );
-        results = Some(iteration_results);
     }
-    let results = results.expect("repeat is validated as at least one");
+    let start = Instant::now();
+    let results = ocr.predict(images)?;
+    info!(
+        "OCR completed (run {}/{}) in {:.2}ms",
+        args.repeat,
+        args.repeat,
+        start.elapsed().as_secs_f64() * 1000.0
+    );
 
     // Report results
     info!("\n=== OCR Results ===");

--- a/examples/structure.rs
+++ b/examples/structure.rs
@@ -152,8 +152,9 @@ use oar_ocr::oarocr::OARStructureBuilder;
 use oar_ocr::processors::LimitType;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 use tracing::{error, info, warn};
-use utils::device_config::parse_device_config;
+use utils::device_config::{apply_ort_overrides, parse_device_config};
 use utils::pdf::{PdfDocument, is_pdf_file};
 
 /// Command-line arguments for the structure analysis example
@@ -321,6 +322,22 @@ struct Args {
     /// Number of cropped regions to process per recognition batch
     #[arg(long = "region-batch-size")]
     region_batch_size: Option<usize>,
+
+    /// Repeat inference to expose warm-up and steady-state latency.
+    #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u32).range(1..))]
+    repeat: u32,
+
+    /// ONNX Runtime intra-op worker threads (explicit tuning experiment).
+    #[arg(long)]
+    ort_intra_threads: Option<usize>,
+
+    /// ONNX Runtime inter-op worker threads (only useful with parallel execution).
+    #[arg(long)]
+    ort_inter_threads: Option<usize>,
+
+    /// Enable ONNX Runtime parallel graph execution.
+    #[arg(long)]
+    ort_parallel_execution: bool,
 
     /// Layout detection score threshold (varies by class, 0.3-0.5)
     #[arg(long, default_value = "0.5")]
@@ -584,7 +601,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Always set layout model name (has default value)
     builder = builder.layout_model_name(&args.layout_model_name);
 
-    if let Some(config) = parse_device_config(&args.device)? {
+    let ort_config = apply_ort_overrides(
+        parse_device_config(&args.device)?,
+        args.ort_intra_threads,
+        args.ort_inter_threads,
+        args.ort_parallel_execution,
+    )?;
+    if let Some(config) = ort_config {
         builder = builder.ort_session(config);
     }
 
@@ -685,7 +708,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .text_recognition_config(text_rec_config);
     }
 
+    let build_start = Instant::now();
     let analyzer = builder.build()?;
+    info!(
+        "Structure pipeline built in {:.2}ms",
+        build_start.elapsed().as_secs_f64() * 1000.0
+    );
 
     // Collect all results for potential concatenation
     let mut all_results: Vec<oar_ocr::domain::structure::StructureResult> = Vec::new();
@@ -732,7 +760,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Batch processing {} image(s) with configured batching",
         images.len()
     );
-    let batch_results = analyzer.predict_images(images);
+    let mut batch_results = None;
+    for iteration in 1..=args.repeat {
+        let iteration_images = images.clone();
+        let predict_start = Instant::now();
+        let results = analyzer.predict_images(iteration_images);
+        info!(
+            "Structure inference completed (run {}/{}) in {:.2}ms",
+            iteration,
+            args.repeat,
+            predict_start.elapsed().as_secs_f64() * 1000.0
+        );
+        batch_results = Some(results);
+    }
+    let batch_results = batch_results.expect("repeat is validated as at least one");
 
     // Process each result: assign metadata, save, visualize, log
     for (idx, (page_result, (source_path, source_stem))) in

--- a/examples/structure.rs
+++ b/examples/structure.rs
@@ -760,20 +760,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Batch processing {} image(s) with configured batching",
         images.len()
     );
-    let mut batch_results = None;
-    for iteration in 1..=args.repeat {
-        let iteration_images = images.clone();
+    // Only the warm-up runs need a cloned image set; the final (or only) run
+    // can move `images` directly, so `--repeat 1` (the default) never pays a
+    // clone.
+    for iteration in 1..args.repeat {
         let predict_start = Instant::now();
-        let results = analyzer.predict_images(iteration_images);
+        analyzer.predict_images(images.clone());
         info!(
             "Structure inference completed (run {}/{}) in {:.2}ms",
             iteration,
             args.repeat,
             predict_start.elapsed().as_secs_f64() * 1000.0
         );
-        batch_results = Some(results);
     }
-    let batch_results = batch_results.expect("repeat is validated as at least one");
+    let predict_start = Instant::now();
+    let batch_results = analyzer.predict_images(images);
+    info!(
+        "Structure inference completed (run {}/{}) in {:.2}ms",
+        args.repeat,
+        args.repeat,
+        predict_start.elapsed().as_secs_f64() * 1000.0
+    );
 
     // Process each result: assign metadata, save, visualize, log
     for (idx, (page_result, (source_path, source_stem))) in

--- a/examples/utils/device_config.rs
+++ b/examples/utils/device_config.rs
@@ -3,9 +3,44 @@
 //! This module provides utilities for parsing device strings and creating
 //! ONNX Runtime session configurations with appropriate execution providers.
 
-#[cfg(feature = "cuda")]
+#[cfg(any(feature = "cuda", feature = "coreml"))]
 use oar_ocr::core::config::OrtExecutionProvider;
 use oar_ocr::core::config::OrtSessionConfig;
+#[cfg(feature = "coreml")]
+use oar_ocr::core::config::{
+    OrtCoreMLComputeUnits, OrtCoreMLConfig, OrtCoreMLModelFormat, OrtCoreMLSpecializationStrategy,
+};
+
+/// Applies optional ONNX Runtime thread and execution-mode overrides.
+///
+/// A default CPU configuration is materialized only when an override is
+/// present, preserving `None` for the common unconfigured CPU path.
+#[allow(dead_code)] // This shared module is compiled by examples without tuning flags.
+pub fn apply_ort_overrides(
+    mut config: Option<OrtSessionConfig>,
+    intra_threads: Option<usize>,
+    inter_threads: Option<usize>,
+    parallel_execution: bool,
+) -> Result<Option<OrtSessionConfig>, Box<dyn std::error::Error>> {
+    if intra_threads == Some(0) || inter_threads == Some(0) {
+        return Err("ONNX Runtime thread counts must be at least one".into());
+    }
+    if intra_threads.is_none() && inter_threads.is_none() && !parallel_execution {
+        return Ok(config);
+    }
+
+    let mut configured = config.take().unwrap_or_default();
+    if let Some(threads) = intra_threads {
+        configured = configured.with_intra_threads(threads);
+    }
+    if let Some(threads) = inter_threads {
+        configured = configured.with_inter_threads(threads);
+    }
+    if parallel_execution {
+        configured = configured.with_parallel_execution(true);
+    }
+    Ok(Some(configured))
+}
 
 /// Parses device string and creates OrtSessionConfig with appropriate execution providers.
 ///
@@ -13,6 +48,9 @@ use oar_ocr::core::config::OrtSessionConfig;
 ///
 /// - `"cpu"` -> CPU execution provider (returns None as CPU is default)
 /// - `"cuda"` or `"cuda:0"` -> CUDA execution provider with device ID
+/// - `"coreml"`, `"coreml:gpu"`, or `"coreml:ane"` -> CoreML MLProgram provider
+/// - `"coreml-nn"` variants -> legacy CoreML NeuralNetwork representation
+/// - `"coreml-static"` variants -> only offload models with static input shapes
 ///
 /// # Arguments
 ///
@@ -45,6 +83,65 @@ pub fn parse_device_config(
     if device_lower == "cpu" {
         // CPU is the default, no need for special config
         return Ok(None);
+    }
+
+    #[cfg(feature = "coreml")]
+    if device_lower == "coreml"
+        || device_lower.starts_with("coreml:")
+        || device_lower == "coreml-nn"
+        || device_lower.starts_with("coreml-nn:")
+        || device_lower == "coreml-static"
+        || device_lower.starts_with("coreml-static:")
+    {
+        let (kind, units) = device_lower
+            .split_once(':')
+            .unwrap_or((&device_lower, "all"));
+        let compute_units = match units {
+            "gpu" => OrtCoreMLComputeUnits::CPUAndGPU,
+            "ane" => OrtCoreMLComputeUnits::CPUAndNeuralEngine,
+            "cpu" => OrtCoreMLComputeUnits::CPUOnly,
+            "all" => OrtCoreMLComputeUnits::All,
+            _ => {
+                return Err(format!(
+                    "Invalid CoreML compute units: '{}'. Expected all, gpu, ane, or cpu",
+                    units
+                )
+                .into());
+            }
+        };
+        let model_format = match kind {
+            "coreml-nn" => OrtCoreMLModelFormat::NeuralNetwork,
+            "coreml" | "coreml-static" => OrtCoreMLModelFormat::MLProgram,
+            _ => unreachable!("CoreML kind was validated above"),
+        };
+        let provider = OrtExecutionProvider::CoreML {
+            ane_only: None,
+            subgraphs: Some(false),
+        };
+        let coreml_config = OrtCoreMLConfig {
+            compute_units: Some(compute_units),
+            model_format: Some(model_format),
+            static_input_shapes: Some(kind == "coreml-static"),
+            specialization_strategy: Some(OrtCoreMLSpecializationStrategy::FastPrediction),
+            allow_low_precision_accumulation_on_gpu: Some(true),
+            profile_compute_plan: None,
+            model_cache_dir: None,
+        };
+        return Ok(Some(
+            OrtSessionConfig::new()
+                .with_execution_providers(vec![provider])
+                .with_coreml_config(coreml_config),
+        ));
+    }
+
+    #[cfg(not(feature = "coreml"))]
+    if device_lower.starts_with("coreml") {
+        return Err(format!(
+            "CoreML device '{}' requested but the coreml feature is not enabled. \
+             Rebuild with --features=coreml to enable CoreML support.",
+            device
+        )
+        .into());
     }
 
     #[cfg(feature = "cuda")]
@@ -95,10 +192,15 @@ pub fn parse_device_config(
     }
 
     Err(format!(
-        "Unsupported device: {}. Supported devices: cpu{}",
+        "Unsupported device: {}. Supported devices: cpu{}{}",
         device,
         if cfg!(feature = "cuda") {
             ", cuda, cuda:N"
+        } else {
+            ""
+        },
+        if cfg!(feature = "coreml") {
+            ", coreml[:gpu|ane|cpu], coreml-nn[:gpu|ane|cpu], coreml-static[:gpu|ane|cpu]"
         } else {
             ""
         }

--- a/oar-ocr-core/src/core/config/onnx.rs
+++ b/oar-ocr-core/src/core/config/onnx.rs
@@ -21,6 +21,65 @@ pub enum OrtGraphOptimizationLevel {
     All,
 }
 
+/// CoreML hardware selection used by the ONNX Runtime CoreML execution provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum OrtCoreMLComputeUnits {
+    /// Let CoreML select from CPU, GPU, and Neural Engine.
+    #[default]
+    All,
+    /// Restrict CoreML to CPU and GPU.
+    CPUAndGPU,
+    /// Restrict CoreML to CPU and Neural Engine.
+    CPUAndNeuralEngine,
+    /// Restrict CoreML to CPU.
+    CPUOnly,
+}
+
+/// CoreML model representation created by ONNX Runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum OrtCoreMLModelFormat {
+    /// The modern CoreML representation (macOS 12+), with broader operator support.
+    #[default]
+    MLProgram,
+    /// The legacy CoreML neural-network representation.
+    NeuralNetwork,
+}
+
+/// CoreML graph-specialization policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum OrtCoreMLSpecializationStrategy {
+    /// CoreML's balanced default.
+    #[default]
+    Default,
+    /// Prefer steady-state prediction latency over specialization time and size.
+    FastPrediction,
+}
+
+/// Advanced CoreML execution-provider options.
+///
+/// These options live on [`OrtSessionConfig`] instead of adding fields to
+/// [`OrtExecutionProvider::CoreML`], preserving source compatibility for code
+/// that constructs or exhaustively matches the provider variant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct OrtCoreMLConfig {
+    /// Hardware units available to CoreML.
+    pub compute_units: Option<OrtCoreMLComputeUnits>,
+    /// CoreML model representation.
+    pub model_format: Option<OrtCoreMLModelFormat>,
+    /// Only claim nodes whose model inputs have static shapes.
+    pub static_input_shapes: Option<bool>,
+    /// CoreML graph-specialization policy.
+    pub specialization_strategy: Option<OrtCoreMLSpecializationStrategy>,
+    /// Permit FP16 accumulation on the GPU.
+    pub allow_low_precision_accumulation_on_gpu: Option<bool>,
+    /// Log CoreML's hardware assignment and estimated cost.
+    pub profile_compute_plan: Option<bool>,
+    /// Directory used to cache compiled CoreML models.
+    pub model_cache_dir: Option<String>,
+}
+
+pub(crate) const COREML_CONFIG_ENTRY: &str = "oar.internal.coreml_config";
+
 /// Execution providers for ONNX Runtime.
 ///
 /// This enum represents the different execution providers that can be used
@@ -82,7 +141,8 @@ pub enum OrtExecutionProvider {
     },
     /// CoreML execution provider (macOS/iOS only)
     CoreML {
-        /// Use Apple Neural Engine only
+        /// Use CPU and Apple Neural Engine compute units. Despite the
+        /// historical name, unsupported nodes may still execute on CPU.
         ane_only: Option<bool>,
         /// Enable subgraphs
         subgraphs: Option<bool>,
@@ -193,6 +253,24 @@ impl OrtSessionConfig {
         self
     }
 
+    /// Sets advanced options for any CoreML execution provider in this session.
+    pub fn with_coreml_config(mut self, config: OrtCoreMLConfig) -> Self {
+        let value =
+            serde_json::to_string(&config).expect("serializing OrtCoreMLConfig cannot fail");
+        self.session_config_entries
+            .get_or_insert_with(Default::default)
+            .insert(COREML_CONFIG_ENTRY.to_owned(), value);
+        self
+    }
+
+    pub(crate) fn coreml_config(&self) -> Result<Option<OrtCoreMLConfig>, serde_json::Error> {
+        self.session_config_entries
+            .as_ref()
+            .and_then(|entries| entries.get(COREML_CONFIG_ENTRY))
+            .map(|value| serde_json::from_str(value))
+            .transpose()
+    }
+
     /// Effective intra-op thread count, defaulting to available parallelism.
     pub fn get_intra_threads(&self) -> usize {
         self.intra_threads.unwrap_or_else(|| {
@@ -256,5 +334,37 @@ mod tests {
             config.get_optimization_level(),
             OrtGraphOptimizationLevel::All
         ));
+    }
+
+    #[test]
+    fn coreml_provider_keeps_legacy_variant_shape() {
+        let provider = OrtExecutionProvider::CoreML {
+            ane_only: Some(true),
+            subgraphs: Some(false),
+        };
+        let OrtExecutionProvider::CoreML {
+            ane_only,
+            subgraphs,
+        } = provider
+        else {
+            unreachable!()
+        };
+        assert_eq!(ane_only, Some(true));
+        assert_eq!(subgraphs, Some(false));
+    }
+
+    #[test]
+    fn coreml_advanced_config_round_trips_through_session_config() {
+        let expected = OrtCoreMLConfig {
+            compute_units: Some(OrtCoreMLComputeUnits::CPUAndGPU),
+            model_format: Some(OrtCoreMLModelFormat::MLProgram),
+            static_input_shapes: Some(true),
+            specialization_strategy: Some(OrtCoreMLSpecializationStrategy::FastPrediction),
+            allow_low_precision_accumulation_on_gpu: Some(true),
+            profile_compute_plan: None,
+            model_cache_dir: Some("cache".to_owned()),
+        };
+        let config = OrtSessionConfig::new().with_coreml_config(expected.clone());
+        assert_eq!(config.coreml_config().unwrap(), Some(expected));
     }
 }

--- a/oar-ocr-core/src/core/inference/ort_infer_config.rs
+++ b/oar-ocr-core/src/core/inference/ort_infer_config.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::core::config::{
-    OrtExecutionProvider, OrtGraphOptimizationLevel as OG, OrtSessionConfig,
+    COREML_CONFIG_ENTRY, OrtCoreMLConfig, OrtExecutionProvider, OrtGraphOptimizationLevel as OG,
+    OrtSessionConfig,
 };
 use ort::ep::ExecutionProviderDispatch;
 use ort::logging::LogLevel;
@@ -53,11 +54,17 @@ impl OrtInfer {
         }
         if let Some(entries) = &cfg.session_config_entries {
             for (key, value) in entries {
+                if key == COREML_CONFIG_ENTRY {
+                    continue;
+                }
                 builder = builder.with_config_entry(key, value)?;
             }
         }
         if let Some(eps) = &cfg.execution_providers {
-            let providers = Self::build_execution_providers(eps)?;
+            let coreml_config = cfg.coreml_config().map_err(|error| {
+                ort::Error::new(format!("invalid CoreML session configuration: {error}"))
+            })?;
+            let providers = Self::build_execution_providers(eps, coreml_config.as_ref())?;
             if !providers.is_empty() {
                 builder = builder.with_execution_providers(providers)?;
             }
@@ -67,6 +74,7 @@ impl OrtInfer {
 
     fn build_execution_providers(
         eps: &[OrtExecutionProvider],
+        _coreml_config: Option<&OrtCoreMLConfig>,
     ) -> Result<Vec<ExecutionProviderDispatch>, ort::Error> {
         use crate::core::config::OrtExecutionProvider as EP;
         let mut providers = Vec::new();
@@ -197,15 +205,72 @@ impl OrtInfer {
                     ane_only,
                     subgraphs,
                 } => {
-                    use ort::execution_providers::coreml::ComputeUnits;
+                    use crate::core::config::{
+                        OrtCoreMLComputeUnits, OrtCoreMLModelFormat,
+                        OrtCoreMLSpecializationStrategy,
+                    };
+                    use ort::execution_providers::coreml::{
+                        ComputeUnits, ModelFormat, SpecializationStrategy,
+                    };
                     let mut coreml_provider =
                         ort::execution_providers::CoreMLExecutionProvider::default();
-                    if let Some(true) = ane_only {
+                    if let Some(units) = _coreml_config.and_then(|config| config.compute_units) {
+                        let units = match units {
+                            OrtCoreMLComputeUnits::All => ComputeUnits::All,
+                            OrtCoreMLComputeUnits::CPUAndGPU => ComputeUnits::CPUAndGPU,
+                            OrtCoreMLComputeUnits::CPUAndNeuralEngine => {
+                                ComputeUnits::CPUAndNeuralEngine
+                            }
+                            OrtCoreMLComputeUnits::CPUOnly => ComputeUnits::CPUOnly,
+                        };
+                        coreml_provider = coreml_provider.with_compute_units(units);
+                    } else if let Some(true) = ane_only {
                         coreml_provider =
                             coreml_provider.with_compute_units(ComputeUnits::CPUAndNeuralEngine);
                     }
                     if let Some(sub) = subgraphs {
                         coreml_provider = coreml_provider.with_subgraphs(*sub);
+                    }
+                    if let Some(format) = _coreml_config.and_then(|config| config.model_format) {
+                        let format = match format {
+                            OrtCoreMLModelFormat::MLProgram => ModelFormat::MLProgram,
+                            OrtCoreMLModelFormat::NeuralNetwork => ModelFormat::NeuralNetwork,
+                        };
+                        coreml_provider = coreml_provider.with_model_format(format);
+                    }
+                    if let Some(enable) =
+                        _coreml_config.and_then(|config| config.static_input_shapes)
+                    {
+                        coreml_provider = coreml_provider.with_static_input_shapes(enable);
+                    }
+                    if let Some(strategy) =
+                        _coreml_config.and_then(|config| config.specialization_strategy)
+                    {
+                        let strategy = match strategy {
+                            OrtCoreMLSpecializationStrategy::Default => {
+                                SpecializationStrategy::Default
+                            }
+                            OrtCoreMLSpecializationStrategy::FastPrediction => {
+                                SpecializationStrategy::FastPrediction
+                            }
+                        };
+                        coreml_provider = coreml_provider.with_specialization_strategy(strategy);
+                    }
+                    if let Some(enable) = _coreml_config
+                        .and_then(|config| config.allow_low_precision_accumulation_on_gpu)
+                    {
+                        coreml_provider =
+                            coreml_provider.with_low_precision_accumulation_on_gpu(enable);
+                    }
+                    if let Some(enable) =
+                        _coreml_config.and_then(|config| config.profile_compute_plan)
+                    {
+                        coreml_provider = coreml_provider.with_profile_compute_plan(enable);
+                    }
+                    if let Some(path) =
+                        _coreml_config.and_then(|config| config.model_cache_dir.as_ref())
+                    {
+                        coreml_provider = coreml_provider.with_model_cache_dir(path);
                     }
                     providers.push(coreml_provider.build());
                 }

--- a/oar-ocr-vl/README.md
+++ b/oar-ocr-vl/README.md
@@ -59,6 +59,13 @@ On macOS, enable Metal instead:
 cargo add oar-ocr-vl --features metal,download-binaries
 ```
 
+Metal inference uses Candle's fused SDPA kernels for supported attention
+shapes, including GQA without expanding K/V heads. For the best measured Apple
+Silicon throughput, explicitly set `OAR_VL_DTYPE=f16`. Use
+`OAR_VL_DISABLE_METAL_SDPA=1` for compatibility comparisons. The optional
+`OAR_VL_METAL_NATIVE_SOFTMAX=1` switch only changes the eager fallback; eager
+attention otherwise preserves the F32 softmax round trip.
+
 The crate's custom CUDA kernels compile to PTX for the oldest GPU detected by `nvidia-smi` at build time. For headless, container, or cross-machine builds, set the target explicitly, for example `CUDA_COMPUTE_CAP=89 cargo build -p oar-ocr-vl --features cuda,download-binaries`. These kernels require compute capability 8.0 or newer.
 
 ## Usage

--- a/oar-ocr-vl/examples/metal_bench.rs
+++ b/oar-ocr-vl/examples/metal_bench.rs
@@ -1,0 +1,294 @@
+//! Small, model-independent Metal benchmark for the VLM hot path.
+//!
+//! Run with:
+//! `cargo run --release -p oar-ocr-vl --features metal --example metal_bench`
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+use candle_core::{DType, Device, Result, Tensor};
+#[cfg(all(feature = "metal", target_os = "macos"))]
+use oar_ocr_vl::attention::repeat_kv;
+#[cfg(all(feature = "metal", target_os = "macos"))]
+use oar_ocr_vl::attention::scaled_dot_product_attention_gqa;
+#[cfg(all(feature = "metal", target_os = "macos"))]
+use oar_ocr_vl::utils::select_dtype;
+#[cfg(all(feature = "metal", target_os = "macos"))]
+use std::time::{Duration, Instant};
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn synchronize(tensor: Tensor) -> Result<()> {
+    tensor.device().synchronize()?;
+    std::hint::black_box(tensor);
+    Ok(())
+}
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn measure<F>(name: &str, warmups: usize, iterations: usize, mut operation: F) -> Result<()>
+where
+    F: FnMut() -> Result<Tensor>,
+{
+    for _ in 0..warmups {
+        synchronize(operation()?)?;
+    }
+
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        synchronize(operation()?)?;
+        samples.push(start.elapsed());
+    }
+    samples.sort_unstable();
+    let median = samples[samples.len() / 2];
+    let mean = samples.iter().sum::<Duration>() / samples.len() as u32;
+    println!(
+        "{name:<34} median={:>8.3} ms  mean={:>8.3} ms",
+        median.as_secs_f64() * 1_000.0,
+        mean.as_secs_f64() * 1_000.0
+    );
+    Ok(())
+}
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn measure_token<F>(name: &str, warmups: usize, iterations: usize, mut operation: F) -> Result<()>
+where
+    F: FnMut() -> Result<u32>,
+{
+    for _ in 0..warmups {
+        std::hint::black_box(operation()?);
+    }
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        std::hint::black_box(operation()?);
+        samples.push(start.elapsed());
+    }
+    samples.sort_unstable();
+    let median = samples[samples.len() / 2];
+    let mean = samples.iter().sum::<Duration>() / samples.len() as u32;
+    println!(
+        "{name:<34} median={:>8.3} ms  mean={:>8.3} ms",
+        median.as_secs_f64() * 1_000.0,
+        mean.as_secs_f64() * 1_000.0
+    );
+    Ok(())
+}
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn bench_projection(device: &Device, dtype: DType) -> Result<()> {
+    let input = Tensor::randn(0f32, 1f32, (512, 1024), device)?.to_dtype(dtype)?;
+    let weight = Tensor::randn(0f32, 0.02f32, (1024, 1024), device)?.to_dtype(dtype)?;
+    measure(&format!("projection 512x1024 {dtype:?}"), 3, 9, || {
+        input.matmul(&weight)
+    })
+}
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn native_softmax_attention(q: &Tensor, k: &Tensor, v: &Tensor) -> Result<Tensor> {
+    let weights = (q.matmul(&k.transpose(2, 3)?)? * 0.125)?;
+    candle_nn::ops::softmax_last_dim(&weights)?.matmul(v)
+}
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn f32_softmax_attention(q: &Tensor, k: &Tensor, v: &Tensor, scale: f64) -> Result<Tensor> {
+    let weights = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+    let dtype = weights.dtype();
+    candle_nn::ops::softmax_last_dim(&weights.to_dtype(DType::F32)?)?
+        .to_dtype(dtype)?
+        .matmul(v)
+}
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn bench_attention(device: &Device, dtype: DType, q_len: usize, kv_len: usize) -> Result<()> {
+    let shape_q = (1, 8, q_len, 64);
+    let shape_kv = (1, 8, kv_len, 64);
+    let q = Tensor::randn(0f32, 1f32, shape_q, device)?.to_dtype(dtype)?;
+    let k = Tensor::randn(0f32, 1f32, shape_kv, device)?.to_dtype(dtype)?;
+    let v = Tensor::randn(0f32, 1f32, shape_kv, device)?.to_dtype(dtype)?;
+    measure(
+        &format!("attention/fp32-sm q={q_len} kv={kv_len} {dtype:?}"),
+        2,
+        7,
+        || f32_softmax_attention(&q, &k, &v, 0.125),
+    )?;
+    measure(
+        &format!("attention/native-sm q={q_len} kv={kv_len} {dtype:?}"),
+        2,
+        7,
+        || native_softmax_attention(&q, &k, &v),
+    )?;
+    if device.is_metal() {
+        measure(
+            &format!("attention/fused-sdpa q={q_len} kv={kv_len} {dtype:?}"),
+            2,
+            7,
+            || candle_nn::ops::sdpa(&q, &k, &v, None, false, 0.125, 1.0),
+        )?;
+    }
+
+    if q_len == 512 {
+        let reference = f32_softmax_attention(&q, &k, &v, 0.125)?.to_dtype(DType::F32)?;
+        let native = native_softmax_attention(&q, &k, &v)?.to_dtype(DType::F32)?;
+        let error = (reference - native.clone())?.abs()?;
+        let max_abs = error.max_all()?.to_scalar::<f32>()?;
+        let mean_abs = error.mean_all()?.to_scalar::<f32>()?;
+        println!("  native softmax delta: max_abs={max_abs:.6}, mean_abs={mean_abs:.8}");
+        if device.is_metal() {
+            let fused =
+                candle_nn::ops::sdpa(&q, &k, &v, None, false, 0.125, 1.0)?.to_dtype(DType::F32)?;
+            let fused_error = (fused - native)?.abs()?;
+            let fused_max_abs = fused_error.max_all()?.to_scalar::<f32>()?;
+            let fused_mean_abs = fused_error.mean_all()?.to_scalar::<f32>()?;
+            println!(
+                "  fused SDPA delta: max_abs={fused_max_abs:.6}, mean_abs={fused_mean_abs:.8}"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn bench_sampling(device: &Device, dtype: DType) -> Result<()> {
+    let logits = Tensor::randn(0f32, 1f32, 151_936, device)?.to_dtype(dtype)?;
+    measure_token(&format!("sampling/full-download {dtype:?}"), 2, 15, || {
+        let values = logits
+            .to_dtype(DType::F32)?
+            .to_device(&Device::Cpu)?
+            .to_vec1::<f32>()?;
+        Ok(values
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.total_cmp(b.1))
+            .map(|(index, _)| index as u32)
+            .unwrap_or(0))
+    })?;
+    measure_token(&format!("sampling/device-argmax {dtype:?}"), 2, 15, || {
+        logits.argmax(candle_core::D::Minus1)?.to_scalar::<u32>()
+    })
+}
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn bench_gqa(device: &Device, dtype: DType, q_len: usize, kv_len: usize) -> Result<()> {
+    let q = Tensor::randn(0f32, 1f32, (1, 16, q_len, 128), device)?.to_dtype(dtype)?;
+    let k = Tensor::randn(0f32, 1f32, (1, 2, kv_len, 128), device)?.to_dtype(dtype)?;
+    let v = Tensor::randn(0f32, 1f32, (1, 2, kv_len, 128), device)?.to_dtype(dtype)?;
+    measure(
+        &format!("gqa/repeat-eager q={q_len} kv={kv_len} {dtype:?}"),
+        2,
+        7,
+        || {
+            let repeated_k = repeat_kv(&k, 8)?.contiguous()?;
+            let repeated_v = repeat_kv(&v, 8)?.contiguous()?;
+            f32_softmax_attention(&q, &repeated_k, &repeated_v, 0.08838835)
+        },
+    )?;
+    measure(
+        &format!("gqa/shared-dispatch q={q_len} kv={kv_len} {dtype:?}"),
+        2,
+        7,
+        || scaled_dot_product_attention_gqa(&q, &k, &v, None, 0.08838835, false, 8),
+    )?;
+    measure(
+        &format!("gqa/fused-sdpa q={q_len} kv={kv_len} {dtype:?}"),
+        2,
+        7,
+        || candle_nn::ops::sdpa(&q, &k, &v, None, false, 0.08838835, 1.0),
+    )?;
+
+    let repeated_k = repeat_kv(&k, 8)?.contiguous()?;
+    let repeated_v = repeat_kv(&v, 8)?.contiguous()?;
+    let eager =
+        f32_softmax_attention(&q, &repeated_k, &repeated_v, 0.08838835)?.to_dtype(DType::F32)?;
+    let fused =
+        candle_nn::ops::sdpa(&q, &k, &v, None, false, 0.08838835, 1.0)?.to_dtype(DType::F32)?;
+    let error = (eager - fused)?.abs()?;
+    println!(
+        "  GQA fused delta: max_abs={:.6}, mean_abs={:.8}",
+        error.max_all()?.to_scalar::<f32>()?,
+        error.mean_all()?.to_scalar::<f32>()?
+    );
+    Ok(())
+}
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn report_softmax_accuracy(device: &Device, dtype: DType, score_stddev: f32) -> Result<()> {
+    let scores = (Tensor::randn(0f32, 1f32, (8, 512, 512), device)? * score_stddev as f64)?
+        .to_dtype(dtype)?;
+    let reference = candle_nn::ops::softmax_last_dim(&scores.to_dtype(DType::F32)?)?
+        .to_dtype(dtype)?
+        .to_dtype(DType::F32)?;
+    let native = candle_nn::ops::softmax_last_dim(&scores)?.to_dtype(DType::F32)?;
+    let error = (reference.clone() - &native)?.abs()?;
+    let max_abs = error.max_all()?.to_scalar::<f32>()?;
+    let mean_abs = error.mean_all()?.to_scalar::<f32>()?;
+    let row_sum_error = (native.sum(candle_core::D::Minus1)? - 1f64)?
+        .abs()?
+        .max_all()?
+        .to_scalar::<f32>()?;
+    let reference_argmax = reference
+        .argmax(candle_core::D::Minus1)?
+        .flatten_all()?
+        .to_device(&Device::Cpu)?
+        .to_vec1::<u32>()?;
+    let native_argmax = native
+        .argmax(candle_core::D::Minus1)?
+        .flatten_all()?
+        .to_device(&Device::Cpu)?
+        .to_vec1::<u32>()?;
+    let mismatches = reference_argmax
+        .iter()
+        .zip(native_argmax.iter())
+        .filter(|(a, b)| a != b)
+        .count();
+    println!(
+        "softmax accuracy {dtype:?} std={score_stddev:<3}: max_abs={max_abs:.6}, \
+         mean_abs={mean_abs:.8}, max_row_sum_err={row_sum_error:.6}, argmax_mismatch={mismatches}/{}",
+        reference_argmax.len()
+    );
+    Ok(())
+}
+
+#[cfg(all(feature = "metal", target_os = "macos"))]
+fn main() -> Result<()> {
+    let device = Device::new_metal(0)?;
+    println!("VLM Metal microbenchmark (synchronized end-to-end kernel latency)");
+    println!("shape: batch=1, heads=8, head_dim=64\n");
+    println!("project automatic dtype: {:?}\n", select_dtype(&device));
+
+    println!("-- CPU F32 reference --");
+    let cpu = Device::Cpu;
+    bench_projection(&cpu, DType::F32)?;
+    bench_attention(&cpu, DType::F32, 512, 512)?;
+    bench_attention(&cpu, DType::F32, 1, 1024)?;
+    println!();
+
+    for dtype in [DType::F32, DType::F16, DType::BF16] {
+        println!("-- {dtype:?} --");
+        let result: Result<()> = (|| {
+            bench_projection(&device, dtype)?;
+            bench_attention(&device, dtype, 256, 256)?;
+            bench_attention(&device, dtype, 512, 512)?;
+            bench_attention(&device, dtype, 1, 256)?;
+            bench_attention(&device, dtype, 1, 1024)?;
+            bench_gqa(&device, dtype, 512, 512)?;
+            bench_gqa(&device, dtype, 1, 1024)?;
+            bench_sampling(&device, dtype)?;
+            Ok(())
+        })();
+        if let Err(error) = result {
+            println!("unsupported or failed: {error}");
+        }
+        println!();
+    }
+
+    println!("-- native Metal softmax numerical stress --");
+    for dtype in [DType::F16, DType::BF16] {
+        for score_stddev in [1f32, 4f32, 8f32] {
+            report_softmax_accuracy(&device, dtype, score_stddev)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(all(feature = "metal", target_os = "macos")))]
+fn main() {
+    eprintln!("This benchmark requires macOS and --features metal");
+}

--- a/oar-ocr-vl/examples/paddleocr_vl.rs
+++ b/oar-ocr-vl/examples/paddleocr_vl.rs
@@ -88,6 +88,10 @@ struct Args {
     /// Maximum number of tokens to generate (default: 512)
     #[arg(long, default_value = "512")]
     max_tokens: usize,
+
+    /// Repeat inference to expose Metal warm-up and steady-state latency.
+    #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u32).range(1..))]
+    repeat: u32,
 }
 
 fn parse_task(task_str: &str) -> Result<PaddleOcrVlTask, Box<dyn std::error::Error>> {
@@ -164,36 +168,43 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for image_path in &existing_images {
         info!("\nProcessing: {}", image_path.display());
-
-        // Load image
         let rgb_img = match load_image(image_path) {
-            Ok(img) => img,
+            Ok(image) => image,
             Err(e) => {
                 error!("  Failed to load image: {}", e);
                 continue;
             }
         };
 
-        // Run inference
-        let infer_start = Instant::now();
-        match model
-            .generate_tokens(&[rgb_img], &[task], args.max_tokens)
-            .pop()
-            .unwrap()
-        {
-            Ok(tokens) => {
-                let infer_duration = infer_start.elapsed();
-                info!(
-                    "  Inference time: {:.2}ms, tokens: {}, fingerprint: {:016x}",
-                    infer_duration.as_secs_f64() * 1000.0,
-                    tokens.len(),
-                    token_fingerprint(&tokens)
-                );
-                println!("{}", model.decode_tokens(&tokens, task)?.1);
+        let mut last_tokens = None;
+        for iteration in 1..=args.repeat {
+            let infer_start = Instant::now();
+            let result = model
+                .generate_tokens(std::slice::from_ref(&rgb_img), &[task], args.max_tokens)
+                .pop()
+                .expect("single-image request returns one result");
+            let infer_duration = infer_start.elapsed();
+            match result {
+                Ok(tokens) => {
+                    info!(
+                        "  Inference time (run {}/{}): {:.2}ms, tokens: {}, {:.2} tokens/s, fingerprint: {:016x}",
+                        iteration,
+                        args.repeat,
+                        infer_duration.as_secs_f64() * 1000.0,
+                        tokens.len(),
+                        tokens.len() as f64 / infer_duration.as_secs_f64(),
+                        token_fingerprint(&tokens)
+                    );
+                    last_tokens = Some(tokens);
+                }
+                Err(e) => {
+                    error!("  Inference failed: {}", e);
+                    break;
+                }
             }
-            Err(e) => {
-                error!("  Inference failed: {}", e);
-            }
+        }
+        if let Some(tokens) = last_tokens {
+            println!("{}", model.decode_tokens(&tokens, task)?.1);
         }
     }
     Ok(())

--- a/oar-ocr-vl/src/attention.rs
+++ b/oar-ocr-vl/src/attention.rs
@@ -29,6 +29,77 @@ fn grouped_query_attention_disabled() -> bool {
     *DISABLED.get_or_init(|| std::env::var_os("OAR_VL_DISABLE_GQA").is_some())
 }
 
+/// Native half-precision eager softmax is opt-in on Metal. Fused SDPA has its
+/// own softmax implementation and is unaffected by these switches.
+fn metal_native_softmax_enabled(dtype: DType) -> bool {
+    static FORCE_NATIVE: OnceLock<bool> = OnceLock::new();
+    static FORCE_F32: OnceLock<bool> = OnceLock::new();
+    let force_native =
+        *FORCE_NATIVE.get_or_init(|| std::env::var_os("OAR_VL_METAL_NATIVE_SOFTMAX").is_some());
+    let force_f32 =
+        *FORCE_F32.get_or_init(|| std::env::var_os("OAR_VL_METAL_F32_SOFTMAX").is_some());
+    !force_f32 && force_native && matches!(dtype, DType::F16 | DType::BF16)
+}
+
+fn metal_sdpa_disabled() -> bool {
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| std::env::var_os("OAR_VL_DISABLE_METAL_SDPA").is_some())
+}
+
+fn try_metal_sdpa(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    mask: Option<&Tensor>,
+    scale: f64,
+    is_causal: bool,
+    allow_vector_kernel: bool,
+) -> Result<Option<Tensor>> {
+    if metal_sdpa_disabled() || !q.device().is_metal() {
+        return Ok(None);
+    }
+    let Ok((batch, num_heads, query_len, _)) = q.dims4() else {
+        return Ok(None);
+    };
+    let Ok((_, num_kv_heads, kv_len, _)) = k.dims4() else {
+        return Ok(None);
+    };
+    if v.rank() != 4 || num_kv_heads == 0 {
+        return Ok(None);
+    }
+    // Candle's q_len == 1 vector kernel ignores both explicit masks and their
+    // strides. Keep masked decode on the eager path until the kernel supports
+    // masks. Standard attention also keeps decode eager by design.
+    if query_len == 0
+        || (query_len == 1 && (!allow_vector_kernel || mask.is_some()))
+        || num_heads % num_kv_heads != 0
+    {
+        return Ok(None);
+    }
+
+    let expanded_mask = match mask {
+        Some(mask) if mask.dims() == [batch, num_heads, query_len, kv_len] => Some(mask.clone()),
+        Some(mask) => Some(mask.broadcast_as((batch, num_heads, query_len, kv_len))?),
+        None => None,
+    };
+    // The eager implementation treats an explicit mask as authoritative and
+    // only synthesizes a causal mask when no mask was supplied.
+    let do_causal = is_causal && expanded_mask.is_none();
+    let fused = candle_nn::ops::sdpa(
+        q,
+        k,
+        v,
+        expanded_mask.as_ref(),
+        do_causal,
+        scale as f32,
+        1.0,
+    );
+    // Candle's Metal support matrix is private and may change between patch
+    // releases. An unsupported fused shape is an optimization miss, not an
+    // inference failure, so let the caller continue through the eager path.
+    Ok(fused.ok())
+}
+
 #[cfg(feature = "cuda")]
 fn flash_attention_disabled() -> bool {
     static DISABLED: OnceLock<bool> = OnceLock::new();
@@ -85,6 +156,10 @@ pub fn scaled_dot_product_attention(
     scale: f64,
     is_causal: bool,
 ) -> Result<Tensor> {
+    if let Some(output) = try_metal_sdpa(q, k, v, mask, scale, is_causal, false)? {
+        return Ok(output);
+    }
+
     // Q @ K^T
     let attn_weights = q.matmul(&k.transpose(2, 3)?)?;
 
@@ -104,11 +179,19 @@ pub fn scaled_dot_product_attention(
         None => attn_weights,
     };
 
-    // Softmax: cast to F32 for numerical stability, then cast back
+    // Softmax: cast to F32 for numerical stability, then cast back. Metal can
+    // opt into its native half-precision kernel to avoid two conversions.
     let input_dtype = attn_weights.dtype();
-    let attn_weights = attn_weights.to_dtype(DType::F32)?;
-    let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
-    let attn_weights = attn_weights.to_dtype(input_dtype)?;
+    let use_native_metal_softmax = q.device().is_metal()
+        && input_dtype != DType::F32
+        && metal_native_softmax_enabled(input_dtype);
+    let attn_weights = if use_native_metal_softmax {
+        candle_nn::ops::softmax_last_dim(&attn_weights)?
+    } else {
+        let attn_weights = attn_weights.to_dtype(DType::F32)?;
+        let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+        attn_weights.to_dtype(input_dtype)?
+    };
 
     // Attention @ V
     attn_weights.matmul(v)
@@ -190,6 +273,10 @@ pub fn scaled_dot_product_attention_gqa(
         )
     }
 
+    if let Some(output) = try_metal_sdpa(q, k, v, mask, scale, is_causal, true)? {
+        return Ok(output);
+    }
+
     let grouped_batch = batch * num_kv_heads;
     let grouped_queries = num_kv_groups * query_len;
     let grouped_q = q.reshape((grouped_batch, grouped_queries, head_dim))?;
@@ -209,9 +296,15 @@ pub fn scaled_dot_product_attention_gqa(
     };
 
     let weight_dtype = weights.dtype();
-    let weights = candle_nn::ops::softmax_last_dim(&weights.to_dtype(DType::F32)?)?
-        .to_dtype(weight_dtype)?
-        .reshape((grouped_batch, grouped_queries, kv_len))?;
+    let use_native_metal_softmax = q.device().is_metal()
+        && weight_dtype != DType::F32
+        && metal_native_softmax_enabled(weight_dtype);
+    let weights = if use_native_metal_softmax {
+        candle_nn::ops::softmax_last_dim(&weights)?
+    } else {
+        candle_nn::ops::softmax_last_dim(&weights.to_dtype(DType::F32)?)?.to_dtype(weight_dtype)?
+    }
+    .reshape((grouped_batch, grouped_queries, kv_len))?;
     let grouped_v = v.reshape((grouped_batch, kv_len, head_dim))?;
     weights
         .matmul(&grouped_v)?
@@ -819,6 +912,91 @@ mod tests {
                 .zip(grouped)
                 .all(|(left, right)| (left - right).abs() < 1e-5)
         );
+        Ok(())
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn test_metal_fused_gqa_matches_repeated_kv() -> Result<()> {
+        let Ok(device) = Device::new_metal(0) else {
+            return Ok(());
+        };
+        let q = Tensor::randn(0f32, 1f32, (1, 4, 16, 64), &device)?.to_dtype(DType::F16)?;
+        let k = Tensor::randn(0f32, 1f32, (1, 2, 16, 64), &device)?.to_dtype(DType::F16)?;
+        let v = Tensor::randn(0f32, 1f32, (1, 2, 16, 64), &device)?.to_dtype(DType::F16)?;
+        let mask = create_causal_mask(16, 16, DType::F16, &device)?;
+        let fused = scaled_dot_product_attention_gqa(&q, &k, &v, Some(&mask), 0.125, false, 2)?;
+        let repeated = scaled_dot_product_attention(
+            &q,
+            &repeat_kv(&k, 2)?.contiguous()?,
+            &repeat_kv(&v, 2)?.contiguous()?,
+            Some(&mask),
+            0.125,
+            false,
+        )?;
+        let max_prefill_error = (fused.to_dtype(DType::F32)? - repeated.to_dtype(DType::F32)?)?
+            .abs()?
+            .max_all()?
+            .to_scalar::<f32>()?;
+        assert!(
+            max_prefill_error <= 0.01,
+            "prefill error {max_prefill_error}"
+        );
+
+        let q = Tensor::randn(0f32, 1f32, (1, 4, 1, 64), &device)?.to_dtype(DType::F16)?;
+        let k = Tensor::randn(0f32, 1f32, (1, 2, 32, 64), &device)?.to_dtype(DType::F16)?;
+        let v = Tensor::randn(0f32, 1f32, (1, 2, 32, 64), &device)?.to_dtype(DType::F16)?;
+        let fused = scaled_dot_product_attention_gqa(&q, &k, &v, None, 0.125, false, 2)?;
+        let repeated = scaled_dot_product_attention(
+            &q,
+            &repeat_kv(&k, 2)?.contiguous()?,
+            &repeat_kv(&v, 2)?.contiguous()?,
+            None,
+            0.125,
+            false,
+        )?;
+        let max_decode_error = (fused.to_dtype(DType::F32)? - repeated.to_dtype(DType::F32)?)?
+            .abs()?
+            .max_all()?
+            .to_scalar::<f32>()?;
+        assert!(max_decode_error <= 0.01, "decode error {max_decode_error}");
+
+        let mut mask_values = vec![0f32; 32];
+        mask_values[16..].fill(f32::NEG_INFINITY);
+        let decode_mask =
+            Tensor::from_vec(mask_values, (1, 1, 1, 32), &device)?.to_dtype(DType::F16)?;
+        assert!(
+            try_metal_sdpa(&q, &k, &v, Some(&decode_mask), 0.125, false, true)?.is_none(),
+            "masked single-token decode must not use Candle's mask-blind vector kernel"
+        );
+        let masked =
+            scaled_dot_product_attention_gqa(&q, &k, &v, Some(&decode_mask), 0.125, false, 2)?;
+        let repeated_masked = scaled_dot_product_attention(
+            &q,
+            &repeat_kv(&k, 2)?.contiguous()?,
+            &repeat_kv(&v, 2)?.contiguous()?,
+            Some(&decode_mask),
+            0.125,
+            false,
+        )?;
+        let max_masked_error = (masked.to_dtype(DType::F32)?
+            - repeated_masked.to_dtype(DType::F32)?)?
+        .abs()?
+        .max_all()?
+        .to_scalar::<f32>()?;
+        assert!(
+            max_masked_error <= 0.01,
+            "masked decode error {max_masked_error}"
+        );
+
+        let q = Tensor::randn(0f32, 1f32, (1, 4, 3, 48), &device)?.to_dtype(DType::F16)?;
+        let k = Tensor::randn(0f32, 1f32, (1, 2, 3, 48), &device)?.to_dtype(DType::F16)?;
+        let v = Tensor::randn(0f32, 1f32, (1, 2, 3, 48), &device)?.to_dtype(DType::F16)?;
+        assert!(
+            try_metal_sdpa(&q, &k, &v, None, 0.125, false, true)?.is_none(),
+            "unsupported fused shapes must fall back instead of failing"
+        );
+        scaled_dot_product_attention_gqa(&q, &k, &v, None, 0.125, false, 2)?;
         Ok(())
     }
 

--- a/oar-ocr-vl/src/attention.rs
+++ b/oar-ocr-vl/src/attention.rs
@@ -71,6 +71,16 @@ fn try_metal_sdpa(
     // before it ever reaches this function, so the non-GQA caller (which has
     // no equivalent upstream check) can't hand a fused Metal kernel batch,
     // head, length, or head_dim mismatches it isn't guaranteed to validate.
+    // `allow_vector_kernel` is only ever `true` for the GQA caller, which has
+    // already validated `num_heads == num_kv_heads * num_kv_groups`; the
+    // plain (non-GQA) caller documents equal head counts, so require an exact
+    // match there instead of merely a multiple, or a head-count mismatch
+    // would silently get grouped-query semantics on Metal only.
+    let heads_match = if allow_vector_kernel {
+        num_heads.is_multiple_of(num_kv_heads)
+    } else {
+        num_heads == num_kv_heads
+    };
     if num_kv_heads == 0
         || batch != k_batch
         || batch != v_batch
@@ -78,14 +88,25 @@ fn try_metal_sdpa(
         || kv_len != v_len
         || head_dim != k_head_dim
         || head_dim != v_head_dim
-        || !num_heads.is_multiple_of(num_kv_heads)
+        || !heads_match
     {
         return Ok(None);
     }
     // Candle's q_len == 1 vector kernel ignores both explicit masks and their
     // strides. Keep masked decode on the eager path until the kernel supports
     // masks. Standard attention also keeps decode eager by design.
-    if query_len == 0 || (query_len == 1 && (!allow_vector_kernel || mask.is_some())) {
+    //
+    // Candle's causal kernel derives its diagonal offset as `kv_len - query_len`
+    // in unsigned arithmetic; when query_len > kv_len that underflows and every
+    // row ends up fully masked (a 0/0 softmax), unlike the eager causal mask
+    // (`create_causal_mask`), which saturates that offset to 0 and still lets
+    // early rows attend the first key. No cache in this crate currently grows
+    // query_len past kv_len, but keep this on the eager path rather than rely
+    // on that invariant holding forever.
+    if query_len == 0
+        || (query_len == 1 && (!allow_vector_kernel || mask.is_some()))
+        || (is_causal && mask.is_none() && query_len > kv_len)
+    {
         return Ok(None);
     }
 
@@ -1009,6 +1030,57 @@ mod tests {
             "unsupported fused shapes must fall back instead of failing"
         );
         scaled_dot_product_attention_gqa(&q, &k, &v, None, 0.125, false, 2)?;
+        Ok(())
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn test_metal_plain_sdpa_rejects_head_count_mismatch() -> Result<()> {
+        let Ok(device) = Device::new_metal(0) else {
+            return Ok(());
+        };
+        // scaled_dot_product_attention is the non-GQA entry point; unlike the
+        // GQA wrapper it never validates num_heads against num_kv_heads
+        // upstream, so try_metal_sdpa must reject a multiple-but-unequal head
+        // count itself instead of silently getting GQA semantics from
+        // Candle's fused kernel.
+        let q = Tensor::randn(0f32, 1f32, (1, 4, 8, 64), &device)?.to_dtype(DType::F16)?;
+        let k = Tensor::randn(0f32, 1f32, (1, 2, 8, 64), &device)?.to_dtype(DType::F16)?;
+        let v = Tensor::randn(0f32, 1f32, (1, 2, 8, 64), &device)?.to_dtype(DType::F16)?;
+        assert!(
+            try_metal_sdpa(&q, &k, &v, None, 0.125, false, false)?.is_none(),
+            "plain scaled_dot_product_attention must not dispatch mismatched head counts to the fused kernel"
+        );
+        assert!(scaled_dot_product_attention(&q, &k, &v, None, 0.125, false).is_err());
+        Ok(())
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn test_metal_causal_query_longer_than_kv_matches_eager() -> Result<()> {
+        let Ok(device) = Device::new_metal(0) else {
+            return Ok(());
+        };
+        // query_len > kv_len with is_causal=true and no explicit mask: Candle's
+        // Metal causal kernel underflows its diagonal offset for this shape, so
+        // try_metal_sdpa must fall back to the eager path instead of dispatching.
+        let q = Tensor::randn(0f32, 1f32, (1, 2, 8, 64), &device)?.to_dtype(DType::F16)?;
+        let k = Tensor::randn(0f32, 1f32, (1, 2, 3, 64), &device)?.to_dtype(DType::F16)?;
+        let v = Tensor::randn(0f32, 1f32, (1, 2, 3, 64), &device)?.to_dtype(DType::F16)?;
+        assert!(
+            try_metal_sdpa(&q, &k, &v, None, 0.125, true, false)?.is_none(),
+            "causal query_len > kv_len must fall back to the eager path on Metal"
+        );
+        let out = scaled_dot_product_attention(&q, &k, &v, None, 0.125, true)?;
+        assert_eq!(out.dims(), &[1, 2, 8, 64]);
+        assert!(
+            out.to_dtype(DType::F32)?
+                .flatten_all()?
+                .to_vec1::<f32>()?
+                .iter()
+                .all(|value| value.is_finite()),
+            "eager fallback must not produce NaN/inf for this shape"
+        );
         Ok(())
     }
 

--- a/oar-ocr-vl/src/attention.rs
+++ b/oar-ocr-vl/src/attention.rs
@@ -58,22 +58,34 @@ fn try_metal_sdpa(
     if metal_sdpa_disabled() || !q.device().is_metal() {
         return Ok(None);
     }
-    let Ok((batch, num_heads, query_len, _)) = q.dims4() else {
+    let Ok((batch, num_heads, query_len, head_dim)) = q.dims4() else {
         return Ok(None);
     };
-    let Ok((_, num_kv_heads, kv_len, _)) = k.dims4() else {
+    let Ok((k_batch, num_kv_heads, kv_len, k_head_dim)) = k.dims4() else {
         return Ok(None);
     };
-    if v.rank() != 4 || num_kv_heads == 0 {
+    let Ok((v_batch, v_heads, v_len, v_head_dim)) = v.dims4() else {
+        return Ok(None);
+    };
+    // Mirror the shape consistency scaled_dot_product_attention_gqa enforces
+    // before it ever reaches this function, so the non-GQA caller (which has
+    // no equivalent upstream check) can't hand a fused Metal kernel batch,
+    // head, length, or head_dim mismatches it isn't guaranteed to validate.
+    if num_kv_heads == 0
+        || batch != k_batch
+        || batch != v_batch
+        || num_kv_heads != v_heads
+        || kv_len != v_len
+        || head_dim != k_head_dim
+        || head_dim != v_head_dim
+        || !num_heads.is_multiple_of(num_kv_heads)
+    {
         return Ok(None);
     }
     // Candle's q_len == 1 vector kernel ignores both explicit masks and their
     // strides. Keep masked decode on the eager path until the kernel supports
     // masks. Standard attention also keeps decode eager by design.
-    if query_len == 0
-        || (query_len == 1 && (!allow_vector_kernel || mask.is_some()))
-        || num_heads % num_kv_heads != 0
-    {
+    if query_len == 0 || (query_len == 1 && (!allow_vector_kernel || mask.is_some())) {
         return Ok(None);
     }
 

--- a/oar-ocr-vl/src/hunyuanocr/llm.rs
+++ b/oar-ocr-vl/src/hunyuanocr/llm.rs
@@ -4,7 +4,7 @@ use super::dynamic_kv::{
     DynamicKvAppend, FusedAddRmsNormBf16, FusedSiluMulBf16, FusedXdRope, FusedXdRopeRmsNormF16,
 };
 use crate::attention::{
-    RotaryEmbedding, flash_attention, repeat_kv, scaled_dot_product_attention, select_rope_sections,
+    RotaryEmbedding, flash_attention, scaled_dot_product_attention_gqa, select_rope_sections,
 };
 #[cfg(feature = "cuda")]
 use crate::decoder_graph::{
@@ -514,29 +514,16 @@ impl HunyuanAttention {
         };
         let attn_output = match flash_output {
             Some(output) => output,
-            None => {
-                let key_states = repeat_kv(&k_all, self.num_kv_groups)
-                    .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "repeat_kv key", e))?
-                    .contiguous()
-                    .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "attn key contiguous", e))?;
-                let value_states = repeat_kv(&v_all, self.num_kv_groups)
-                    .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "repeat_kv value", e))?
-                    .contiguous()
-                    .map_err(|e| {
-                        candle_to_ocr_inference("HunyuanOCR", "attn value contiguous", e)
-                    })?;
-                scaled_dot_product_attention(
-                    q,
-                    &key_states,
-                    &value_states,
-                    causal_mask,
-                    self.scaling,
-                    seq_len > 1,
-                )
-                .map_err(|e| {
-                    candle_to_ocr_inference("HunyuanOCR", "scaled dot-product attention", e)
-                })?
-            }
+            None => scaled_dot_product_attention_gqa(
+                q,
+                &k_all,
+                &v_all,
+                causal_mask,
+                self.scaling,
+                seq_len > 1,
+                self.num_kv_groups,
+            )
+            .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "grouped-query attention", e))?,
         };
         self.project_attention_output(&attn_output, model_dtype, b, seq_len)
     }

--- a/oar-ocr-vl/src/mineru/model.rs
+++ b/oar-ocr-vl/src/mineru/model.rs
@@ -732,6 +732,12 @@ struct SamplingParams {
     gpu_greedy_sampling: bool,
 }
 
+impl SamplingParams {
+    fn is_greedy(&self) -> bool {
+        !self.do_sample || self.top_k == 1
+    }
+}
+
 fn select_next_token(
     logits: &Tensor,
     history: &[u32],
@@ -745,11 +751,34 @@ fn select_next_token(
     #[cfg(feature = "cuda")]
     if params.gpu_greedy_sampling
         && logits.device().is_cuda()
-        && (!params.do_sample || params.top_k == 1)
+        && params.is_greedy()
         && params.repetition_penalty <= 1.0
         && matches!(logits.dtype(), DType::BF16 | DType::F32)
     {
         return select_greedy_token_cuda(logits, history, params.no_repeat_ngram_size);
+    }
+
+    // Metal's generic argmax returns a scalar token without downloading and
+    // allocating the full vocabulary on the host. Preserve the CPU processor
+    // path whenever repetition or no-repeat-ngram would modify the logits.
+    if logits.device().is_metal()
+        && params.is_greedy()
+        && params.repetition_penalty <= 1.0
+        && matches!(logits.dtype(), DType::F16 | DType::BF16 | DType::F32)
+        && no_repeat_ngram_banned_tokens(history, params.no_repeat_ngram_size).is_empty()
+    {
+        let not_nan = logits
+            .eq(logits)
+            .map_err(|e| candle_to_ocr_inference("MinerU2.5", "Metal NaN mask", e))?;
+        let neg_inf = Tensor::new(f32::NEG_INFINITY, logits.device())
+            .and_then(|value| value.to_dtype(logits.dtype()))
+            .and_then(|value| value.broadcast_as(logits.dims()))
+            .map_err(|e| candle_to_ocr_inference("MinerU2.5", "Metal NaN replacement", e))?;
+        return not_nan
+            .where_cond(logits, &neg_inf)
+            .and_then(|logits| logits.argmax(candle_core::D::Minus1))
+            .and_then(|token| token.to_scalar::<u32>())
+            .map_err(|e| candle_to_ocr_inference("MinerU2.5", "Metal greedy argmax", e));
     }
 
     let logits = logits
@@ -763,7 +792,7 @@ fn select_next_token(
 
     apply_sampling_processors(&mut logits_vec, history, params);
 
-    if !params.do_sample || params.top_k == 1 {
+    if params.is_greedy() {
         return Ok(argmax_token(&logits_vec));
     }
 
@@ -814,7 +843,7 @@ fn apply_sampling_processors(logits: &mut [f32], history: &[u32], params: &Sampl
     apply_repetition_penalty(logits, history, params.repetition_penalty);
     apply_no_repeat_ngram(logits, history, params.no_repeat_ngram_size);
 
-    if !params.do_sample || params.top_k == 1 {
+    if params.is_greedy() {
         return;
     }
 
@@ -1155,6 +1184,44 @@ mod tests {
         let gpu = select_next_token(&gpu_logits, &history, &params).unwrap();
         assert_eq!(cpu, 1024);
         assert_eq!(gpu, cpu);
+        Ok(())
+    }
+
+    #[cfg(all(feature = "metal", target_os = "macos"))]
+    #[test]
+    fn mineru_metal_greedy_matches_cpu_and_preserves_first_tie() -> candle_core::Result<()> {
+        let Ok(device) = Device::new_metal(0) else {
+            return Ok(());
+        };
+        let mut values = vec![0.0f32; 151_936];
+        values[0] = f32::NAN;
+        values[1] = 10.0;
+        values[1024] = 10.0;
+        let metal_logits = Tensor::from_vec(values, 151_936, &device)?.to_dtype(DType::F16)?;
+        let cpu_logits = metal_logits.to_device(&Device::Cpu)?;
+        let params = SamplingParams {
+            repetition_penalty: 1.0,
+            no_repeat_ngram_size: 3,
+            do_sample: true,
+            temperature: 0.01,
+            top_p: 0.001,
+            top_k: 1,
+            #[cfg(feature = "cuda")]
+            gpu_greedy_sampling: false,
+        };
+
+        let cpu = select_next_token(&cpu_logits, &[], &params).unwrap();
+        let metal = select_next_token(&metal_logits, &[], &params).unwrap();
+        assert_eq!(cpu, 1);
+        assert_eq!(metal, cpu);
+
+        // The current bigram [4, 5] bans token 1, forcing the exact CPU
+        // processor fallback and selecting the other tied token.
+        let history = [4, 5, 1, 8, 4, 5];
+        assert_eq!(
+            select_next_token(&metal_logits, &history, &params).unwrap(),
+            1024
+        );
         Ok(())
     }
 

--- a/oar-ocr-vl/src/paddleocr_vl/ernie.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/ernie.rs
@@ -1,6 +1,6 @@
 use super::config::PaddleOcrVlConfig;
 use crate::attention::{
-    RotaryEmbedding, flash_attention, repeat_kv, scaled_dot_product_attention, select_rope_sections,
+    RotaryEmbedding, flash_attention, scaled_dot_product_attention_gqa, select_rope_sections,
 };
 #[cfg(feature = "cuda")]
 use crate::decoder_graph::decoder_cache_capacity;
@@ -294,29 +294,16 @@ impl Ernie4_5Attention {
         let is_causal = causal_mask.is_none();
         let attn_output = match flash {
             Some(attn) => attn,
-            None => {
-                let key_states = repeat_kv(&k_all, self.num_kv_groups)
-                    .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "repeat_kv key", e))?;
-                let value_states = repeat_kv(&v_all, self.num_kv_groups)
-                    .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "repeat_kv value", e))?;
-                let key_states = key_states.contiguous().map_err(|e| {
-                    candle_to_ocr_inference("PaddleOCR-VL", "attn key_states contiguous", e)
-                })?;
-                let value_states = value_states.contiguous().map_err(|e| {
-                    candle_to_ocr_inference("PaddleOCR-VL", "attn value_states contiguous", e)
-                })?;
-                scaled_dot_product_attention(
-                    &q,
-                    &key_states,
-                    &value_states,
-                    causal_mask,
-                    self.scaling,
-                    is_causal,
-                )
-                .map_err(|e| {
-                    candle_to_ocr_inference("PaddleOCR-VL", "scaled_dot_product_attention", e)
-                })?
-            }
+            None => scaled_dot_product_attention_gqa(
+                &q,
+                &k_all,
+                &v_all,
+                causal_mask,
+                self.scaling,
+                is_causal,
+                self.num_kv_groups,
+            )
+            .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "grouped-query attention", e))?,
         };
 
         self.project_attention_output(&attn_output, b, seq_len)


### PR DESCRIPTION
## Summary

- extend CoreML session configuration with compute-unit, model-format, specialization, static-shape, precision, profiling, and cache controls while preserving the existing `OrtExecutionProvider::CoreML` variant shape
- add fused Metal SDPA/GQA routing with masked single-token safety and eager fallback for unsupported Candle kernels
- keep eager F16/BF16 softmax numerics conservative by default, add an opt-in native path, and make Metal greedy argmax NaN-compatible with CPU
- add repeat/thread tuning to the OCR examples and a model-independent Metal benchmark with accurate device synchronization

## Why

The change improves Apple Silicon and CoreML steady-state inference performance, while fixing review findings around ignored decode masks, hard failures on unsupported fused shapes, timing contamination, numerical behavior changes, NaN handling, and downstream Rust API compatibility.

## Validation

- `cargo check --workspace --all-targets`
- `cargo check -p oar-ocr --all-targets --features coreml`
- `cargo check -p oar-ocr-vl --all-targets --features metal`
- `cargo test --workspace --lib --features download-binaries` (610 passed)
- `cargo test -p oar-ocr-vl --features metal,download-binaries metal -- --nocapture` (4 passed on Metal)
- `cargo test -p oar-ocr-core --features coreml,download-binaries coreml -- --nocapture` (2 passed)
- Clippy with `-D warnings` for Metal and CoreML targets
