### PR TITLE
chore: bump version to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "oar-ocr-derive", "oar-ocr-core", "oar-ocr-vl"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ repository = "https://github.com/greatv/oar-ocr"
 homepage = "https://github.com/greatv/oar-ocr"
 
 [workspace.dependencies]
-oar-ocr-core = { version = "0.8.0", path = "oar-ocr-core", default-features = false }
-oar-ocr-derive = { version = "0.8.0", path = "oar-ocr-derive", default-features = false }
+oar-ocr-core = { version = "0.8.1", path = "oar-ocr-core", default-features = false }
+oar-ocr-derive = { version = "0.8.1", path = "oar-ocr-derive", default-features = false }
 
 # Shared third-party dependencies (kept in sync via workspace inheritance).
 clap = { version = "4.5.42", features = ["derive"] }


### PR DESCRIPTION
## Summary

- bump the shared workspace version from `0.8.0` to `0.8.1`
- update the published `oar-ocr-core` and `oar-ocr-derive` dependency requirements to `0.8.1`
- keep all four workspace crates aligned with the `v0.8.1` release tag

## Impact

This prepares the workspace for the `v0.8.1` crates.io and GitHub release. There are no runtime or API changes in this PR.

## Validation

- `cargo test --workspace`