### PR TITLE
Make oar-ocr-vl standalone with native PP-DocLayout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           cargo clippy --all-targets --all -- -D warnings
           cargo clippy --all-targets -p oar-ocr-vl -- -D warnings
+          cargo clippy --all-targets -p oar-ocr-core --no-default-features -- -D warnings
 
       - name: Check rustdoc warnings
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "oar-ocr-derive", "oar-ocr-core", "oar-ocr-vl"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ repository = "https://github.com/greatv/oar-ocr"
 homepage = "https://github.com/greatv/oar-ocr"
 
 [workspace.dependencies]
-oar-ocr-core = { version = "0.8.1", path = "oar-ocr-core", default-features = false }
-oar-ocr-derive = { version = "0.8.1", path = "oar-ocr-derive", default-features = false }
+oar-ocr-core = { version = "0.9.0", path = "oar-ocr-core", default-features = false }
+oar-ocr-derive = { version = "0.9.0", path = "oar-ocr-derive", default-features = false }
 
 # Shared third-party dependencies (kept in sync via workspace inheritance).
 clap = { version = "4.5.42", features = ["derive"] }

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -50,7 +50,7 @@ Accepted values (case-insensitive):
 Without the override, devices that advertise BF16 support use it after a runtime kernel probe. If the probe fails (for example on pre-Ampere CUDA GPUs), inference falls back to F16. CPU and devices without advertised BF16 support use F32.
 
 ```bash
-OAR_VL_DTYPE=f16 cargo run --release --features cuda,download-binaries -p oar-ocr-vl --example paddleocr_vl -- ...
+OAR_VL_DTYPE=f16 cargo run --release --features cuda -p oar-ocr-vl --example paddleocr_vl -- ...
 ```
 
 ## `OAR_VL_ATTN_FULL_SEQ_THRESHOLD`
@@ -60,7 +60,7 @@ Maximum sequence length (in vision patches) for which PaddleOCR-VL's vision atte
 Independently of this threshold, the full path is skipped automatically whenever its softmax scratch would not fit in the free device memory, so low-VRAM GPUs normally don't need this variable.
 
 ```bash
-OAR_VL_ATTN_FULL_SEQ_THRESHOLD=0 cargo run --release --features cuda,download-binaries -p oar-ocr-vl --example paddleocr_vl -- ...
+OAR_VL_ATTN_FULL_SEQ_THRESHOLD=0 cargo run --release --features cuda -p oar-ocr-vl --example paddleocr_vl -- ...
 ```
 
 ## VL Performance and Debug Overrides
@@ -95,7 +95,7 @@ With the `cuda` feature enabled, `oar-ocr-vl` compiles its custom kernels, inclu
 
 ```bash
 CUDA_COMPUTE_CAP=89 NVCC=/usr/local/cuda/bin/nvcc \
-    cargo build -p oar-ocr-vl --features cuda,download-binaries
+    cargo build -p oar-ocr-vl --features cuda
 ```
 
 ## `CUDA_LAUNCH_BLOCKING`

--- a/docs/features.md
+++ b/docs/features.md
@@ -178,6 +178,17 @@ Existing files and explicit paths remain under caller control. In-memory ONNX so
 
 `auto-download` supplies model files at runtime. It does not install ONNX Runtime or any accelerator dependencies.
 
+## `oar-ocr-vl` needs none of this
+
+`oar-ocr-vl` is a separate, self-contained crate. It runs every model on Candle — including layout detection, through `oar_ocr_vl::PpDocLayout`, a native port of PP-DocLayoutV2/V3 — so it depends on neither `oar-ocr-core` nor ONNX Runtime, and none of the features above apply to it. It has two of its own, both off by default:
+
+| Feature | Purpose |
+|---|---|
+| `cuda` | Candle CUDA backend |
+| `metal` | Candle Metal backend |
+
+To source layout from somewhere else, implement `oar_ocr_vl::LayoutSource` and pass it to `DocParser::parse`.
+
 ## Recommended Combinations
 
 | Use case | Features |
@@ -201,7 +212,7 @@ Features listed in this table are added to the two default features unless `--no
 - Execution provider order matters. ONNX Runtime tries providers in the order supplied to `OrtSessionConfig`.
 - Feature flags compile provider support but do not install GPU drivers, TensorRT, DirectML, Core ML, OpenVINO, or other system runtimes.
 - Avoid `--all-features` for normal builds. Several providers are platform-specific and some provider combinations have no matching prebuilt ONNX Runtime distribution.
-- The `oar-ocr-vl` crate has its own `cuda`, `metal`, and `download-binaries` features. They are independent of the root-crate features documented here.
+- The `oar-ocr-vl` crate is independent of everything documented here; see [`oar-ocr-vl` needs none of this](#oar-ocr-vl-needs-none-of-this).
 
 Inspect the resolved feature graph with:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -267,23 +267,23 @@ PaddleOCR-VL-1.5 and PaddleOCR-VL-1.6 are drop-in replacements via `PaddleOcrVl:
 
 ### Installation
 
-Add the VL crate and the core crate used by the snippets below to your `Cargo.toml`. `download-binaries` supplies ONNX Runtime for the core helpers unless you link a system installation with `ORT_LIB_PATH` or `ORT_LIB_LOCATION`.
+`oar-ocr-vl` is self-contained and runs on Candle, so it pulls in **no ONNX Runtime** and does not depend on `oar-ocr-core`:
 
 ```toml
 [dependencies]
-oar-ocr-core = { version = "0.8", default-features = false }
-oar-ocr-vl = { version = "0.8", features = ["download-binaries"] }
+oar-ocr-vl = "0.9"
 ```
 
 For GPU acceleration, enable CUDA:
 
 ```toml
 [dependencies]
-oar-ocr-core = { version = "0.8", default-features = false }
-oar-ocr-vl = { version = "0.8", features = ["cuda", "download-binaries"] }
+oar-ocr-vl = { version = "0.9", features = ["cuda"] }
 ```
 
 On macOS, use the `metal` feature instead.
+
+Layout-first parsing with `DocParser` uses `PpDocLayout`, a native Candle port of PP-DocLayoutV2/V3, so nothing further is required. To source layout from somewhere else, implement `oar_ocr_vl::LayoutSource` and pass it to `DocParser::parse`.
 
 ### Downloading the Model
 
@@ -309,7 +309,7 @@ hf download PaddlePaddle/PaddleOCR-VL-1.6 --local-dir PaddleOCR-VL-1.6
 ### Basic Usage
 
 ```rust,no_run
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::{PaddleOcrVl, PaddleOcrVlTask};
 use oar_ocr_vl::utils::parse_device;
 use std::path::Path;
@@ -334,7 +334,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 PaddleOCR-VL-1.5 and PaddleOCR-VL-1.6 use the same API:
 
 ```rust,no_run
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::{PaddleOcrVl, PaddleOcrVlTask};
 use oar_ocr_vl::utils::parse_device;
 use std::path::Path;
@@ -359,13 +359,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
+cargo run -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
     -m PaddlePaddle/PaddleOCR-VL --device cuda --task ocr document.jpg
 
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
+cargo run -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
     -m PaddlePaddle/PaddleOCR-VL-1.5 --device cuda --task spotting spotting.jpg
 
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
+cargo run -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
     -m PaddlePaddle/PaddleOCR-VL-1.6 --device cuda --task seal seal.jpg
 ```
 
@@ -410,7 +410,7 @@ Input pages are converted to RGB, resized with bicubic antialiasing, and aligned
 ### Basic Usage
 
 ```rust,no_run
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::ovisocr2::DEFAULT_MAX_NEW_TOKENS;
 use oar_ocr_vl::utils::parse_device;
 use oar_ocr_vl::OvisOcr2;
@@ -433,7 +433,7 @@ The API is batch-oriented: pass multiple page images to `parse` and receive one 
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example ovisocr2 -- \
+cargo run -p oar-ocr-vl --features cuda --example ovisocr2 -- \
     --model-dir ATH-MaaS/OvisOCR2 \
     --device cuda:0 \
     document-1.jpg document-2.jpg
@@ -461,7 +461,7 @@ hf download zenosai/MonkeyOCRv2-B-Parsing --local-dir MonkeyOCRv2-B-Parsing
 ### Basic Usage
 
 ```rust,no_run
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 use oar_ocr_vl::{MonkeyOcrV2, MonkeyOcrV2Task};
 
@@ -486,7 +486,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example monkeyocrv2 -- \
+cargo run -p oar-ocr-vl --features cuda --example monkeyocrv2 -- \
     --model-dir zenosai/MonkeyOCRv2-S-Parsing \
     --device cuda:0 \
     --task end-to-end \
@@ -518,7 +518,7 @@ The download places 1.5 weights directly in `HunyuanOCR/` and its optional DFlas
 ### Basic Usage
 
 ```rust,no_run
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::HunyuanOcr;
 use oar_ocr_vl::utils::parse_device;
 
@@ -560,7 +560,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example hunyuanocr -- \
+cargo run -p oar-ocr-vl --features cuda --example hunyuanocr -- \
     --model-dir tencent/HunyuanOCR \
     --dflash-dir tencent/HunyuanOCR/dflash \
     --device cuda \
@@ -596,7 +596,7 @@ hf download zai-org/GLM-OCR --local-dir GLM-OCR
 ### Basic Usage
 
 ```rust,no_run
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::GlmOcr;
 use oar_ocr_vl::utils::parse_device;
 
@@ -620,7 +620,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example glmocr -- \
+cargo run -p oar-ocr-vl --features cuda --example glmocr -- \
     --model-dir zai-org/GLM-OCR \
     --device cuda \
     --prompt "Text Recognition:" \
@@ -646,7 +646,7 @@ hf download opendatalab/MinerU2.5-Pro-2605-1.2B --local-dir MinerU2.5-Pro-2605-1
 ### Basic Usage
 
 ```rust,no_run
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::MinerU;
 use oar_ocr_vl::utils::parse_device;
 
@@ -671,12 +671,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
+cargo run -p oar-ocr-vl --features cuda --example mineru -- \
     --model-dir opendatalab/MinerU2.5-2509-1.2B \
     --device cuda \
     document.jpg
 
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
+cargo run -p oar-ocr-vl --features cuda --example mineru -- \
     --model-dir opendatalab/MinerU2.5-Pro-2605-1.2B \
     --device cuda \
     document.jpg
@@ -700,7 +700,7 @@ hf download opendatalab/MinerU-Diffusion-V1-0320-2.5B \
 ### Basic Usage
 
 ```rust,no_run
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::mineru_diffusion::DEFAULT_PROMPT;
 use oar_ocr_vl::utils::parse_device;
 use oar_ocr_vl::{DiffusionGenerationConfig, MinerUDiffusion};
@@ -724,7 +724,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Running the Example
 
 ```bash
-cargo run -p oar-ocr-vl --features cuda,download-binaries \
+cargo run -p oar-ocr-vl --features cuda \
     --example mineru_diffusion -- \
     --model-dir opendatalab/MinerU-Diffusion-V1-0320-2.5B \
     --device cuda:0 \
@@ -735,27 +735,23 @@ cargo run -p oar-ocr-vl --features cuda,download-binaries \
 
 DocParser provides a unified API for external layout-first document parsing with VL-based recognition. The `doc_parser` example supports PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR. MonkeyOCRv2 also implements `RecognitionBackend`, but uses its dedicated model-native example for complete pages.
 
-Use `parse(&layout, image)` with an ONNX layout detector. OvisOCR2 deliberately does not implement `RecognitionBackend`; use its full-page `OvisOcr2::parse` API instead. The library also implements `RecognitionBackend` for MonkeyOCRv2, HunyuanOCR, and MinerU2.5/Pro, but they are intentionally not exposed by the CLI example because their reference-quality paths are model-native parsing. MinerU-Diffusion uses its dedicated example.
+Use `parse(&layout, image)` with any `LayoutSource` — `PpDocLayout` is the built-in one and runs on Candle, so no ONNX Runtime is involved. The regions are recognized in the order the layout source returns them. OvisOCR2 deliberately does not implement `RecognitionBackend`; use its full-page `OvisOcr2::parse` API instead. The library also implements `RecognitionBackend` for MonkeyOCRv2, HunyuanOCR, and MinerU2.5/Pro, but they are intentionally not exposed by the CLI example because their reference-quality paths are model-native parsing. MinerU-Diffusion uses its dedicated example.
 
 ### Basic Usage
 
 ```rust
-use oar_ocr_core::utils::load_image;
-use oar_ocr_core::predictors::LayoutDetectionPredictor;
-use oar_ocr_vl::{DocParser, GlmOcr, PaddleOcrVl};
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
-use std::path::Path;
+use oar_ocr_vl::{DocParser, GlmOcr, PaddleOcrVl, PpDocLayout};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let device = parse_device("cpu")?;
 
     // Initialize layout detector
-    let layout = LayoutDetectionPredictor::builder()
-        .model_name("pp-doclayoutv3")
-        .build("pp-doclayoutv3.onnx")?;
+    let layout = PpDocLayout::from_dir("PaddlePaddle/PP-DocLayoutV3", device.clone())?;
 
     // Load document image
-    let image = load_image(Path::new("document.jpg"))?;
+    let image = load_image("document.jpg")?;
 
     // Option 1: Using PaddleOCR-VL
     let paddleocr_vl = PaddleOcrVl::from_dir("PaddlePaddle/PaddleOCR-VL", device.clone())?;
@@ -791,34 +787,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ```bash
 # Using PaddleOCR-VL
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example doc_parser -- \
+cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
     --model-name paddleocr-vl \
     --model-dir PaddlePaddle/PaddleOCR-VL \
-    --layout-model pp-doclayoutv3.onnx \
+    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
     --device cuda \
     document.jpg
 
 # Using PaddleOCR-VL-1.5
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example doc_parser -- \
+cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
     --model-name paddleocr-vl-1.5 \
     --model-dir PaddlePaddle/PaddleOCR-VL-1.5 \
-    --layout-model pp-doclayoutv3.onnx \
+    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
     --device cuda \
     document.jpg
 
 # Using PaddleOCR-VL-1.6
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example doc_parser -- \
+cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
     --model-name paddleocr-vl-1.6 \
     --model-dir PaddlePaddle/PaddleOCR-VL-1.6 \
-    --layout-model pp-doclayoutv3.onnx \
+    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
     --device cuda \
     document.jpg
 
 # Using GLM-OCR with layout
-cargo run -p oar-ocr-vl --features cuda,download-binaries --example doc_parser -- \
+cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
     --model-name glmocr \
     --model-dir zai-org/GLM-OCR \
-    --layout-model pp-doclayoutv3.onnx \
+    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
     --device cuda \
     document.jpg
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -283,7 +283,16 @@ oar-ocr-vl = { version = "0.9", features = ["cuda"] }
 
 On macOS, use the `metal` feature instead.
 
-Layout-first parsing with `DocParser` uses `PpDocLayout`, a native Candle port of PP-DocLayoutV2/V3, so nothing further is required. To source layout from somewhere else, implement `oar_ocr_vl::LayoutSource` and pass it to `DocParser::parse`.
+Layout-first parsing with `DocParser` uses `PpDocLayout`, a native Candle port of PP-DocLayoutV2/V3, so no extra dependency is required — only the checkpoint. `PpDocLayout::from_dir` reads `config.json` and `model.safetensors`, which are published in the `_safetensors` repositories:
+
+```bash
+git lfs install
+git clone https://huggingface.co/PaddlePaddle/PP-DocLayoutV3_safetensors
+# or the V2 checkpoint, which predicts reading order with a pointer network
+git clone https://huggingface.co/PaddlePaddle/PP-DocLayoutV2_safetensors
+```
+
+The unsuffixed `PaddlePaddle/PP-DocLayoutV3` repository ships Paddle inference weights instead and cannot be loaded here. To source layout from somewhere else, implement `oar_ocr_vl::LayoutSource` and pass it to `DocParser::parse`.
 
 ### Downloading the Model
 
@@ -748,7 +757,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let device = parse_device("cpu")?;
 
     // Initialize layout detector
-    let layout = PpDocLayout::from_dir("PaddlePaddle/PP-DocLayoutV3", device.clone())?;
+    let layout = PpDocLayout::from_dir("PaddlePaddle/PP-DocLayoutV3_safetensors", device.clone())?;
 
     // Load document image
     let image = load_image("document.jpg")?;
@@ -790,7 +799,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
     --model-name paddleocr-vl \
     --model-dir PaddlePaddle/PaddleOCR-VL \
-    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
+    --layout-dir PaddlePaddle/PP-DocLayoutV3_safetensors \
     --device cuda \
     document.jpg
 
@@ -798,7 +807,7 @@ cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
 cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
     --model-name paddleocr-vl-1.5 \
     --model-dir PaddlePaddle/PaddleOCR-VL-1.5 \
-    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
+    --layout-dir PaddlePaddle/PP-DocLayoutV3_safetensors \
     --device cuda \
     document.jpg
 
@@ -806,7 +815,7 @@ cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
 cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
     --model-name paddleocr-vl-1.6 \
     --model-dir PaddlePaddle/PaddleOCR-VL-1.6 \
-    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
+    --layout-dir PaddlePaddle/PP-DocLayoutV3_safetensors \
     --device cuda \
     document.jpg
 
@@ -814,7 +823,7 @@ cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
 cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
     --model-name glmocr \
     --model-dir zai-org/GLM-OCR \
-    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
+    --layout-dir PaddlePaddle/PP-DocLayoutV3_safetensors \
     --device cuda \
     document.jpg
 

--- a/oar-ocr-core/Cargo.toml
+++ b/oar-ocr-core/Cargo.toml
@@ -46,7 +46,11 @@ multiversion = { version = "0.8", optional = true }
 nalgebra = "0.35"
 ndarray = "0.17"
 oar-ocr-derive.workspace = true
-ort = { version = "2.0.0-rc.12", default-features = false, features = [ "std", "ndarray", "tracing", "copy-dylibs" ] }
+# Pinned exactly: `ort` is pre-release, so a caret requirement lets Cargo pick
+# up the next release candidate on a fresh resolve. rc.13 renames every
+# execution-provider type (`CPUExecutionProvider` -> `CPU`, ...), which breaks
+# the build without any change on our side. Unpin together with that migration.
+ort = { version = "=2.0.0-rc.12", default-features = false, features = [ "std", "ndarray", "tracing", "copy-dylibs" ] }
 rayon.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/oar-ocr-vl/Cargo.toml
+++ b/oar-ocr-vl/Cargo.toml
@@ -20,14 +20,14 @@ categories = ["computer-vision", "science"]
 
 [features]
 default = []
-download-binaries = ["oar-ocr-core/download-binaries"]
+# This crate is Candle-only: layout detection runs through `pp_doclayout`, so
+# there is no ONNX Runtime anywhere in the tree and no feature to turn it on.
 # When enabled, turns on Candle's CUDA backend for GPU acceleration.
 cuda = [
     "candle-core/cuda",
     "dep:candle-flash-attn",
     "candle-nn/cuda",
     "candle-transformers/cuda",
-    "oar-ocr-core/cuda",
 ]
 # When enabled, turns on Candle's Metal backend for GPU acceleration on Apple devices.
 # Cargo features cannot be target-scoped directly, so Linux `--all-features`
@@ -46,13 +46,13 @@ candle-transformers = "0.11.0"
 html-escape = "0.2"
 half = "2"
 image.workspace = true
-oar-ocr-core.workspace = true
 once_cell = "1.19"
 rand = "0.10"
 rayon.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+thiserror = "2.0"
 tokenizers.workspace = true
 tracing.workspace = true
 
@@ -60,5 +60,4 @@ tracing.workspace = true
 clap.workspace = true
 criterion = { version = "0.8", features = ["html_reports"] }
 hayro.workspace = true
-oar-ocr = { path = "..", default-features = false }
 tracing-subscriber.workspace = true

--- a/oar-ocr-vl/README.md
+++ b/oar-ocr-vl/README.md
@@ -192,7 +192,7 @@ use oar_ocr_vl::{DocParser, PaddleOcrVl, PpDocLayout};
 
 let device = parse_device("cpu")?;
 
-let layout = PpDocLayout::from_dir("PaddlePaddle/PP-DocLayoutV3", device.clone())?;
+let layout = PpDocLayout::from_dir("PaddlePaddle/PP-DocLayoutV3_safetensors", device.clone())?;
 let vl = PaddleOcrVl::from_dir("PaddlePaddle/PaddleOCR-VL-1.5", device)?;
 let parser = DocParser::new(&vl);
 
@@ -232,7 +232,7 @@ This example combines layout detection with a VLM for recognition. It supports P
 cargo run --release -p oar-ocr-vl --features cuda --example doc_parser -- \
     --model-name paddleocr-vl-1.5 \
     --model-dir PaddlePaddle/PaddleOCR-VL-1.5 \
-    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
+    --layout-dir PaddlePaddle/PP-DocLayoutV3_safetensors \
     --device cuda \
     document.jpg
 ```

--- a/oar-ocr-vl/README.md
+++ b/oar-ocr-vl/README.md
@@ -20,6 +20,7 @@ This crate provides native Rust inference for document VLMs using [Candle](https
 | [MinerU2.5-2509](https://huggingface.co/opendatalab/MinerU2.5-2509-1.2B) | 1.2B | Model-native two-step layout detection and content extraction |
 | [MinerU2.5-Pro-2605](https://huggingface.co/opendatalab/MinerU2.5-Pro-2605-1.2B) | 1.2B | Newer compatible checkpoint using the MinerU2.5 two-step pipeline |
 | [MinerU-Diffusion-V1-0320](https://huggingface.co/opendatalab/MinerU-Diffusion-V1-0320-2.5B) | 2.5B | Block-diffusion OCR with two-step structured extraction or single-pass recognition |
+| [PP-DocLayoutV2](https://huggingface.co/PaddlePaddle/PP-DocLayoutV2_safetensors) / [V3](https://huggingface.co/PaddlePaddle/PP-DocLayoutV3_safetensors) | 54M / 33M | Layout detection and reading-order prediction, feeding `DocParser` |
 
 See [`examples`](examples) for runnable examples.
 
@@ -27,59 +28,45 @@ See [`examples`](examples) for runnable examples.
 
 **DocParser** is a unified document parsing API for layout-first backends. It combines:
 
-1. **Layout detection** (ONNX models like PP-DocLayoutV3) to identify document regions
+1. **Layout detection** to identify document regions and their reading order. `PpDocLayout` is a native Candle port of PP-DocLayoutV2/V3; any other detector can be plugged in through the `LayoutSource` trait.
 2. **VL-based recognition** to extract content from each region
 
 Use DocParser with PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, GLM-OCR, and optionally MonkeyOCRv2 for externally detected crops. MonkeyOCRv2's native `Layout` and `EndToEnd` tasks are preferable for complete pages. OvisOCR2 and HPD-Parsing are end-to-end full-page parsers and deliberately do not use DocParser. HunyuanOCR should be used with its model-native full-page prompts. MinerU2.5, MinerU2.5-Pro, and MinerU-Diffusion should use their model-native two-step extraction examples.
 
 ## Installation
 
-Add `oar-ocr-vl` with bundled ONNX Runtime binaries. The snippets below also import image-loading and layout helpers from `oar-ocr-core`, so declare it as a direct dependency:
-
-```bash
-cargo add oar-ocr-vl --features download-binaries
-cargo add oar-ocr-core --no-default-features
-```
-
-The VL crate has no default features and depends on `oar-ocr-core`, which links ONNX Runtime. You may omit `download-binaries` only when a system ONNX Runtime installation is available through `ORT_LIB_PATH` or `ORT_LIB_LOCATION`.
+This crate is self-contained: everything runs on Candle, it does not depend on `oar-ocr-core`, and **no build of it links ONNX Runtime**.
 
 ```bash
 cargo add oar-ocr-vl
-cargo add oar-ocr-core --no-default-features
 ```
 
 To enable GPU acceleration (CUDA), add the feature flag:
 
 ```bash
-cargo add oar-ocr-vl --features cuda,download-binaries
+cargo add oar-ocr-vl --features cuda
 ```
 
 On macOS, enable Metal instead:
 
 ```bash
-cargo add oar-ocr-vl --features metal,download-binaries
+cargo add oar-ocr-vl --features metal
 ```
 
-Metal inference uses Candle's fused SDPA kernels for supported attention
-shapes, including GQA without expanding K/V heads. For the best measured Apple
-Silicon throughput, explicitly set `OAR_VL_DTYPE=f16`. Use
-`OAR_VL_DISABLE_METAL_SDPA=1` for compatibility comparisons. The optional
-`OAR_VL_METAL_NATIVE_SOFTMAX=1` switch only changes the eager fallback; eager
-attention otherwise preserves the F32 softmax round trip.
+Metal inference uses Candle's fused SDPA kernels for supported attention shapes, including GQA without expanding K/V heads. For the best measured Apple Silicon throughput, explicitly set `OAR_VL_DTYPE=f16`. Use `OAR_VL_DISABLE_METAL_SDPA=1` for compatibility comparisons. The optional `OAR_VL_METAL_NATIVE_SOFTMAX=1` switch only changes the eager fallback; eager attention otherwise preserves the F32 softmax round trip.
 
-The crate's custom CUDA kernels compile to PTX for the oldest GPU detected by `nvidia-smi` at build time. For headless, container, or cross-machine builds, set the target explicitly, for example `CUDA_COMPUTE_CAP=89 cargo build -p oar-ocr-vl --features cuda,download-binaries`. These kernels require compute capability 8.0 or newer.
+The crate's custom CUDA kernels compile to PTX for the oldest GPU detected by `nvidia-smi` at build time. For headless, container, or cross-machine builds, set the target explicitly, for example `CUDA_COMPUTE_CAP=89 cargo build -p oar-ocr-vl --features cuda`. These kernels require compute capability 8.0 or newer.
 
 ## Usage
 
-The snippets below use canonical model repository IDs for VLM checkpoints and
-registered bare file names for ONNX models.
+The snippets below use canonical model repository IDs for the checkpoints.
 
 ### PaddleOCR-VL
 
 Use PaddleOCR-VL to recognize a specific aspect of an image (e.g., just the table or text).
 
 ```rust
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::{PaddleOcrVl, PaddleOcrVlTask};
 use oar_ocr_vl::utils::parse_device;
 
@@ -101,7 +88,7 @@ println!("Result: {}", result);
 PaddleOCR-VL-1.5 and PaddleOCR-VL-1.6 are loaded the same way, with additional tasks. PaddleOCR-VL-1.6 is plug-compatible with the 1.5 loader; point the same API at its checkpoint directory.
 
 ```rust
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::{PaddleOcrVl, PaddleOcrVlTask};
 use oar_ocr_vl::utils::parse_device;
 
@@ -116,12 +103,18 @@ let result = model
 println!("Result: {}", result);
 ```
 
+### PP-DocLayout
+
+`PpDocLayout` detects layout regions and predicts their reading order, and implements `LayoutSource`, so it plugs straight into `DocParser` (see below). PP-DocLayoutV2 and PP-DocLayoutV3 load through the same API; the generation is read from `config.json`. Use the `_safetensors` repositories, which carry the `model.safetensors` weights this port loads.
+
+PP-DocLayoutV2 applies the per-class thresholds from its `config.json`; PP-DocLayoutV3 uses a single threshold, adjustable with `with_score_threshold`.
+
 ### OvisOCR2
 
 OvisOCR2 performs model-native full-page parsing without an external layout detector. `parse` applies the official prompt, image resizing, and post-processing and returns one Markdown document per page.
 
 ```rust
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::ovisocr2::DEFAULT_MAX_NEW_TOKENS;
 use oar_ocr_vl::utils::parse_device;
 use oar_ocr_vl::OvisOcr2;
@@ -143,7 +136,7 @@ The official runtime resizes RGB input with bicubic antialiasing to a 32-pixel-a
 MonkeyOCRv2-S-Parsing and MonkeyOCRv2-B-Parsing use native Monkey ViT-S and ViT-B encoders, respectively, with the same Qwen3-0.6B decoder. The API reads either checkpoint's dimensions from its configuration and exposes the official full-page layout and end-to-end prompts as well as cropped text, formula, and OTSL-table recognition.
 
 ```rust
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 use oar_ocr_vl::{MonkeyOcrV2, MonkeyOcrV2Task};
 
@@ -169,7 +162,7 @@ HPD-Parsing performs full-page parsing with the official dynamic 448-pixel Inter
 This is a model/runtime contract, not a training-free switch for arbitrary VLM checkpoints. A compatible model must have been trained to emit the `<FORK>`/`<CHILD>` protocol and must provide the matching P-MTP head. The decoder batching and fork-safe cache machinery is shared with the Qwen3-family text implementation, but other OCR VLMs do not acquire hierarchical outputs merely by loading HPD's head.
 
 ```rust
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 use oar_ocr_vl::{HpdGenerationConfig, HpdParsing};
 
@@ -190,37 +183,27 @@ The returned text is the model-native reading-order `<BLOCK>type [bbox]<CHILD>co
 
 ### DocParser
 
-Parse an entire page into Markdown with a layout predictor. This path is intended for external layout-first backends such as PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR.
+Parse an entire page into Markdown. This path is intended for external layout-first backends such as PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR.
 
 ```rust
-use oar_ocr_core::utils::load_image;
-use oar_ocr_core::predictors::LayoutDetectionPredictor;
-use oar_ocr_vl::{DocParser, PaddleOcrVl};
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
+use oar_ocr_vl::{DocParser, PaddleOcrVl, PpDocLayout};
 
 let device = parse_device("cpu")?;
 
-// 1. Setup Layout Detector
-let layout_predictor = LayoutDetectionPredictor::builder()
-    .model_name("pp-doclayoutv3")
-    .build("pp-doclayoutv3.onnx")?;
-
-// 2. Setup a layout-first recognition backend
-let vl = PaddleOcrVl::from_dir("PaddlePaddle/PaddleOCR-VL-1.5", device.clone())?;
+let layout = PpDocLayout::from_dir("PaddlePaddle/PP-DocLayoutV3", device.clone())?;
+let vl = PaddleOcrVl::from_dir("PaddlePaddle/PaddleOCR-VL-1.5", device)?;
 let parser = DocParser::new(&vl);
 
-// 3. Parse Document
-let image = load_image("page.jpg")?;
-let result = parser.parse(&layout_predictor, image)?;
-
-// 4. Output as Markdown
+let result = parser.parse(&layout, load_image("page.jpg")?)?;
 println!("{}", result.to_markdown());
 ```
 
 ### MinerU2.5 / MinerU2.5-Pro
 
 ```rust
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::MinerU;
 use oar_ocr_vl::utils::parse_device;
 
@@ -243,13 +226,13 @@ The `oar-ocr-vl` crate includes several examples demonstrating its capabilities.
 
 ### DocParser
 
-This example combines layout detection (ONNX) with a VLM for recognition. It supports PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR.
+This example combines layout detection with a VLM for recognition. It supports PaddleOCR-VL, PaddleOCR-VL-1.5, PaddleOCR-VL-1.6, and GLM-OCR.
 
 ```bash
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example doc_parser -- \
+cargo run --release -p oar-ocr-vl --features cuda --example doc_parser -- \
     --model-name paddleocr-vl-1.5 \
     --model-dir PaddlePaddle/PaddleOCR-VL-1.5 \
-    --layout-model pp-doclayoutv3.onnx \
+    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
     --device cuda \
     document.jpg
 ```
@@ -262,28 +245,28 @@ Run the PaddleOCR-VL model directly on an image with a specific task prompt.
 
 ```bash
 # OCR task
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
+cargo run --release -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
     --model-dir PaddlePaddle/PaddleOCR-VL \
     --device cuda \
     --task ocr \
     document.jpg
 
 # Table task
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
+cargo run --release -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
     --model-dir PaddlePaddle/PaddleOCR-VL \
     --device cuda \
     --task table \
     table.jpg
 
 # Text spotting with PaddleOCR-VL-1.5 or 1.6
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
+cargo run --release -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
     --model-dir PaddlePaddle/PaddleOCR-VL-1.5 \
     --device cuda \
     --task spotting \
     spotting.jpg
 
 # Seal recognition with PaddleOCR-VL-1.5 or 1.6
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
+cargo run --release -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
     --model-dir PaddlePaddle/PaddleOCR-VL-1.6 \
     --device cuda \
     --task seal \
@@ -293,7 +276,7 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example pa
 ### HunyuanOCR 1.5 Direct Inference
 
 ```bash
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example hunyuanocr -- \
+cargo run --release -p oar-ocr-vl --features cuda --example hunyuanocr -- \
     --model-dir tencent/HunyuanOCR \
     --dflash-dir tencent/HunyuanOCR/dflash \
     --device cuda \
@@ -306,7 +289,7 @@ The model repository root contains HunyuanOCR 1.5, which the loader detects auto
 ### GLM-OCR Direct Inference
 
 ```bash
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example glmocr -- \
+cargo run --release -p oar-ocr-vl --features cuda --example glmocr -- \
     --model-dir zai-org/GLM-OCR \
     --device cuda \
     --prompt "Text Recognition:" \
@@ -318,7 +301,7 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example gl
 The example accepts multiple page images. It uses the official prompt and defaults to 16,384 generated tokens per page. Add `--keep-image-tags` to retain the model's visual-region `<img>` blocks.
 
 ```bash
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example ovisocr2 -- \
+cargo run --release -p oar-ocr-vl --features cuda --example ovisocr2 -- \
     --model-dir ATH-MaaS/OvisOCR2 \
     --device cuda:0 \
     document-1.jpg document-2.jpg
@@ -329,7 +312,7 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example ov
 Run the official end-to-end prompt over a complete page:
 
 ```bash
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example monkeyocrv2 -- \
+cargo run --release -p oar-ocr-vl --features cuda --example monkeyocrv2 -- \
     --model-dir zenosai/MonkeyOCRv2-S-Parsing \
     --device cuda:0 \
     --task end-to-end \
@@ -341,7 +324,7 @@ Pass the ViT-B checkpoint directory to `--model-dir` to use that variant. Other 
 ### HPD-Parsing Direct Inference
 
 ```bash
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example hpd_parsing -- \
+cargo run --release -p oar-ocr-vl --features cuda --example hpd_parsing -- \
     --model-dir PaddlePaddle/HPD-Parsing \
     --device cuda:0 \
     document.jpg
@@ -354,7 +337,7 @@ Use `--no-mtp` to compare with ordinary greedy decoding, `--speculative-tokens` 
 Model-native two-step document extraction (layout prompt + content extraction):
 
 ```bash
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
+cargo run --release -p oar-ocr-vl --features cuda --example mineru -- \
     --model-dir opendatalab/MinerU2.5-2509-1.2B \
     --device cuda:0 \
     document.jpg
@@ -363,7 +346,7 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example mi
 `MinerU2.5-Pro-2605` uses the same loader and example:
 
 ```bash
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
+cargo run --release -p oar-ocr-vl --features cuda --example mineru -- \
     --model-dir opendatalab/MinerU2.5-Pro-2605-1.2B \
     --device cuda:0 \
     document.jpg
@@ -374,7 +357,7 @@ cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example mi
 The default mode performs two-step structured extraction with block-diffusion decoding. Add `--single-pass` for flat full-page text recognition.
 
 ```bash
-cargo run --release -p oar-ocr-vl --features cuda,download-binaries --example mineru_diffusion -- \
+cargo run --release -p oar-ocr-vl --features cuda --example mineru_diffusion -- \
     --model-dir opendatalab/MinerU-Diffusion-V1-0320-2.5B \
     --device cuda:0 \
     document.jpg

--- a/oar-ocr-vl/examples/doc_parser.rs
+++ b/oar-ocr-vl/examples/doc_parser.rs
@@ -219,12 +219,9 @@ fn process_images<B: oar_ocr_vl::RecognitionBackend>(
                 info!("  Parsed in {:.2}s", start.elapsed().as_secs_f64());
                 info!("  Elements: {}", result.layout_elements.len());
 
-                // Get markdown (OpenOCR-compatible) from the parsed result.
-                let markdown = oar_ocr_vl::utils::to_markdown_openocr(
-                    &result.layout_elements,
-                    ignore_labels,
-                    true,
-                );
+                // Get markdown from the parsed result.
+                let markdown =
+                    oar_ocr_vl::utils::to_markdown(&result.layout_elements, ignore_labels, true);
 
                 // Save or print
                 if let Some(ref dir) = args.output_dir {

--- a/oar-ocr-vl/examples/doc_parser.rs
+++ b/oar-ocr-vl/examples/doc_parser.rs
@@ -14,28 +14,28 @@
 //! cargo run -p oar-ocr-vl --example doc_parser -- \
 //!     --model-name paddleocr-vl \
 //!     --model-dir PaddlePaddle/PaddleOCR-VL \
-//!     --layout-dir PaddlePaddle/PP-DocLayoutV3 \
+//!     --layout-dir PaddlePaddle/PP-DocLayoutV3_safetensors \
 //!     document.jpg
 //!
 //! # Using PaddleOCR-VL-1.5 model
 //! cargo run -p oar-ocr-vl --example doc_parser -- \
 //!     --model-name paddleocr-vl-1.5 \
 //!     --model-dir PaddlePaddle/PaddleOCR-VL-1.5 \
-//!     --layout-dir PaddlePaddle/PP-DocLayoutV3 \
+//!     --layout-dir PaddlePaddle/PP-DocLayoutV3_safetensors \
 //!     document.jpg
 //!
 //! # Using PaddleOCR-VL-1.6 model
 //! cargo run -p oar-ocr-vl --example doc_parser -- \
 //!     --model-name paddleocr-vl-1.6 \
 //!     --model-dir PaddlePaddle/PaddleOCR-VL-1.6 \
-//!     --layout-dir PaddlePaddle/PP-DocLayoutV3 \
+//!     --layout-dir PaddlePaddle/PP-DocLayoutV3_safetensors \
 //!     document.jpg
 //!
 //! # Using GLM-OCR model
 //! cargo run -p oar-ocr-vl --example doc_parser -- \
 //!     --model-name glmocr \
 //!     --model-dir zai-org/GLM-OCR \
-//!     --layout-dir PaddlePaddle/PP-DocLayoutV3 \
+//!     --layout-dir PaddlePaddle/PP-DocLayoutV3_safetensors \
 //!     document.jpg
 //! ```
 

--- a/oar-ocr-vl/examples/doc_parser.rs
+++ b/oar-ocr-vl/examples/doc_parser.rs
@@ -11,31 +11,31 @@
 //!
 //! ```bash
 //! # Using PaddleOCR-VL model
-//! cargo run -p oar-ocr-vl --features download-binaries --example doc_parser -- \
+//! cargo run -p oar-ocr-vl --example doc_parser -- \
 //!     --model-name paddleocr-vl \
 //!     --model-dir PaddlePaddle/PaddleOCR-VL \
-//!     --layout-model pp-doclayoutv3.onnx \
+//!     --layout-dir PaddlePaddle/PP-DocLayoutV3 \
 //!     document.jpg
 //!
 //! # Using PaddleOCR-VL-1.5 model
-//! cargo run -p oar-ocr-vl --features download-binaries --example doc_parser -- \
+//! cargo run -p oar-ocr-vl --example doc_parser -- \
 //!     --model-name paddleocr-vl-1.5 \
 //!     --model-dir PaddlePaddle/PaddleOCR-VL-1.5 \
-//!     --layout-model pp-doclayoutv3.onnx \
+//!     --layout-dir PaddlePaddle/PP-DocLayoutV3 \
 //!     document.jpg
 //!
 //! # Using PaddleOCR-VL-1.6 model
-//! cargo run -p oar-ocr-vl --features download-binaries --example doc_parser -- \
+//! cargo run -p oar-ocr-vl --example doc_parser -- \
 //!     --model-name paddleocr-vl-1.6 \
 //!     --model-dir PaddlePaddle/PaddleOCR-VL-1.6 \
-//!     --layout-model pp-doclayoutv3.onnx \
+//!     --layout-dir PaddlePaddle/PP-DocLayoutV3 \
 //!     document.jpg
 //!
 //! # Using GLM-OCR model
-//! cargo run -p oar-ocr-vl --features download-binaries --example doc_parser -- \
+//! cargo run -p oar-ocr-vl --example doc_parser -- \
 //!     --model-name glmocr \
 //!     --model-dir zai-org/GLM-OCR \
-//!     --layout-model pp-doclayoutv3.onnx \
+//!     --layout-dir PaddlePaddle/PP-DocLayoutV3 \
 //!     document.jpg
 //! ```
 
@@ -47,11 +47,9 @@ use std::time::Instant;
 
 use tracing::{error, info};
 
-use oar_ocr_core::domain::LayoutDetectionConfig;
-use oar_ocr_core::predictors::LayoutDetectionPredictor;
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
-use oar_ocr_vl::{DocParser, DocParserConfig};
+use oar_ocr_vl::{DocParser, DocParserConfig, PpDocLayout};
 
 /// Recognition model type
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -85,17 +83,13 @@ struct Args {
     #[arg(short, long)]
     model_dir: PathBuf,
 
-    /// Path to the PP-DocLayout ONNX model file (v2/v3, required)
+    /// Path to a PP-DocLayoutV2/V3 checkpoint directory
     #[arg(short, long)]
-    layout_model: Option<PathBuf>,
+    layout_dir: PathBuf,
 
     /// Paths to input document images
     #[arg(required = true)]
     images: Vec<PathBuf>,
-
-    /// Layout model name for label mapping
-    #[arg(long, default_value = "pp-doclayoutv3")]
-    layout_model_name: String,
 
     /// Device to run on: cpu, cuda, cuda:N, or metal
     #[arg(short, long, default_value = "cpu")]
@@ -128,16 +122,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         error!("Model directory not found: {}", args.model_dir.display());
         return Err("Model directory not found".into());
     }
-    let layout_model_path = args.layout_model.as_ref().ok_or_else(|| {
+    if !args.layout_dir.exists() {
         error!(
-            "Layout model is required for {:?}. Use the hunyuanocr/mineru examples for model-native full-page parsing.",
-            args.model_name
+            "Layout checkpoint not found: {}. Use the hunyuanocr/mineru examples for \
+             model-native full-page parsing.",
+            args.layout_dir.display()
         );
-        "Layout model not provided"
-    })?;
-    if !layout_model_path.exists() {
-        error!("Layout model not found: {}", layout_model_path.display());
-        return Err("Layout model not found".into());
+        return Err("Layout checkpoint not found".into());
     }
 
     // Filter valid images
@@ -156,27 +147,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let device = parse_device(&args.device)?;
     info!("Device: {:?}", device);
 
-    info!("Loading layout model...");
-    let normalized_layout_name = args.layout_model_name.to_lowercase().replace('-', "_");
-    let layout_config = match normalized_layout_name.as_str() {
-        "pp_doclayoutv2" | "pp_doclayout_v2" => {
-            Some(LayoutDetectionConfig::with_pp_doclayoutv2_defaults())
-        }
-        "pp_doclayoutv3" | "pp_doclayout_v3" => {
-            Some(LayoutDetectionConfig::with_pp_doclayoutv3_defaults())
-        }
-        "pp_structurev3" | "pp_structure_v3" => {
-            Some(LayoutDetectionConfig::with_pp_structurev3_defaults())
-        }
-        _ => None,
-    };
-
-    let mut layout_builder =
-        LayoutDetectionPredictor::builder().model_name(&args.layout_model_name);
-    if let Some(config) = layout_config {
-        layout_builder = layout_builder.with_config(config);
-    }
-    let layout_predictor = layout_builder.build(layout_model_path)?;
+    info!("Loading PP-DocLayout...");
+    let layout = PpDocLayout::from_dir(&args.layout_dir, device.clone())?;
+    info!("Layout model: {:?}", layout.version());
 
     // Create config
     let config = DocParserConfig {
@@ -196,7 +169,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
 
             let parser = DocParser::with_config(&vl, config);
-            process_images(&parser, &layout_predictor, &existing_images, &args)?;
+            process_images(&parser, &layout, &existing_images, &args)?;
         }
         ModelName::GlmOcr => {
             info!("Loading GLM-OCR model...");
@@ -208,7 +181,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
 
             let parser = DocParser::with_config(&model, config);
-            process_images(&parser, &layout_predictor, &existing_images, &args)?;
+            process_images(&parser, &layout, &existing_images, &args)?;
         }
     }
     Ok(())
@@ -216,7 +189,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn process_images<B: oar_ocr_vl::RecognitionBackend>(
     parser: &DocParser<B>,
-    layout_predictor: &LayoutDetectionPredictor,
+    layout: &PpDocLayout,
     images: &[PathBuf],
     args: &Args,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -240,7 +213,7 @@ fn process_images<B: oar_ocr_vl::RecognitionBackend>(
         };
 
         let start = Instant::now();
-        let result = parser.parse(layout_predictor, rgb_img);
+        let result = parser.parse(layout, rgb_img);
         match result {
             Ok(result) => {
                 info!("  Parsed in {:.2}s", start.elapsed().as_secs_f64());

--- a/oar-ocr-vl/examples/glmocr.rs
+++ b/oar-ocr-vl/examples/glmocr.rs
@@ -5,13 +5,13 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --features download-binaries --example glmocr -- [OPTIONS] <IMAGES>...
+//! cargo run -p oar-ocr-vl --example glmocr -- [OPTIONS] <IMAGES>...
 //! ```
 //!
 //! # Examples
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --features download-binaries --example glmocr -- \
+//! cargo run -p oar-ocr-vl --example glmocr -- \
 //!     --model-dir zai-org/GLM-OCR \
 //!     --prompt "Text Recognition:" \
 //!     document.jpg

--- a/oar-ocr-vl/examples/glmocr.rs
+++ b/oar-ocr-vl/examples/glmocr.rs
@@ -24,8 +24,8 @@ use std::path::PathBuf;
 use std::time::Instant;
 use tracing::{error, info};
 
-use oar_ocr_core::utils::load_image;
 use oar_ocr_vl::GlmOcr;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 use utils::token_fingerprint;
 

--- a/oar-ocr-vl/examples/hpd_parsing.rs
+++ b/oar-ocr-vl/examples/hpd_parsing.rs
@@ -9,11 +9,11 @@
 mod utils;
 
 use clap::Parser;
-use oar_ocr_core::utils::load_image;
 use oar_ocr_vl::HpdParsing;
 use oar_ocr_vl::hpd_parsing::{
     DEFAULT_MAX_NEW_TOKENS, DEFAULT_PROMPT, DEFAULT_SPECULATIVE_TOKENS, HpdGenerationConfig,
 };
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 use std::path::PathBuf;
 use std::time::Instant;

--- a/oar-ocr-vl/examples/hpd_parsing.rs
+++ b/oar-ocr-vl/examples/hpd_parsing.rs
@@ -1,7 +1,7 @@
 //! HPD-Parsing native Candle inference.
 //!
 //! ```bash
-//! cargo run --release -p oar-ocr-vl --features cuda,download-binaries \
+//! cargo run --release -p oar-ocr-vl --features cuda \
 //!   --example hpd_parsing -- \
 //!   --model-dir PaddlePaddle/HPD-Parsing --device cuda:0 document.jpg
 //! ```

--- a/oar-ocr-vl/examples/hunyuanocr.rs
+++ b/oar-ocr-vl/examples/hunyuanocr.rs
@@ -6,13 +6,13 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --features download-binaries --example hunyuanocr -- [OPTIONS] <IMAGES>...
+//! cargo run -p oar-ocr-vl --example hunyuanocr -- [OPTIONS] <IMAGES>...
 //! ```
 //!
 //! # Examples
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --features download-binaries --example hunyuanocr -- \\
+//! cargo run -p oar-ocr-vl --example hunyuanocr -- \\
 //!     --model-dir tencent/HunyuanOCR \\
 //!     --prompt "Detect and recognize text in the image, and output the text coordinates in a formatted manner." \\
 //!     document.jpg

--- a/oar-ocr-vl/examples/hunyuanocr.rs
+++ b/oar-ocr-vl/examples/hunyuanocr.rs
@@ -26,8 +26,8 @@ use std::time::Duration;
 use std::time::Instant;
 use tracing::{error, info};
 
-use oar_ocr_core::utils::load_image;
 use oar_ocr_vl::HunyuanOcr;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 use utils::token_fingerprint;
 

--- a/oar-ocr-vl/examples/mineru.rs
+++ b/oar-ocr-vl/examples/mineru.rs
@@ -33,8 +33,8 @@ use std::path::PathBuf;
 use std::time::Instant;
 use tracing::{error, info};
 
-use oar_ocr_core::utils::load_image;
 use oar_ocr_vl::MinerU;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 use oar_ocr_vl::utils::{convert_otsl_to_html, truncate_repetitive_content};
 

--- a/oar-ocr-vl/examples/mineru.rs
+++ b/oar-ocr-vl/examples/mineru.rs
@@ -7,19 +7,19 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --features download-binaries --example mineru -- [OPTIONS] <IMAGES>...
+//! cargo run -p oar-ocr-vl --example mineru -- [OPTIONS] <IMAGES>...
 //! ```
 //!
 //! # Example
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
+//! cargo run -p oar-ocr-vl --features cuda --example mineru -- \
 //!     --model-dir opendatalab/MinerU2.5-2509-1.2B \
 //!     --device cuda:0 \
 //!     document.jpg
 //!
 //! # MinerU2.5-Pro uses the same loader and pipeline
-//! cargo run -p oar-ocr-vl --features cuda,download-binaries --example mineru -- \
+//! cargo run -p oar-ocr-vl --features cuda --example mineru -- \
 //!     --model-dir opendatalab/MinerU2.5-Pro-2605-1.2B \
 //!     --device cuda:0 \
 //!     document.jpg

--- a/oar-ocr-vl/examples/mineru_diffusion.rs
+++ b/oar-ocr-vl/examples/mineru_diffusion.rs
@@ -34,8 +34,8 @@ use clap::Parser;
 use image::{RgbImage, imageops};
 use tracing::{error, info};
 
-use oar_ocr_core::utils::load_image;
 use oar_ocr_vl::mineru_diffusion::DEFAULT_PROMPT;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 use oar_ocr_vl::utils::{convert_otsl_to_html, truncate_repetitive_content};
 use oar_ocr_vl::{DiffusionGenerationConfig, MinerUDiffusion};

--- a/oar-ocr-vl/examples/mineru_diffusion.rs
+++ b/oar-ocr-vl/examples/mineru_diffusion.rs
@@ -19,7 +19,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --features cuda,download-binaries --example mineru_diffusion -- \
+//! cargo run -p oar-ocr-vl --features cuda --example mineru_diffusion -- \
 //!     --model-dir opendatalab/MinerU-Diffusion-V1-0320-2.5B \
 //!     --device cuda:0 \
 //!     document.jpg

--- a/oar-ocr-vl/examples/monkeyocrv2.rs
+++ b/oar-ocr-vl/examples/monkeyocrv2.rs
@@ -1,7 +1,7 @@
 //! MonkeyOCRv2-S/B-Parsing inference example (Candle-based).
 //!
 //! ```bash
-//! cargo run --release -p oar-ocr-vl --features cuda,download-binaries \
+//! cargo run --release -p oar-ocr-vl --features cuda \
 //!   --example monkeyocrv2 -- \
 //!   --model-dir zenosai/MonkeyOCRv2-S-Parsing \
 //!   --device cuda:0 --task end-to-end document.jpg

--- a/oar-ocr-vl/examples/monkeyocrv2.rs
+++ b/oar-ocr-vl/examples/monkeyocrv2.rs
@@ -10,8 +10,8 @@
 mod utils;
 
 use clap::{Parser, ValueEnum};
-use oar_ocr_core::utils::load_image;
 use oar_ocr_vl::monkeyocrv2::DEFAULT_MAX_NEW_TOKENS;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 use oar_ocr_vl::{MonkeyOcrV2, MonkeyOcrV2Task};
 use std::path::PathBuf;

--- a/oar-ocr-vl/examples/ovisocr2.rs
+++ b/oar-ocr-vl/examples/ovisocr2.rs
@@ -19,9 +19,9 @@ use std::path::PathBuf;
 use std::time::Instant;
 use tracing::{error, info};
 
-use oar_ocr_core::utils::load_image;
 use oar_ocr_vl::OvisOcr2;
 use oar_ocr_vl::ovisocr2::DEFAULT_MAX_NEW_TOKENS;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 
 #[derive(Parser)]

--- a/oar-ocr-vl/examples/ovisocr2.rs
+++ b/oar-ocr-vl/examples/ovisocr2.rs
@@ -6,7 +6,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --features download-binaries --example ovisocr2 -- \
+//! cargo run -p oar-ocr-vl --example ovisocr2 -- \
 //!     --model-dir ATH-MaaS/OvisOCR2 \
 //!     --device cpu \
 //!     document-1.jpg document-2.png

--- a/oar-ocr-vl/examples/paddleocr_vl.rs
+++ b/oar-ocr-vl/examples/paddleocr_vl.rs
@@ -8,7 +8,7 @@
 //! # Usage
 //!
 //! ```bash
-//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- [OPTIONS] <IMAGES>...
+//! cargo run -p oar-ocr-vl --example paddleocr_vl -- [OPTIONS] <IMAGES>...
 //! ```
 //!
 //! # Arguments
@@ -23,31 +23,31 @@
 //!
 //! ```bash
 //! # OCR text recognition
-//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
 //!     -m PaddlePaddle/PaddleOCR-VL --task ocr document.jpg
 //!
 //! # Table recognition
-//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
 //!     -m PaddlePaddle/PaddleOCR-VL --task table table.jpg
 //!
 //! # Formula recognition
-//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
 //!     -m PaddlePaddle/PaddleOCR-VL --task formula formula.jpg
 //!
 //! # Chart recognition
-//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
 //!     -m PaddlePaddle/PaddleOCR-VL --task chart chart.jpg
 //!
 //! # Text spotting with PaddleOCR-VL-1.5 or 1.6
-//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
 //!     -m PaddlePaddle/PaddleOCR-VL-1.5 --task spotting spotting.jpg
 //!
 //! # Seal recognition with PaddleOCR-VL-1.5 or 1.6
-//! cargo run -p oar-ocr-vl --features download-binaries --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --example paddleocr_vl -- \
 //!     -m PaddlePaddle/PaddleOCR-VL-1.6 --task seal seal.jpg
 //!
 //! # Run on CUDA GPU
-//! cargo run -p oar-ocr-vl --features cuda,download-binaries --example paddleocr_vl -- \
+//! cargo run -p oar-ocr-vl --features cuda --example paddleocr_vl -- \
 //!     -m PaddlePaddle/PaddleOCR-VL -d cuda --task ocr document.jpg
 //! ```
 

--- a/oar-ocr-vl/examples/paddleocr_vl.rs
+++ b/oar-ocr-vl/examples/paddleocr_vl.rs
@@ -59,7 +59,7 @@ use std::time::Instant;
 
 use tracing::{error, info};
 
-use oar_ocr_core::utils::load_image;
+use oar_ocr_vl::utils::image::load_image;
 use oar_ocr_vl::utils::parse_device;
 use oar_ocr_vl::{PaddleOcrVl, PaddleOcrVlTask};
 use utils::token_fingerprint;

--- a/oar-ocr-vl/examples/utils/structure_match.rs
+++ b/oar-ocr-vl/examples/utils/structure_match.rs
@@ -21,8 +21,8 @@
 //! `"other"`, the same-category pass is skipped (the category carries no
 //! useful signal) and we go straight to the cross-category fallback.
 
-use oar_ocr_core::domain::structure::{LayoutElement, LayoutElementType, StructureResult};
-use oar_ocr_core::processors::BoundingBox;
+use oar_ocr_vl::geometry::BoundingBox;
+use oar_ocr_vl::structure::{LayoutElement, LayoutElementType, StructureResult};
 
 #[derive(Debug, Clone, Copy)]
 pub struct MatchThresholds {
@@ -191,10 +191,10 @@ fn best_formula(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use oar_ocr_core::domain::structure::{
+    use oar_ocr_vl::geometry::BoundingBox;
+    use oar_ocr_vl::structure::{
         FormulaResult, LayoutElement, LayoutElementType, StructureResult, TableResult, TableType,
     };
-    use oar_ocr_core::processors::BoundingBox;
 
     fn bb(x1: f32, y1: f32, x2: f32, y2: f32) -> BoundingBox {
         BoundingBox::from_coords(x1, y1, x2, y2)

--- a/oar-ocr-vl/src/attention.rs
+++ b/oar-ocr-vl/src/attention.rs
@@ -19,9 +19,9 @@
 //! let (cos, sin) = rope.forward_multi_axis(&position_ids, dtype)?;
 //! ```
 
+use crate::error::Error;
 use crate::utils::candle_to_ocr_processing;
 use candle_core::{D, DType, Device, IndexOp, Result, Tensor};
-use oar_ocr_core::core::errors::OCRError;
 use std::sync::OnceLock;
 
 fn grouped_query_attention_disabled() -> bool {
@@ -717,7 +717,7 @@ impl RotaryEmbedding {
         head_dim: usize,
         rope_theta: f64,
         device: &Device,
-    ) -> std::result::Result<Self, OCRError> {
+    ) -> std::result::Result<Self, Error> {
         Self::new_multi_axis(head_dim, rope_theta, 1, device)
     }
 
@@ -730,9 +730,9 @@ impl RotaryEmbedding {
         rope_theta: f64,
         num_dims: usize,
         device: &Device,
-    ) -> std::result::Result<Self, OCRError> {
+    ) -> std::result::Result<Self, Error> {
         if !head_dim.is_multiple_of(2) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!("RotaryEmbedding: head_dim must be even, got {head_dim}"),
             });
         }
@@ -744,7 +744,7 @@ impl RotaryEmbedding {
         }
         let inv_freq = Tensor::from_vec(inv_freq, (half,), device).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "RotaryEmbedding: failed to create inv_freq tensor",
                 e,
             )
@@ -767,12 +767,12 @@ impl RotaryEmbedding {
         &self,
         position_ids: &Tensor,
         dtype: DType,
-    ) -> std::result::Result<(Tensor, Tensor), OCRError> {
+    ) -> std::result::Result<(Tensor, Tensor), Error> {
         match self {
             Self::Dynamic { inv_freq, num_dims } => {
                 let dims = position_ids.dims();
                 if dims.len() != 3 || dims[0] != *num_dims {
-                    return Err(OCRError::InvalidInput {
+                    return Err(Error::InvalidInput {
                         message: format!(
                             "RotaryEmbedding: expected position_ids shape ({}, B, S), got {:?}",
                             num_dims, dims
@@ -782,7 +782,7 @@ impl RotaryEmbedding {
 
                 let position_ids = position_ids.to_dtype(DType::F32).map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "RotaryEmbedding: position_ids cast to f32 failed",
                         e,
                     )
@@ -790,7 +790,7 @@ impl RotaryEmbedding {
 
                 let inv_len = inv_freq.dims1().map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "RotaryEmbedding: inv_freq dims1 failed",
                         e,
                     )
@@ -799,7 +799,7 @@ impl RotaryEmbedding {
                     .reshape((1usize, 1usize, 1usize, inv_len))
                     .map_err(|e| {
                         candle_to_ocr_processing(
-                            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                            crate::error::ProcessingStage::TensorOperation,
                             "RotaryEmbedding: inv_freq reshape failed",
                             e,
                         )
@@ -809,7 +809,7 @@ impl RotaryEmbedding {
                     .unsqueeze(3)
                     .map_err(|e| {
                         candle_to_ocr_processing(
-                            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                            crate::error::ProcessingStage::TensorOperation,
                             "RotaryEmbedding: position_ids unsqueeze failed",
                             e,
                         )
@@ -817,7 +817,7 @@ impl RotaryEmbedding {
                     .broadcast_mul(&inv)
                     .map_err(|e| {
                         candle_to_ocr_processing(
-                            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                            crate::error::ProcessingStage::TensorOperation,
                             "RotaryEmbedding: rotary freqs multiply failed",
                             e,
                         )
@@ -825,7 +825,7 @@ impl RotaryEmbedding {
 
                 let emb = Tensor::cat(&[&freqs, &freqs], D::Minus1).map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "RotaryEmbedding: rotary emb cat failed",
                         e,
                     )
@@ -835,7 +835,7 @@ impl RotaryEmbedding {
                     .cos()
                     .map_err(|e| {
                         candle_to_ocr_processing(
-                            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                            crate::error::ProcessingStage::TensorOperation,
                             "RotaryEmbedding: rotary cos failed",
                             e,
                         )
@@ -843,7 +843,7 @@ impl RotaryEmbedding {
                     .to_dtype(dtype)
                     .map_err(|e| {
                         candle_to_ocr_processing(
-                            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                            crate::error::ProcessingStage::TensorOperation,
                             "RotaryEmbedding: rotary cos cast failed",
                             e,
                         )
@@ -853,7 +853,7 @@ impl RotaryEmbedding {
                     .sin()
                     .map_err(|e| {
                         candle_to_ocr_processing(
-                            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                            crate::error::ProcessingStage::TensorOperation,
                             "RotaryEmbedding: rotary sin failed",
                             e,
                         )
@@ -861,7 +861,7 @@ impl RotaryEmbedding {
                     .to_dtype(dtype)
                     .map_err(|e| {
                         candle_to_ocr_processing(
-                            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                            crate::error::ProcessingStage::TensorOperation,
                             "RotaryEmbedding: rotary sin cast failed",
                             e,
                         )
@@ -907,9 +907,9 @@ pub fn select_rope_sections(
     cos_or_sin: &Tensor,
     rope_section: &[usize],
     num_dims: usize,
-) -> std::result::Result<Tensor, OCRError> {
+) -> std::result::Result<Tensor, Error> {
     if rope_section.is_empty() {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: "rope_section is empty".to_string(),
         });
     }
@@ -918,7 +918,7 @@ pub fn select_rope_sections(
     let head_dim = dims.get(3).copied().unwrap_or(0);
     let section_sum: usize = rope_section.iter().sum();
     if section_sum * 2 != head_dim {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "rope_section sum ({}) * 2 != head_dim ({})",
                 section_sum, head_dim
@@ -928,7 +928,7 @@ pub fn select_rope_sections(
 
     let actual_dims = dims.first().copied().unwrap_or(0);
     if actual_dims != num_dims {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "rope tensor has {} dims, expected {}",
                 actual_dims, num_dims
@@ -949,7 +949,7 @@ pub fn select_rope_sections(
         let next = offset + sec;
         let seg = cos_or_sin.i((.., .., .., offset..next)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 format!(
                     "rope slice failed at chunk {} (offset {}..{})",
                     i, offset, next
@@ -959,7 +959,7 @@ pub fn select_rope_sections(
         })?;
         let picked = seg.i((i % num_dims, .., .., ..)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 format!("rope pick failed at chunk {} (dim {})", i, i % num_dims),
                 e,
             )
@@ -971,14 +971,14 @@ pub fn select_rope_sections(
     let refs: Vec<&Tensor> = chunks.iter().collect();
     let cat = Tensor::cat(&refs, D::Minus1).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "rope cat failed",
             e,
         )
     })?;
     cat.unsqueeze(1).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "rope unsqueeze failed",
             e,
         )
@@ -1407,7 +1407,7 @@ mod tests {
     // RoPE Tests
 
     #[test]
-    fn test_rotary_embedding_dynamic_single_axis() -> std::result::Result<(), OCRError> {
+    fn test_rotary_embedding_dynamic_single_axis() -> std::result::Result<(), Error> {
         let device = Device::Cpu;
         let rope = RotaryEmbedding::new_dynamic(64, 10000.0, &device)?;
 
@@ -1415,7 +1415,7 @@ mod tests {
         let position_ids = Tensor::arange(0u32, 8u32, &device)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "Failed to create position_ids",
                     e,
                 )
@@ -1423,7 +1423,7 @@ mod tests {
             .reshape((1, 1, 8))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "Failed to reshape position_ids",
                     e,
                 )
@@ -1437,14 +1437,14 @@ mod tests {
     }
 
     #[test]
-    fn test_rotary_embedding_multi_axis() -> std::result::Result<(), OCRError> {
+    fn test_rotary_embedding_multi_axis() -> std::result::Result<(), Error> {
         let device = Device::Cpu;
         let rope = RotaryEmbedding::new_multi_axis(128, 10000.0, 3, &device)?;
 
         // Create 3-axis position IDs: (3, batch, seq)
         let position_ids = Tensor::zeros((3, 2, 16), DType::U32, &device).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "Failed to create position_ids",
                 e,
             )
@@ -1464,7 +1464,7 @@ mod tests {
         // Odd head_dim should fail
         let result = RotaryEmbedding::new_multi_axis(63, 10000.0, 1, &device);
         assert!(result.is_err());
-        if let Err(OCRError::ConfigError { message }) = result {
+        if let Err(Error::Config { message }) = result {
             assert!(message.contains("must be even"));
         } else {
             panic!("Expected ConfigError");
@@ -1472,14 +1472,14 @@ mod tests {
     }
 
     #[test]
-    fn test_rotary_embedding_wrong_position_ids_shape() -> std::result::Result<(), OCRError> {
+    fn test_rotary_embedding_wrong_position_ids_shape() -> std::result::Result<(), Error> {
         let device = Device::Cpu;
         let rope = RotaryEmbedding::new_multi_axis(64, 10000.0, 3, &device)?;
 
         // Wrong shape: (2, batch, seq) instead of (3, batch, seq)
         let position_ids = Tensor::zeros((2, 2, 16), DType::U32, &device).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "Failed to create position_ids",
                 e,
             )
@@ -1487,7 +1487,7 @@ mod tests {
 
         let result = rope.forward_multi_axis(&position_ids, DType::F32);
         assert!(result.is_err());
-        if let Err(OCRError::InvalidInput { message }) = result {
+        if let Err(Error::InvalidInput { message }) = result {
             assert!(message.contains("expected position_ids shape (3"));
         } else {
             panic!("Expected InvalidInput error");

--- a/oar-ocr-vl/src/crop.rs
+++ b/oar-ocr-vl/src/crop.rs
@@ -1,0 +1,68 @@
+//! Cropping a page image down to a detected region.
+
+use crate::error::{Error, ProcessingStage};
+use crate::geometry::BoundingBox;
+use image::RgbImage;
+
+/// Crops the axis-aligned extent of `bbox` out of `image`, clamped to the image
+/// bounds.
+pub fn crop_bounding_box(image: &RgbImage, bbox: &BoundingBox) -> Result<RgbImage, Error> {
+    if bbox.points.is_empty() {
+        return Err(crop_error("empty bounding box".to_string()));
+    }
+
+    let x1 = (bbox.x_min().max(0.0) as u32).min(image.width().saturating_sub(1));
+    let y1 = (bbox.y_min().max(0.0) as u32).min(image.height().saturating_sub(1));
+    let x2 = (bbox.x_max().max(0.0) as u32).min(image.width());
+    let y2 = (bbox.y_max().max(0.0) as u32).min(image.height());
+
+    if x2 <= x1 || y2 <= y1 {
+        return Err(crop_error(format!(
+            "invalid crop region: ({x1}, {y1}) to ({x2}, {y2})"
+        )));
+    }
+
+    Ok(image::imageops::crop_imm(image, x1, y1, x2 - x1, y2 - y1).to_image())
+}
+
+fn crop_error(context: String) -> Error {
+    Error::Processing {
+        kind: ProcessingStage::ImageProcessing,
+        context,
+        source: Box::new(Error::invalid_input("bounding box crop")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crops_the_requested_region() {
+        let image = RgbImage::new(100, 80);
+        let crop = crop_bounding_box(&image, &BoundingBox::from_coords(10.0, 20.0, 40.0, 60.0))
+            .expect("crop succeeds");
+        assert_eq!(crop.dimensions(), (30, 40));
+    }
+
+    /// Boxes reaching past the edges are clamped rather than rejected.
+    #[test]
+    fn clamps_to_the_image_bounds() {
+        let image = RgbImage::new(50, 50);
+        let crop = crop_bounding_box(
+            &image,
+            &BoundingBox::from_coords(-10.0, -10.0, 999.0, 999.0),
+        )
+        .expect("crop succeeds");
+        assert_eq!(crop.dimensions(), (50, 50));
+    }
+
+    #[test]
+    fn rejects_degenerate_boxes() {
+        let image = RgbImage::new(50, 50);
+        assert!(crop_bounding_box(&image, &BoundingBox::new(Vec::new())).is_err());
+        assert!(
+            crop_bounding_box(&image, &BoundingBox::from_coords(10.0, 10.0, 10.0, 10.0)).is_err()
+        );
+    }
+}

--- a/oar-ocr-vl/src/decoder_graph.rs
+++ b/oar-ocr-vl/src/decoder_graph.rs
@@ -31,11 +31,11 @@ pub(crate) const fn decoder_attention_is_causal(query_len: usize) -> bool {
 }
 
 #[cfg(feature = "cuda")]
+use crate::error::Error;
+#[cfg(feature = "cuda")]
 use crate::utils::candle_to_ocr_inference;
 #[cfg(feature = "cuda")]
 use candle_core::{CpuStorage, DType, Device, InplaceOp1, Layout, Tensor};
-#[cfg(feature = "cuda")]
-use oar_ocr_core::core::OCRError;
 #[cfg(feature = "cuda")]
 use std::cell::RefCell;
 
@@ -44,8 +44,8 @@ pub(crate) fn cuda_graph_error(
     model_name: &str,
     context: impl Into<String>,
     source: impl std::error::Error + Send + Sync + 'static,
-) -> OCRError {
-    OCRError::Inference {
+) -> Error {
+    Error::Inference {
         model_name: model_name.to_string(),
         context: context.into(),
         source: Box::new(source),
@@ -57,7 +57,7 @@ pub(crate) fn sync_graph_tensor(
     model_name: &str,
     tensor: &Tensor,
     operation: &'static str,
-) -> Result<(), OCRError> {
+) -> Result<(), Error> {
     tensor
         .flatten_all()
         .and_then(|x| x.narrow(0, 0, 1))

--- a/oar-ocr-vl/src/doc_parser.rs
+++ b/oar-ocr-vl/src/doc_parser.rs
@@ -93,18 +93,7 @@ impl Default for DocParserConfig {
             max_tokens: 4096,
             skip_auxiliary_regions: true,
             skip_region_blocks: true,
-            markdown_ignore_labels: vec![
-                "number".to_string(),
-                "footnote".to_string(),
-                "header".to_string(),
-                "header_image".to_string(),
-                "footer".to_string(),
-                "footer_image".to_string(),
-                "aside_text".to_string(),
-                // PaddleOCR-VL markdown output skips `formula_number` blocks by default (unless explicitly
-                // merged into the preceding formula), so ignore it for OpenOCR/PaddleX parity.
-                "formula_number".to_string(),
-            ],
+            markdown_ignore_labels: super::utils::default_markdown_ignore_labels(),
         }
     }
 }
@@ -926,5 +915,42 @@ mod tests {
 
         assert_eq!(result.layout_elements.len(), 1);
         assert_eq!(*backend.crops.borrow(), vec![(120, 80)]);
+    }
+
+    /// `parse_to_markdown` and `StructureResult::to_markdown` must drop the
+    /// same labels; they used to disagree, so a page header reached the prose
+    /// through one path but not the other.
+    #[test]
+    fn both_markdown_entry_points_skip_the_same_labels() {
+        let backend = RecordingBackend {
+            crops: RefCell::new(Vec::new()),
+        };
+        let config = DocParserConfig {
+            // Keep the auxiliary regions so they reach the renderer at all.
+            skip_auxiliary_regions: false,
+            ..DocParserConfig::default()
+        };
+        let parser = DocParser::with_config(&backend, config);
+        let layout = StaticLayout::new(vec![
+            element("header", 10.0, 5.0, 190.0, 20.0),
+            element("text", 10.0, 60.0, 190.0, 140.0),
+        ]);
+
+        let result = parser
+            .parse(&layout, RgbImage::new(200, 200))
+            .expect("parse succeeds");
+        assert!(
+            result
+                .layout_elements
+                .iter()
+                .any(|e| e.element_type == LayoutElementType::Header),
+            "the header must survive parsing for this test to mean anything"
+        );
+
+        let from_config = super::super::utils::to_markdown(
+            &result.layout_elements,
+            &parser.config().markdown_ignore_labels,
+        );
+        assert_eq!(result.to_markdown(), from_config);
     }
 }

--- a/oar-ocr-vl/src/doc_parser.rs
+++ b/oar-ocr-vl/src/doc_parser.rs
@@ -1,6 +1,6 @@
 //! Unified layout-first document parser: detect layout (PP-DocLayout v2/v3),
-//! sort by reading order, then crop and recognize each region with a pluggable
-//! backend into structured results.
+//! then crop and recognize each region with a pluggable backend into structured
+//! results. The layout source supplies the regions in reading order.
 //!
 //! Supported backends:
 //! - [`PaddleOcrVl`] - PaddleOCR-VL, 1.5, and 1.6 with task-specific prompts
@@ -16,16 +16,13 @@ use super::utils::{
     DetectedBox, calculate_overlap_ratio, calculate_projection_overlap_ratio, convert_otsl_to_html,
     crop_margin, filter_overlap_boxes, image::resize_for_mineru, text, truncate_repetitive_content,
 };
+use crate::crop::crop_bounding_box;
+use crate::error::Error;
+use crate::geometry::BoundingBox;
+use crate::layout::LayoutSource;
+use crate::structure::{LayoutElement, LayoutElementType, StructureResult, TableResult, TableType};
 use image::RgbImage;
 use image::{Rgb, imageops};
-use oar_ocr_core::core::{OCRError, OpaqueError};
-use oar_ocr_core::domain::structure::{
-    LayoutElement, LayoutElementType, StructureResult, TableResult, TableType,
-};
-use oar_ocr_core::predictors::LayoutDetectionPredictor;
-use oar_ocr_core::processors::BoundingBox;
-use oar_ocr_core::processors::layout_sorting::{SortableElement, sort_layout_enhanced};
-use oar_ocr_core::utils::BBoxCrop;
 use std::sync::Arc;
 
 /// Recognition task for a layout element.
@@ -54,7 +51,7 @@ pub trait RecognitionBackend {
         image: RgbImage,
         task: RecognitionTask,
         max_tokens: usize,
-    ) -> Result<String, OCRError>;
+    ) -> Result<String, Error>;
 
     /// Whether this backend requires post-processing for table output.
     /// Some backends emit OTSL and need conversion; PaddleOCR-VL outputs HTML directly.
@@ -138,48 +135,40 @@ impl<'a, B: RecognitionBackend> DocParser<'a, B> {
     }
 
     /// Parse a document image using layout-first pipeline.
-    pub fn parse(
+    ///
+    /// `layout` is any [`LayoutSource`]: [`PpDocLayout`](crate::PpDocLayout),
+    /// which runs on Candle like the rest of this crate, or a detector of your
+    /// own. Its regions are used in the order returned.
+    pub fn parse<L: LayoutSource + ?Sized>(
         &self,
-        layout_predictor: &LayoutDetectionPredictor,
+        layout: &L,
         image: RgbImage,
-    ) -> Result<StructureResult, OCRError> {
-        self.parse_with_path(layout_predictor, "<memory>", 0, image)
+    ) -> Result<StructureResult, Error> {
+        self.parse_with_path(layout, "<memory>", 0, image)
     }
 
     /// Parse a document image without layout detection (single full-image OCR).
     ///
     /// Use this for end-to-end models that handle layout internally.
     /// For models requiring separate layout detection, use [`parse`](Self::parse) instead.
-    pub fn parse_without_layout(&self, image: RgbImage) -> Result<StructureResult, OCRError> {
+    pub fn parse_without_layout(&self, image: RgbImage) -> Result<StructureResult, Error> {
         self.recognize_full_image("<memory>".into(), 0, image)
     }
 
     /// Parse a document image with source path information.
-    pub fn parse_with_path(
+    pub fn parse_with_path<L: LayoutSource + ?Sized>(
         &self,
-        layout_predictor: &LayoutDetectionPredictor,
+        layout: &L,
         input_path: impl Into<Arc<str>>,
         index: usize,
         image: RgbImage,
-    ) -> Result<StructureResult, OCRError> {
+    ) -> Result<StructureResult, Error> {
         let input_path: Arc<str> = input_path.into();
         let (page_w, page_h) = (image.width() as f32, image.height() as f32);
 
         // Step 1: Layout detection
-        let layout_result =
-            layout_predictor
-                .predict(vec![image.clone()])
-                .map_err(|e| OCRError::Inference {
-                    model_name: "layout_detection".to_string(),
-                    context: "DocParser: layout prediction failed".to_string(),
-                    source: Box::new(OpaqueError::from_display(e)),
-                })?;
-
-        let detected = layout_result
-            .elements
-            .into_iter()
-            .next()
-            .unwrap_or_default();
+        let layout_result = layout.detect(&image)?;
+        let detected = layout_result.elements;
 
         // OpenOCR applies an additional overlap filter (overlap_ratio > 0.7, mode=small)
         // after PP-DocLayout (v2/v3) to remove redundant boxes.
@@ -219,25 +208,9 @@ impl<'a, B: RecognitionBackend> DocParser<'a, B> {
             return self.recognize_full_image(input_path, index, image);
         }
 
-        // Step 3: Sort by reading order
-        let mut sorted_elements: Vec<LayoutElement> = if layout_result.is_reading_order_sorted {
-            elements
-        } else {
-            let sortable: Vec<SortableElement> = elements
-                .iter()
-                .map(|e| SortableElement {
-                    bbox: e.bbox.clone(),
-                    element_type: e.element_type,
-                    num_lines: e.num_lines,
-                })
-                .collect();
-            let sorted_indices = sort_layout_enhanced(&sortable, page_w, page_h);
-            sorted_indices
-                .into_iter()
-                .filter_map(|idx| elements.get(idx).cloned())
-                .collect()
-        };
-
+        // Step 3: Number the elements. A `LayoutSource` hands them over in
+        // reading order, so there is nothing to sort here.
+        let mut sorted_elements = elements;
         assign_order_indices(&mut sorted_elements);
 
         // Step 4: Recognize each element (with OpenOCR-style block merging)
@@ -293,7 +266,7 @@ impl<'a, B: RecognitionBackend> DocParser<'a, B> {
                     } else {
                         bbox.clone()
                     };
-                    let crop = match BBoxCrop::crop_bounding_box(&image, &crop_bbox) {
+                    let crop = match crop_bounding_box(&image, &crop_bbox) {
                         Ok(crop) => crop,
                         Err(_) => continue,
                     };
@@ -318,7 +291,7 @@ impl<'a, B: RecognitionBackend> DocParser<'a, B> {
                     } else {
                         element.bbox.clone()
                     };
-                    match BBoxCrop::crop_bounding_box(&image, &crop_bbox) {
+                    match crop_bounding_box(&image, &crop_bbox) {
                         Ok(crop) => crop,
                         Err(_) => continue,
                     }
@@ -332,7 +305,7 @@ impl<'a, B: RecognitionBackend> DocParser<'a, B> {
                 } else {
                     element.bbox.clone()
                 };
-                match BBoxCrop::crop_bounding_box(&image, &crop_bbox) {
+                match crop_bounding_box(&image, &crop_bbox) {
                     Ok(cropped) => cropped,
                     Err(_) => continue,
                 }
@@ -388,12 +361,12 @@ impl<'a, B: RecognitionBackend> DocParser<'a, B> {
     }
 
     /// Parse a document and convert to markdown.
-    pub fn parse_to_markdown(
+    pub fn parse_to_markdown<L: LayoutSource + ?Sized>(
         &self,
-        layout_predictor: &LayoutDetectionPredictor,
+        layout: &L,
         image: RgbImage,
-    ) -> Result<String, OCRError> {
-        let result = self.parse(layout_predictor, image)?;
+    ) -> Result<String, Error> {
+        let result = self.parse(layout, image)?;
         Ok(super::utils::to_markdown(
             &result.layout_elements,
             &self.config.markdown_ignore_labels,
@@ -401,12 +374,12 @@ impl<'a, B: RecognitionBackend> DocParser<'a, B> {
     }
 
     /// Parse a document and convert to OpenOCR/PaddleX-compatible markdown (pretty HTML mode).
-    pub fn parse_to_markdown_openocr(
+    pub fn parse_to_markdown_openocr<L: LayoutSource + ?Sized>(
         &self,
-        layout_predictor: &LayoutDetectionPredictor,
+        layout: &L,
         image: RgbImage,
-    ) -> Result<String, OCRError> {
-        let result = self.parse(layout_predictor, image)?;
+    ) -> Result<String, Error> {
+        let result = self.parse(layout, image)?;
         Ok(super::utils::to_markdown_openocr(
             &result.layout_elements,
             &self.config.markdown_ignore_labels,
@@ -419,7 +392,7 @@ impl<'a, B: RecognitionBackend> DocParser<'a, B> {
         input_path: Arc<str>,
         index: usize,
         image: RgbImage,
-    ) -> Result<StructureResult, OCRError> {
+    ) -> Result<StructureResult, Error> {
         let (page_w, page_h) = (image.width() as f32, image.height() as f32);
         let text = self
             .backend
@@ -446,7 +419,7 @@ impl RecognitionBackend for PaddleOcrVl {
         image: RgbImage,
         task: RecognitionTask,
         max_tokens: usize,
-    ) -> Result<String, OCRError> {
+    ) -> Result<String, Error> {
         let vl_task = match task {
             RecognitionTask::Ocr => PaddleOcrVlTask::Ocr,
             RecognitionTask::Table => PaddleOcrVlTask::Table,
@@ -457,7 +430,7 @@ impl RecognitionBackend for PaddleOcrVl {
         // PaddleOCR-VL's reference pipeline truncates repetitive tails on the *raw* model output,
         // before per-task postprocessing (e.g., table-token conversion).
         let results = self.generate_with_raw(&[image], &[vl_task], max_tokens);
-        let (raw, _) = results.into_iter().next().ok_or(OCRError::InvalidInput {
+        let (raw, _) = results.into_iter().next().ok_or(Error::InvalidInput {
             message: "PaddleOCR-VL: no result returned".to_string(),
         })??;
         let raw = truncate_repetitive_content(&raw, 10, 10, 10);
@@ -483,7 +456,7 @@ impl RecognitionBackend for HunyuanOcr {
         image: RgbImage,
         task: RecognitionTask,
         max_tokens: usize,
-    ) -> Result<String, OCRError> {
+    ) -> Result<String, Error> {
         let prompt = match task {
             RecognitionTask::Ocr => {
                 "Detect and recognize text in the image, and output the text coordinates in a formatted manner."
@@ -501,7 +474,7 @@ impl RecognitionBackend for HunyuanOcr {
             .into_iter()
             .next()
             .unwrap_or_else(|| {
-                Err(OCRError::InvalidInput {
+                Err(Error::InvalidInput {
                     message: "HunyuanOCR: no result returned".to_string(),
                 })
             })?;
@@ -529,7 +502,7 @@ impl RecognitionBackend for GlmOcr {
         image: RgbImage,
         task: RecognitionTask,
         max_tokens: usize,
-    ) -> Result<String, OCRError> {
+    ) -> Result<String, Error> {
         let prompt = match task {
             RecognitionTask::Ocr => "Text Recognition:",
             RecognitionTask::Table => "Table Recognition:",
@@ -541,7 +514,7 @@ impl RecognitionBackend for GlmOcr {
             .into_iter()
             .next()
             .unwrap_or_else(|| {
-                Err(OCRError::InvalidInput {
+                Err(Error::InvalidInput {
                     message: "GLM-OCR: no result returned".to_string(),
                 })
             })?;
@@ -569,7 +542,7 @@ impl RecognitionBackend for MinerU {
         image: RgbImage,
         task: RecognitionTask,
         max_tokens: usize,
-    ) -> Result<String, OCRError> {
+    ) -> Result<String, Error> {
         let prompt = match task {
             RecognitionTask::Ocr => "\nText Recognition:",
             RecognitionTask::Table => "\nTable Recognition:",
@@ -584,7 +557,7 @@ impl RecognitionBackend for MinerU {
             .into_iter()
             .next()
             .unwrap_or_else(|| {
-                Err(OCRError::InvalidInput {
+                Err(Error::InvalidInput {
                     message: "MinerU2.5: no result returned".to_string(),
                 })
             })?;
@@ -879,4 +852,79 @@ fn compute_openocr_merge_groups(elements: &[LayoutElement]) -> Vec<MergeGroup> {
         .into_iter()
         .filter(|g| g.indices.len() > 1 && g.aligns.len() + 1 == g.indices.len())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::LayoutDetectionElement;
+    use crate::layout::StaticLayout;
+    use std::cell::RefCell;
+
+    /// Records the crops it is handed and echoes back a per-call marker.
+    struct RecordingBackend {
+        crops: RefCell<Vec<(u32, u32)>>,
+    }
+
+    impl RecognitionBackend for RecordingBackend {
+        fn recognize(
+            &self,
+            image: RgbImage,
+            _task: RecognitionTask,
+            _max_tokens: usize,
+        ) -> Result<String, Error> {
+            let mut crops = self.crops.borrow_mut();
+            crops.push((image.width(), image.height()));
+            Ok(format!("region {}", crops.len()))
+        }
+    }
+
+    fn element(label: &str, x1: f32, y1: f32, x2: f32, y2: f32) -> LayoutDetectionElement {
+        LayoutDetectionElement {
+            bbox: BoundingBox::from_coords(x1, y1, x2, y2),
+            element_type: label.to_string(),
+            score: 0.9,
+        }
+    }
+
+    /// The parser must run end to end on a caller-supplied `LayoutSource`,
+    /// which is the path that needs no ONNX Runtime.
+    #[test]
+    fn parses_with_a_static_layout_source() {
+        let backend = RecordingBackend {
+            crops: RefCell::new(Vec::new()),
+        };
+        let parser = DocParser::new(&backend);
+        let layout = StaticLayout::new(vec![
+            element("doc_title", 10.0, 10.0, 190.0, 40.0),
+            element("text", 10.0, 60.0, 190.0, 140.0),
+        ]);
+
+        let result = parser
+            .parse(&layout, RgbImage::new(200, 200))
+            .expect("parse succeeds");
+
+        assert_eq!(result.layout_elements.len(), 2);
+        assert_eq!(backend.crops.borrow().len(), 2);
+        assert_eq!(
+            result.layout_elements[0].element_type,
+            LayoutElementType::DocTitle
+        );
+    }
+
+    /// An empty detection list falls back to whole-page recognition.
+    #[test]
+    fn falls_back_to_full_image_when_layout_is_empty() {
+        let backend = RecordingBackend {
+            crops: RefCell::new(Vec::new()),
+        };
+        let parser = DocParser::new(&backend);
+
+        let result = parser
+            .parse(&StaticLayout::new(Vec::new()), RgbImage::new(120, 80))
+            .expect("parse succeeds");
+
+        assert_eq!(result.layout_elements.len(), 1);
+        assert_eq!(*backend.crops.borrow(), vec![(120, 80)]);
+    }
 }

--- a/oar-ocr-vl/src/doc_parser.rs
+++ b/oar-ocr-vl/src/doc_parser.rs
@@ -83,6 +83,9 @@ pub struct DocParserConfig {
     pub skip_region_blocks: bool,
     /// Labels to ignore when converting to markdown.
     pub markdown_ignore_labels: Vec<String>,
+    /// Centre captions and tables with inline HTML in markdown output, as the
+    /// PaddleOCR-VL reference does.
+    pub markdown_pretty: bool,
 }
 
 impl Default for DocParserConfig {
@@ -94,6 +97,7 @@ impl Default for DocParserConfig {
             skip_auxiliary_regions: true,
             skip_region_blocks: true,
             markdown_ignore_labels: super::utils::default_markdown_ignore_labels(),
+            markdown_pretty: true,
         }
     }
 }
@@ -350,6 +354,9 @@ impl<'a, B: RecognitionBackend> DocParser<'a, B> {
     }
 
     /// Parse a document and convert to markdown.
+    ///
+    /// Uses [`DocParserConfig::markdown_ignore_labels`] and
+    /// [`DocParserConfig::markdown_pretty`].
     pub fn parse_to_markdown<L: LayoutSource + ?Sized>(
         &self,
         layout: &L,
@@ -359,20 +366,7 @@ impl<'a, B: RecognitionBackend> DocParser<'a, B> {
         Ok(super::utils::to_markdown(
             &result.layout_elements,
             &self.config.markdown_ignore_labels,
-        ))
-    }
-
-    /// Parse a document and convert to OpenOCR/PaddleX-compatible markdown (pretty HTML mode).
-    pub fn parse_to_markdown_openocr<L: LayoutSource + ?Sized>(
-        &self,
-        layout: &L,
-        image: RgbImage,
-    ) -> Result<String, Error> {
-        let result = self.parse(layout, image)?;
-        Ok(super::utils::to_markdown_openocr(
-            &result.layout_elements,
-            &self.config.markdown_ignore_labels,
-            true,
+            self.config.markdown_pretty,
         ))
     }
 
@@ -950,6 +944,7 @@ mod tests {
         let from_config = super::super::utils::to_markdown(
             &result.layout_elements,
             &parser.config().markdown_ignore_labels,
+            parser.config().markdown_pretty,
         );
         assert_eq!(result.to_markdown(), from_config);
     }

--- a/oar-ocr-vl/src/error.rs
+++ b/oar-ocr-vl/src/error.rs
@@ -1,0 +1,127 @@
+//! Error type for the VL models.
+
+use std::fmt;
+use thiserror::Error;
+
+/// Convenience alias for results produced by this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Boxed source error carried by [`Error::Processing`] and [`Error::Inference`].
+pub type Source = Box<dyn std::error::Error + Send + Sync>;
+
+/// Where in a pipeline a failure happened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessingStage {
+    /// Tensor construction, reshaping or arithmetic.
+    TensorOperation,
+    /// Image normalization.
+    Normalization,
+    /// Image resizing.
+    Resize,
+    /// Any other image processing step.
+    ImageProcessing,
+    /// Decoding or assembling model output.
+    PostProcessing,
+}
+
+impl fmt::Display for ProcessingStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::TensorOperation => "tensor operation",
+            Self::Normalization => "normalization",
+            Self::Resize => "resize",
+            Self::ImageProcessing => "image processing",
+            Self::PostProcessing => "post-processing",
+        };
+        f.write_str(name)
+    }
+}
+
+/// A displayable error captured as a string, for sources that are neither
+/// `Send` nor `Sync`.
+#[derive(Debug, Error)]
+#[error("{0}")]
+pub struct OpaqueError(pub String);
+
+impl OpaqueError {
+    /// Captures any displayable error.
+    pub fn from_display(error: impl fmt::Display) -> Self {
+        Self(error.to_string())
+    }
+}
+
+/// Everything that can go wrong loading or running a model in this crate.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// A model configuration or checkpoint layout is unusable.
+    #[error("configuration: {message}")]
+    Config {
+        /// What is wrong with the configuration.
+        message: String,
+    },
+
+    /// A caller-supplied value is out of range or the wrong shape.
+    #[error("invalid input: {message}")]
+    InvalidInput {
+        /// What is wrong with the input.
+        message: String,
+    },
+
+    /// Pre- or post-processing failed.
+    #[error("{kind} failed: {context}")]
+    Processing {
+        /// The stage that failed.
+        kind: ProcessingStage,
+        /// What was being done.
+        context: String,
+        /// The underlying failure.
+        #[source]
+        source: Source,
+    },
+
+    /// A forward pass failed.
+    #[error("inference failed in model '{model_name}': {context}")]
+    Inference {
+        /// The model that failed.
+        model_name: String,
+        /// What was being done.
+        context: String,
+        /// The underlying failure.
+        #[source]
+        source: Source,
+    },
+
+    /// Reading a checkpoint or image from disk failed.
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Decoding an image failed.
+    #[error("image load: {0}")]
+    ImageLoad(#[from] image::ImageError),
+}
+
+impl Error {
+    /// Builds a [`Error::Config`] from a message.
+    pub fn config(message: impl Into<String>) -> Self {
+        Self::Config {
+            message: message.into(),
+        }
+    }
+
+    /// Builds an [`Error::InvalidInput`] from a message.
+    pub fn invalid_input(message: impl Into<String>) -> Self {
+        Self::InvalidInput {
+            message: message.into(),
+        }
+    }
+}
+
+impl From<candle_core::Error> for Error {
+    fn from(error: candle_core::Error) -> Self {
+        Self::Processing {
+            kind: ProcessingStage::TensorOperation,
+            context: "candle operation".to_string(),
+            source: Box::new(error),
+        }
+    }
+}

--- a/oar-ocr-vl/src/geometry.rs
+++ b/oar-ocr-vl/src/geometry.rs
@@ -1,0 +1,121 @@
+//! Bounding-box geometry used by the layout and structure types.
+
+use serde::{Deserialize, Serialize};
+
+/// A 2D point.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct Point {
+    /// X coordinate.
+    pub x: f32,
+    /// Y coordinate.
+    pub y: f32,
+}
+
+impl Point {
+    /// Creates a point.
+    #[inline]
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+}
+
+/// A polygon bounding box. Detectors here emit axis-aligned rectangles, but the
+/// representation keeps arbitrary point lists so rotated regions stay exact.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BoundingBox {
+    /// Corner points, in order.
+    pub points: Vec<Point>,
+}
+
+impl BoundingBox {
+    /// Creates a box from its corner points.
+    #[inline]
+    pub fn new(points: Vec<Point>) -> Self {
+        Self { points }
+    }
+
+    /// Creates an axis-aligned box from two opposite corners.
+    pub fn from_coords(x1: f32, y1: f32, x2: f32, y2: f32) -> Self {
+        Self::new(vec![
+            Point::new(x1, y1),
+            Point::new(x2, y1),
+            Point::new(x2, y2),
+            Point::new(x1, y2),
+        ])
+    }
+
+    /// Smallest x over all points, or `0.0` when empty.
+    pub fn x_min(&self) -> f32 {
+        self.fold(f32::INFINITY, f32::min, |p| p.x)
+    }
+
+    /// Largest x over all points, or `0.0` when empty.
+    pub fn x_max(&self) -> f32 {
+        self.fold(f32::NEG_INFINITY, f32::max, |p| p.x)
+    }
+
+    /// Smallest y over all points, or `0.0` when empty.
+    pub fn y_min(&self) -> f32 {
+        self.fold(f32::INFINITY, f32::min, |p| p.y)
+    }
+
+    /// Largest y over all points, or `0.0` when empty.
+    pub fn y_max(&self) -> f32 {
+        self.fold(f32::NEG_INFINITY, f32::max, |p| p.y)
+    }
+
+    /// Width of the axis-aligned extent.
+    pub fn width(&self) -> f32 {
+        self.x_max() - self.x_min()
+    }
+
+    /// Height of the axis-aligned extent.
+    pub fn height(&self) -> f32 {
+        self.y_max() - self.y_min()
+    }
+
+    /// Intersection over union of the two axis-aligned extents.
+    pub fn iou(&self, other: &BoundingBox) -> f32 {
+        let inter_width =
+            (self.x_max().min(other.x_max()) - self.x_min().max(other.x_min())).max(0.0);
+        let inter_height =
+            (self.y_max().min(other.y_max()) - self.y_min().max(other.y_min())).max(0.0);
+        let inter_area = inter_width * inter_height;
+        if inter_area <= 0.0 {
+            return 0.0;
+        }
+        let union = self.width() * self.height() + other.width() * other.height() - inter_area;
+        if union > 0.0 { inter_area / union } else { 0.0 }
+    }
+
+    fn fold(&self, init: f32, op: fn(f32, f32) -> f32, get: fn(&Point) -> f32) -> f32 {
+        if self.points.is_empty() {
+            return 0.0;
+        }
+        self.points.iter().map(get).fold(init, op)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reports_the_extent_of_a_rectangle() {
+        let bbox = BoundingBox::from_coords(10.0, 20.0, 40.0, 60.0);
+        assert_eq!(bbox.x_min(), 10.0);
+        assert_eq!(bbox.y_min(), 20.0);
+        assert_eq!(bbox.x_max(), 40.0);
+        assert_eq!(bbox.y_max(), 60.0);
+        assert_eq!(bbox.width(), 30.0);
+        assert_eq!(bbox.height(), 40.0);
+    }
+
+    /// An empty box must not leak infinities into downstream arithmetic.
+    #[test]
+    fn reports_zero_for_an_empty_box() {
+        let bbox = BoundingBox::new(Vec::new());
+        assert_eq!(bbox.x_min(), 0.0);
+        assert_eq!(bbox.y_max(), 0.0);
+    }
+}

--- a/oar-ocr-vl/src/glmocr/config.rs
+++ b/oar-ocr-vl/src/glmocr/config.rs
@@ -1,5 +1,5 @@
+use crate::error::Error;
 use candle_nn::Activation;
-use oar_ocr_core::core::OCRError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -110,7 +110,7 @@ pub struct GlmOcrConfig {
 }
 
 impl GlmOcrConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         crate::utils::load_json_config(path, "GLM-OCR", "config.json")
     }
 }
@@ -147,34 +147,34 @@ pub struct GlmOcrImageProcessorConfig {
 }
 
 impl GlmOcrImageProcessorConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         crate::utils::load_json_config(path, "GLM-OCR", "preprocessor_config.json")
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         crate::utils::validate_image_mean_std("GLM-OCR", &self.image_mean, &self.image_std)?;
         if self.image_std.contains(&0.0) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "GLM-OCR image_std values must be non-zero (used as divisor)".to_string(),
             });
         }
         if self.patch_size == 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "GLM-OCR patch_size must be > 0".to_string(),
             });
         }
         if self.merge_size == 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "GLM-OCR merge_size must be > 0".to_string(),
             });
         }
         if self.temporal_patch_size == 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "GLM-OCR temporal_patch_size must be > 0".to_string(),
             });
         }
         if self.size.shortest_edge == 0 || self.size.longest_edge == 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "GLM-OCR size.shortest_edge/longest_edge must be > 0".to_string(),
             });
         }

--- a/oar-ocr-vl/src/glmocr/model.rs
+++ b/oar-ocr-vl/src/glmocr/model.rs
@@ -4,11 +4,11 @@ use super::mtp::GlmOcrMtpModel;
 use super::processing::{GlmOcrImageInputs, preprocess_image};
 use super::text::GlmOcrTextModel;
 use super::vision::GlmOcrVisionModel;
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{D, DType, Device, IndexOp, Tensor};
 use candle_nn::{Linear, Module, VarBuilder, linear_no_bias};
 use image::RgbImage;
-use oar_ocr_core::core::OCRError;
 use std::path::Path;
 use tokenizers::Tokenizer;
 
@@ -36,22 +36,21 @@ pub struct GlmOcr {
 }
 
 impl GlmOcr {
-    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, OCRError> {
+    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, Error> {
         let model_dir = model_dir.as_ref();
         let cfg = GlmOcrConfig::from_path(model_dir.join("config.json"))?;
         let image_cfg =
             GlmOcrImageProcessorConfig::from_path(model_dir.join("preprocessor_config.json"))?;
 
-        let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| {
-            OCRError::ConfigError {
+        let tokenizer =
+            Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| Error::Config {
                 message: format!("failed to load GLM-OCR tokenizer.json: {e}"),
-            }
-        })?;
+            })?;
 
         if let Some(tok_image_id) = tokenizer.token_to_id("<|image|>")
             && tok_image_id != cfg.image_token_id
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "GLM-OCR image_token_id mismatch: tokenizer {tok_image_id} != config {}",
                     cfg.image_token_id
@@ -132,12 +131,12 @@ impl GlmOcr {
         images: &[RgbImage],
         instructions: &[impl AsRef<str>],
         max_new_tokens: usize,
-    ) -> Vec<Result<String, OCRError>> {
+    ) -> Vec<Result<String, Error>> {
         if images.is_empty() {
             return Vec::new();
         }
         if images.len() != instructions.len() {
-            return vec![Err(OCRError::InvalidInput {
+            return vec![Err(Error::InvalidInput {
                 message: format!(
                     "GLM-OCR: images count ({}) != instructions count ({})",
                     images.len(),
@@ -155,7 +154,7 @@ impl GlmOcr {
                 let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
-                        Err(OCRError::InvalidInput {
+                        Err(Error::InvalidInput {
                             message: msg.clone(),
                         })
                     })
@@ -172,12 +171,12 @@ impl GlmOcr {
         images: &[RgbImage],
         instructions: &[impl AsRef<str>],
         max_new_tokens: usize,
-    ) -> Vec<Result<Vec<u32>, OCRError>> {
+    ) -> Vec<Result<Vec<u32>, Error>> {
         if images.is_empty() {
             return Vec::new();
         }
         if images.len() != instructions.len() {
-            return vec![Err(OCRError::InvalidInput {
+            return vec![Err(Error::InvalidInput {
                 message: format!(
                     "GLM-OCR: images count ({}) != instructions count ({})",
                     images.len(),
@@ -192,7 +191,7 @@ impl GlmOcr {
                 let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
-                        Err(OCRError::InvalidInput {
+                        Err(Error::InvalidInput {
                             message: msg.clone(),
                         })
                     })
@@ -206,7 +205,7 @@ impl GlmOcr {
         images: &[RgbImage],
         instructions: &[impl AsRef<str>],
         max_new_tokens: usize,
-    ) -> Result<Vec<Vec<u32>>, OCRError> {
+    ) -> Result<Vec<Vec<u32>>, Error> {
         let mut results = Vec::with_capacity(images.len());
 
         for (image, instruction) in images.iter().zip(instructions.iter()) {
@@ -224,12 +223,12 @@ impl GlmOcr {
             let enc = self
                 .tokenizer
                 .encode(prompt, false)
-                .map_err(|e| OCRError::InvalidInput {
+                .map_err(|e| Error::InvalidInput {
                     message: format!("GLM-OCR: tokenizer encode failed: {e}"),
                 })?;
             let input_ids = enc.get_ids().to_vec();
             if input_ids.is_empty() {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: "GLM-OCR: empty prompt after tokenization".to_string(),
                 });
             }
@@ -307,10 +306,10 @@ impl GlmOcr {
         seq_len: usize,
         rope_delta: i64,
         max_new_tokens: usize,
-    ) -> Result<Vec<u32>, OCRError> {
+    ) -> Result<Vec<u32>, Error> {
         let last = prompt_hidden.i((0, seq_len - 1, ..)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: get last hidden",
                 e,
             )
@@ -324,7 +323,7 @@ impl GlmOcr {
                 .and_then(|t| t.to_scalar::<u32>())
                 .map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "GLM-OCR: argmax",
                         e,
                     )
@@ -356,11 +355,11 @@ impl GlmOcr {
         rope_delta: i64,
         max_new_tokens: usize,
         mtp: &GlmOcrMtpModel,
-    ) -> Result<Vec<u32>, OCRError> {
+    ) -> Result<Vec<u32>, Error> {
         let prompt_len = prompt_ids.len();
         let last = prompt_hidden.i((0, prompt_len - 1, ..)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: get MTP target hidden",
                 e,
             )
@@ -371,7 +370,7 @@ impl GlmOcr {
             .and_then(|token| token.to_scalar::<u32>())
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: initial MTP target argmax",
                     e,
                 )
@@ -427,7 +426,7 @@ impl GlmOcr {
                 candle_to_ocr_inference("GLM-OCR", "copy MTP verification tokens", e)
             })?;
             if target_tokens.len() != GLM_MTP_QUERY_LEN {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: format!(
                         "GLM-OCR: verification returned {} tokens, expected {}",
                         target_tokens.len(),
@@ -509,7 +508,7 @@ impl GlmOcr {
         first_hidden: &Tensor,
         first_tokens: &Tensor,
         target_position: i64,
-    ) -> Result<Vec<u32>, OCRError> {
+    ) -> Result<Vec<u32>, Error> {
         let seq_len = first_hidden
             .dim(1)
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "MTP result length", e))?;
@@ -557,7 +556,7 @@ impl GlmOcr {
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "copy MTP proposals", e))
     }
 
-    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, Error> {
         self.decode_generated_tokens(tokens)
     }
 
@@ -565,11 +564,11 @@ impl GlmOcr {
     /// post-process. Use this when the raw token sequence is needed before
     /// any post-processing — for example when feeding output to another
     /// model that operates at token granularity.
-    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, Error> {
         let decoded = self
             .tokenizer
             .decode(tokens, true)
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("GLM-OCR: tokenizer decode failed: {e}"),
             })?;
         Ok(decoded.trim().to_string())
@@ -579,7 +578,7 @@ impl GlmOcr {
         &self.tokenizer
     }
 
-    fn decode_generated_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    fn decode_generated_tokens(&self, tokens: &[u32]) -> Result<String, Error> {
         // No Rust-specific truncation heuristic — match official GLM-OCR behavior.
         // The official implementation relies on EOS-based stopping only.
         self.decode_tokens_raw(tokens)
@@ -589,12 +588,12 @@ impl GlmOcr {
         &self,
         input_ids: &[u32],
         image_inputs: &GlmOcrImageInputs,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let seq_len = input_ids.len();
         let token_ids =
             Tensor::from_vec(input_ids.to_vec(), (1, seq_len), &self.device).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: create input_ids tensor",
                     e,
                 )
@@ -606,7 +605,7 @@ impl GlmOcr {
             .forward(&image_inputs.pixel_values, image_inputs.grid_thw)?;
         let image_embeds = image_embeds.to_dtype(self.dtype).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: cast image_embeds",
                 e,
             )
@@ -625,13 +624,13 @@ impl GlmOcr {
             .collect();
         let image_embeds_len = image_embeds.dim(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: image_embeds dim",
                 e,
             )
         })?;
         if indices.len() != image_embeds_len {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "GLM-OCR: image token count ({}) != image embeds ({})",
                     indices.len(),
@@ -640,21 +639,21 @@ impl GlmOcr {
             });
         }
         if indices.is_empty() {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "GLM-OCR: no image tokens found in prompt".to_string(),
             });
         }
         let start = indices[0];
         let end = *indices.last().unwrap();
         if end + 1 - start != indices.len() {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "GLM-OCR: image tokens are not contiguous in prompt".to_string(),
             });
         }
 
         let hidden_size = embeds.dim(2).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: embed hidden_size",
                 e,
             )
@@ -663,7 +662,7 @@ impl GlmOcr {
         let prefix = if start > 0 {
             embeds.narrow(1, 0, start).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: embed prefix narrow",
                     e,
                 )
@@ -671,7 +670,7 @@ impl GlmOcr {
         } else {
             Tensor::zeros((1, 0, hidden_size), embeds.dtype(), embeds.device()).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: embed prefix zeros",
                     e,
                 )
@@ -684,7 +683,7 @@ impl GlmOcr {
                 .narrow(1, suffix_start, seq_len - suffix_start)
                 .map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "GLM-OCR: embed suffix narrow",
                         e,
                     )
@@ -692,7 +691,7 @@ impl GlmOcr {
         } else {
             Tensor::zeros((1, 0, hidden_size), embeds.dtype(), embeds.device()).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: embed suffix zeros",
                     e,
                 )
@@ -701,14 +700,14 @@ impl GlmOcr {
 
         let image_embeds = image_embeds.unsqueeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: image embeds unsqueeze",
                 e,
             )
         })?;
         embeds = Tensor::cat(&[&prefix, &image_embeds, &suffix], 1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: embed cat",
                 e,
             )
@@ -717,10 +716,10 @@ impl GlmOcr {
         Ok(embeds)
     }
 
-    fn logits_from_hidden(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn logits_from_hidden(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         let hidden = hidden.unsqueeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: logits unsqueeze",
                 e,
             )
@@ -731,7 +730,7 @@ impl GlmOcr {
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "lm_head forward", e))?;
         logits.squeeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: logits squeeze",
                 e,
             )
@@ -739,19 +738,19 @@ impl GlmOcr {
     }
 }
 
-fn token_tensor(token: u32, device: &Device) -> Result<Tensor, OCRError> {
+fn token_tensor(token: u32, device: &Device) -> Result<Tensor, Error> {
     Tensor::new(&[token], device)
         .and_then(|token| token.reshape((1, 1)))
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: create token tensor",
                 e,
             )
         })
 }
 
-fn text_position_ids(start: i64, len: usize, device: &Device) -> Result<Tensor, OCRError> {
+fn text_position_ids(start: i64, len: usize, device: &Device) -> Result<Tensor, Error> {
     let positions: Vec<i64> = (0..len).map(|offset| start + offset as i64).collect();
     let mut data = Vec::with_capacity(3 * len);
     data.extend_from_slice(&positions);
@@ -759,7 +758,7 @@ fn text_position_ids(start: i64, len: usize, device: &Device) -> Result<Tensor, 
     data.extend_from_slice(&positions);
     Tensor::from_vec(data, (3, 1, len), device).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: create text position ids",
             e,
         )
@@ -772,14 +771,14 @@ fn build_prompt(instruction: &str) -> String {
     )
 }
 
-fn expand_image_tokens(prompt: &str, num_image_tokens: usize) -> Result<String, OCRError> {
+fn expand_image_tokens(prompt: &str, num_image_tokens: usize) -> Result<String, Error> {
     if num_image_tokens == 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "GLM-OCR: num_image_tokens is zero".to_string(),
         });
     }
     if !prompt.contains("<|image|>") {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "GLM-OCR: prompt missing <|image|> token".to_string(),
         });
     }
@@ -798,7 +797,7 @@ fn build_position_ids(
     merge_size: usize,
     image_token_id: u32,
     device: &Device,
-) -> Result<(Tensor, i64), OCRError> {
+) -> Result<(Tensor, i64), Error> {
     let (mut pos_t, mut pos_h, mut pos_w) = (Vec::new(), Vec::new(), Vec::new());
     let mut max_pos: i64 = -1;
 
@@ -830,7 +829,7 @@ fn build_position_ids(
         let st_idx = max_pos + 1;
         if is_image {
             if seen_image {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: "GLM-OCR: multiple image groups in prompt are not supported"
                         .to_string(),
                 });
@@ -838,7 +837,7 @@ fn build_position_ids(
             seen_image = true;
             let group_len = e - s;
             if group_len != expected_image_tokens {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: format!(
                         "GLM-OCR: image token count ({group_len}) != expected ({expected_image_tokens})"
                     ),
@@ -869,7 +868,7 @@ fn build_position_ids(
 
     let seq_len = input_ids.len();
     if pos_t.len() != seq_len {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "GLM-OCR: position_ids length mismatch: {} vs {}",
                 pos_t.len(),
@@ -885,7 +884,7 @@ fn build_position_ids(
 
     let position_ids = Tensor::from_vec(data, (3, 1, seq_len), device).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: position_ids tensor",
             e,
         )

--- a/oar-ocr-vl/src/glmocr/mtp.rs
+++ b/oar-ocr-vl/src/glmocr/mtp.rs
@@ -7,12 +7,12 @@
 use super::config::GlmOcrTextConfig;
 use super::text::{GlmOcrTextDecoderLayer, GlmOcrTextRotaryEmbedding};
 use crate::decoder_graph::{CudaGraphKvLengths, cuda_graph_error, sync_graph_tensor};
+use crate::error::Error;
 use crate::utils::candle_to_ocr_inference;
 use candle_core::{D, DType, Device, Tensor};
 use candle_nn::{
     Embedding, Linear, Module, RmsNorm, VarBuilder, embedding, linear_no_bias, rms_norm,
 };
-use oar_ocr_core::core::OCRError;
 use std::cell::RefCell;
 
 struct GlmMtpCudaGraph {
@@ -54,7 +54,7 @@ impl GlmOcrMtpModel {
         cfg: &GlmOcrTextConfig,
         layer_index: usize,
         vb_language_model: VarBuilder,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         let vb = vb_language_model.pp("layers").pp(layer_index);
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("embed_tokens"))
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "load MTP embeddings", e))?;
@@ -97,7 +97,7 @@ impl GlmOcrMtpModel {
         input_ids: &Tensor,
         previous_hidden_states: &Tensor,
         mask_first_position: bool,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let mut inputs_embeds = self
             .embed_tokens
             .forward(input_ids)
@@ -141,7 +141,7 @@ impl GlmOcrMtpModel {
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "MTP fusion projection", e))
     }
 
-    fn tokens_from_hidden(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+    fn tokens_from_hidden(&self, hidden_states: &Tensor) -> Result<Tensor, Error> {
         let hidden_states = self
             .shared_norm
             .forward(hidden_states)
@@ -159,7 +159,7 @@ impl GlmOcrMtpModel {
         previous_hidden_states: &Tensor,
         position_ids: &Tensor,
         mask_first_position: bool,
-    ) -> Result<(Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor), Error> {
         let hidden_states =
             self.fuse_inputs(input_ids, previous_hidden_states, mask_first_position)?;
         let (cos, sin) = self.rotary_emb.forward(&hidden_states, position_ids)?;
@@ -175,7 +175,7 @@ impl GlmOcrMtpModel {
         position_ids: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<(Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor), Error> {
         let hidden_states = self.fuse_inputs(input_ids, previous_hidden_states, false)?;
         let (cos, sin) = self.rotary_emb.forward(&hidden_states, position_ids)?;
         let hidden_states =
@@ -192,7 +192,7 @@ impl GlmOcrMtpModel {
         target_hidden_states: &Tensor,
         position_ids: &Tensor,
         mask_first_position: bool,
-    ) -> Result<(Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor), Error> {
         self.forward_tokens(
             shifted_input_ids,
             target_hidden_states,
@@ -207,7 +207,7 @@ impl GlmOcrMtpModel {
         input_id: &Tensor,
         previous_hidden_state: &Tensor,
         position_ids: &Tensor,
-    ) -> Result<(Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor), Error> {
         let kv_len = self.kv_cache_len().saturating_add(1);
         if let Some(output) =
             self.replay_cuda_graph(input_id, previous_hidden_state, position_ids, kv_len)?
@@ -217,7 +217,7 @@ impl GlmOcrMtpModel {
         self.forward_tokens(input_id, previous_hidden_state, position_ids, false)
     }
 
-    pub(super) fn prepare_cuda_graph(&self, cache_len: usize) -> Result<(), OCRError> {
+    pub(super) fn prepare_cuda_graph(&self, cache_len: usize) -> Result<(), Error> {
         if std::env::var_os("OAR_VL_DISABLE_CUDA_GRAPH").is_some()
             || std::env::var_os("OAR_GLMOCR_DISABLE_CUDA_GRAPH").is_some()
         {
@@ -245,7 +245,7 @@ impl GlmOcrMtpModel {
         self.capture_cuda_graph(cache_len)
     }
 
-    fn capture_cuda_graph(&self, cache_len: usize) -> Result<(), OCRError> {
+    fn capture_cuda_graph(&self, cache_len: usize) -> Result<(), Error> {
         use candle_core::cuda_backend::cudarc::driver::sys::{
             CUgraphInstantiate_flags_enum, CUstreamCaptureMode_enum,
         };
@@ -311,7 +311,7 @@ impl GlmOcrMtpModel {
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
             )
             .map_err(|e| cuda_graph_error("GLM-OCR", "end MTP CUDA graph capture", e))?
-            .ok_or_else(|| OCRError::ConfigError {
+            .ok_or_else(|| Error::Config {
                 message: "GLM-OCR MTP capture returned no graph".to_string(),
             })?;
         graph
@@ -339,7 +339,7 @@ impl GlmOcrMtpModel {
         previous_hidden_state: &Tensor,
         position_ids: &Tensor,
         kv_len: usize,
-    ) -> Result<Option<(Tensor, Tensor)>, OCRError> {
+    ) -> Result<Option<(Tensor, Tensor)>, Error> {
         let captured_ref = self.graph.borrow();
         let Some(captured) = captured_ref.as_ref() else {
             return Ok(None);
@@ -390,7 +390,7 @@ impl GlmOcrMtpModel {
         self.invalidate_cuda_graph();
     }
 
-    pub(super) fn trim_kv_cache(&self, len: usize) -> Result<(), OCRError> {
+    pub(super) fn trim_kv_cache(&self, len: usize) -> Result<(), Error> {
         self.layer.trim_kv_cache(len)
     }
 

--- a/oar-ocr-vl/src/glmocr/processing.rs
+++ b/oar-ocr-vl/src/glmocr/processing.rs
@@ -1,11 +1,11 @@
 use super::config::{GlmOcrImageProcessorConfig, GlmOcrVisionConfig};
+use crate::error::Error;
 use crate::utils::{
     candle_to_ocr_processing,
     image::{image_to_chw, patchify_merge_grouped, pil_resample_to_filter_type},
 };
 use candle_core::{DType, Device, Tensor};
 use image::{RgbImage, imageops::FilterType};
-use oar_ocr_core::core::OCRError;
 
 #[derive(Debug, Clone)]
 pub struct GlmOcrImageInputs {
@@ -22,16 +22,16 @@ fn smart_resize_glm(
     factor: u32,
     min_pixels: u32,
     max_pixels: u32,
-) -> Result<(u32, u32), OCRError> {
+) -> Result<(u32, u32), Error> {
     if num_frames < temporal_factor {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "GLM-OCR smart_resize: num_frames ({num_frames}) < temporal_factor ({temporal_factor})"
             ),
         });
     }
     if factor == 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "GLM-OCR smart_resize: factor must be > 0".to_string(),
         });
     }
@@ -52,7 +52,7 @@ fn smart_resize_glm(
     let max_dim = height.max(width);
     let min_dim = height.min(width);
     if min_dim > 0.0 && (max_dim / min_dim) > 200.0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "GLM-OCR smart_resize: absolute aspect ratio must be <= 200, got {:.3}",
                 max_dim / min_dim
@@ -90,10 +90,10 @@ pub fn preprocess_image(
     vision_cfg: &GlmOcrVisionConfig,
     device: &Device,
     dtype: DType,
-) -> Result<GlmOcrImageInputs, OCRError> {
+) -> Result<GlmOcrImageInputs, Error> {
     cfg.validate()?;
     if cfg.patch_size != vision_cfg.patch_size {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "GLM-OCR patch_size mismatch: preprocessor {} != vision_config {}",
                 cfg.patch_size, vision_cfg.patch_size
@@ -101,7 +101,7 @@ pub fn preprocess_image(
         });
     }
     if cfg.temporal_patch_size != vision_cfg.temporal_patch_size {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "GLM-OCR temporal_patch_size mismatch: preprocessor {} != vision_config {}",
                 cfg.temporal_patch_size, vision_cfg.temporal_patch_size
@@ -109,7 +109,7 @@ pub fn preprocess_image(
         });
     }
     if cfg.merge_size != vision_cfg.spatial_merge_size {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "GLM-OCR merge_size mismatch: preprocessor {} != vision_config {}",
                 cfg.merge_size, vision_cfg.spatial_merge_size
@@ -145,7 +145,7 @@ pub fn preprocess_image(
     };
 
     if rh % factor != 0 || rw % factor != 0 {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "GLM-OCR preprocess produced non-divisible dims: {rh}x{rw} not divisible by factor={factor}"
             ),
@@ -187,7 +187,7 @@ pub fn preprocess_image(
     let grid_w = width / patch_size;
 
     if !grid_h.is_multiple_of(merge_size) || !grid_w.is_multiple_of(merge_size) {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "GLM-OCR preprocess produced non-divisible grid: grid_h={grid_h}, grid_w={grid_w}, merge_size={merge_size}"
             ),
@@ -214,7 +214,7 @@ pub fn preprocess_image(
     let pixel_values = Tensor::from_vec(flat, (num_patches, patch_dim), device)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: failed to create pixel_values tensor",
                 e,
             )
@@ -222,7 +222,7 @@ pub fn preprocess_image(
         .to_dtype(dtype)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: failed to cast pixel_values dtype",
                 e,
             )

--- a/oar-ocr-vl/src/glmocr/text.rs
+++ b/oar-ocr-vl/src/glmocr/text.rs
@@ -7,6 +7,7 @@ use crate::decoder_graph::{
     CudaGraphKvLengths, SingleTokenDecoderCudaGraph, cuda_graph_error, decoder_attention_is_causal,
     sync_graph_tensor,
 };
+use crate::error::Error;
 #[cfg(feature = "cuda")]
 use crate::hunyuanocr::dynamic_kv::DynamicKvAppend;
 use crate::kv_trim::TrimmableKvCache;
@@ -15,7 +16,6 @@ use candle_core::{D, DType, Device, IndexOp, Tensor};
 use candle_nn::{
     Embedding, Linear, Module, RmsNorm, VarBuilder, embedding, linear_no_bias, rms_norm,
 };
-use oar_ocr_core::core::OCRError;
 use std::cell::RefCell;
 
 #[cfg(any(feature = "cuda", test))]
@@ -26,58 +26,58 @@ fn ar_cuda_graph_capacity(prompt_len: usize, max_new_tokens: usize) -> Option<us
     decoder_cache_capacity(prompt_len, max_new_tokens, GLM_DECODE_CACHE_LEN)
 }
 
-fn rotate_half_interleaved(x: &Tensor) -> Result<Tensor, OCRError> {
+fn rotate_half_interleaved(x: &Tensor) -> Result<Tensor, Error> {
     let (b, h, s, d) = x.dims4().map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: rotate_half dims4",
             e,
         )
     })?;
     if d % 2 != 0 {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!("GLM-OCR: head_dim must be even, got {d}"),
         });
     }
     let half = d / 2;
     let x = x.reshape((b, h, s, half, 2)).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: rotate_half reshape",
             e,
         )
     })?;
     let x_even = x.i((.., .., .., .., 0)).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: rotate_half even slice",
             e,
         )
     })?;
     let x_odd = x.i((.., .., .., .., 1)).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: rotate_half odd slice",
             e,
         )
     })?;
     let x_odd = x_odd.neg().map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: rotate_half neg",
             e,
         )
     })?;
     let stacked = Tensor::stack(&[&x_odd, &x_even], D::Minus1).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: rotate_half stack",
             e,
         )
     })?;
     stacked.flatten_from(D::Minus2).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: rotate_half flatten",
             e,
         )
@@ -89,17 +89,17 @@ pub(super) fn apply_rotary_pos_emb(
     k: &Tensor,
     cos: &Tensor,
     sin: &Tensor,
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     let cos = cos.unsqueeze(1).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: cos unsqueeze",
             e,
         )
     })?;
     let sin = sin.unsqueeze(1).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: sin unsqueeze",
             e,
         )
@@ -107,7 +107,7 @@ pub(super) fn apply_rotary_pos_emb(
 
     let (b, h, s, rot_dim) = cos.dims4().map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: cos dims4",
             e,
         )
@@ -115,14 +115,14 @@ pub(super) fn apply_rotary_pos_emb(
     let half = rot_dim / 2;
     let cos_half = cos.narrow(D::Minus1, 0, half).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: cos narrow",
             e,
         )
     })?;
     let sin_half = sin.narrow(D::Minus1, 0, half).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: sin narrow",
             e,
         )
@@ -130,7 +130,7 @@ pub(super) fn apply_rotary_pos_emb(
     let cos = Tensor::stack(&[&cos_half, &cos_half], D::Minus1)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: cos stack",
                 e,
             )
@@ -138,7 +138,7 @@ pub(super) fn apply_rotary_pos_emb(
         .reshape((b, h, s, rot_dim))
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: cos reshape",
                 e,
             )
@@ -146,7 +146,7 @@ pub(super) fn apply_rotary_pos_emb(
     let sin = Tensor::stack(&[&sin_half, &sin_half], D::Minus1)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: sin stack",
                 e,
             )
@@ -154,7 +154,7 @@ pub(super) fn apply_rotary_pos_emb(
         .reshape((b, h, s, rot_dim))
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: sin reshape",
                 e,
             )
@@ -162,7 +162,7 @@ pub(super) fn apply_rotary_pos_emb(
 
     let head_dim = q.dim(D::Minus1).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: q head_dim",
             e,
         )
@@ -170,14 +170,14 @@ pub(super) fn apply_rotary_pos_emb(
 
     let q_rot = q.narrow(D::Minus1, 0, rot_dim).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: q narrow",
             e,
         )
     })?;
     let k_rot = k.narrow(D::Minus1, 0, rot_dim).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: k narrow",
             e,
         )
@@ -188,21 +188,21 @@ pub(super) fn apply_rotary_pos_emb(
 
     let q_mul = q_rot.broadcast_mul(&cos).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: q*cos",
             e,
         )
     })?;
     let q_rot_mul = q_rotated.broadcast_mul(&sin).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: rotate_half(q)*sin",
             e,
         )
     })?;
     let mut q_out = (&q_mul + &q_rot_mul).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: q apply rope",
             e,
         )
@@ -210,21 +210,21 @@ pub(super) fn apply_rotary_pos_emb(
 
     let k_mul = k_rot.broadcast_mul(&cos).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: k*cos",
             e,
         )
     })?;
     let k_rot_mul = k_rotated.broadcast_mul(&sin).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: rotate_half(k)*sin",
             e,
         )
     })?;
     let mut k_out = (&k_mul + &k_rot_mul).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: k apply rope",
             e,
         )
@@ -235,7 +235,7 @@ pub(super) fn apply_rotary_pos_emb(
             .narrow(D::Minus1, rot_dim, head_dim - rot_dim)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: q pass narrow",
                     e,
                 )
@@ -244,21 +244,21 @@ pub(super) fn apply_rotary_pos_emb(
             .narrow(D::Minus1, rot_dim, head_dim - rot_dim)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: k pass narrow",
                     e,
                 )
             })?;
         q_out = Tensor::cat(&[&q_out, &q_pass], D::Minus1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: q cat pass",
                 e,
             )
         })?;
         k_out = Tensor::cat(&[&k_out, &k_pass], D::Minus1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: k cat pass",
                 e,
             )
@@ -268,15 +268,15 @@ pub(super) fn apply_rotary_pos_emb(
     Ok((q_out, k_out))
 }
 
-fn apply_mrope(freqs: &Tensor, mrope_section: &[usize]) -> Result<Tensor, OCRError> {
+fn apply_mrope(freqs: &Tensor, mrope_section: &[usize]) -> Result<Tensor, Error> {
     if mrope_section.is_empty() {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: "GLM-OCR: mrope_section is empty".to_string(),
         });
     }
     let dims = freqs.dims();
     if dims.len() != 4 || dims[0] != 3 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!("GLM-OCR: freqs dims mismatch, got {:?}", dims),
         });
     }
@@ -285,14 +285,14 @@ fn apply_mrope(freqs: &Tensor, mrope_section: &[usize]) -> Result<Tensor, OCRErr
     for (i, &sec) in mrope_section.iter().enumerate() {
         let seg = freqs.narrow(D::Minus1, offset, sec).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: mrope narrow",
                 e,
             )
         })?;
         let picked = seg.i((i % 3, .., .., ..)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: mrope pick",
                 e,
             )
@@ -303,7 +303,7 @@ fn apply_mrope(freqs: &Tensor, mrope_section: &[usize]) -> Result<Tensor, OCRErr
     let refs: Vec<&Tensor> = chunks.iter().collect();
     Tensor::cat(&refs, D::Minus1).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: mrope cat",
             e,
         )
@@ -317,9 +317,9 @@ pub(super) struct GlmOcrTextRotaryEmbedding {
 }
 
 impl GlmOcrTextRotaryEmbedding {
-    pub(super) fn new(cfg: &GlmOcrTextConfig, device: &Device) -> Result<Self, OCRError> {
+    pub(super) fn new(cfg: &GlmOcrTextConfig, device: &Device) -> Result<Self, Error> {
         if cfg.rope_parameters.rope_type != "default" {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "GLM-OCR: unsupported rope_type '{}'",
                     cfg.rope_parameters.rope_type
@@ -333,7 +333,7 @@ impl GlmOcrTextRotaryEmbedding {
         };
         let dim = (head_dim as f64 * cfg.rope_parameters.partial_rotary_factor).floor() as usize;
         if !dim.is_multiple_of(2) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!("GLM-OCR: rotary dim must be even, got {dim}"),
             });
         }
@@ -344,7 +344,7 @@ impl GlmOcrTextRotaryEmbedding {
             .collect();
         let inv_freq = Tensor::from_vec(inv_freq, (dim / 2,), device).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: create inv_freq",
                 e,
             )
@@ -352,7 +352,7 @@ impl GlmOcrTextRotaryEmbedding {
 
         let section_sum: usize = cfg.rope_parameters.mrope_section.iter().sum();
         if section_sum != dim / 2 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "GLM-OCR: mrope_section sum ({section_sum}) != dim/2 ({})",
                     dim / 2
@@ -370,18 +370,18 @@ impl GlmOcrTextRotaryEmbedding {
         &self,
         x: &Tensor,
         position_ids: &Tensor,
-    ) -> Result<(Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor), Error> {
         let dtype = x.dtype();
         let dims = position_ids.dims();
         if dims.len() != 3 || dims[0] != 3 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!("GLM-OCR: position_ids must be (3, B, S), got {:?}", dims),
             });
         }
 
         let position_ids = position_ids.to_dtype(DType::F32).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: position_ids cast",
                 e,
             )
@@ -389,14 +389,14 @@ impl GlmOcrTextRotaryEmbedding {
 
         let inv_len = self.inv_freq.dims1().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: inv_freq dims1",
                 e,
             )
         })?;
         let inv = self.inv_freq.reshape((1, 1, 1, inv_len)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: inv_freq reshape",
                 e,
             )
@@ -405,7 +405,7 @@ impl GlmOcrTextRotaryEmbedding {
             .unsqueeze(3)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: position_ids unsqueeze",
                     e,
                 )
@@ -413,7 +413,7 @@ impl GlmOcrTextRotaryEmbedding {
             .broadcast_mul(&inv)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: freqs multiply",
                     e,
                 )
@@ -422,21 +422,21 @@ impl GlmOcrTextRotaryEmbedding {
         let freqs = apply_mrope(&freqs, &self.mrope_section)?;
         let emb = Tensor::cat(&[&freqs, &freqs], D::Minus1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: freqs cat",
                 e,
             )
         })?;
         let cos = emb.cos().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: cos",
                 e,
             )
         })?;
         let sin = emb.sin().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: sin",
                 e,
             )
@@ -444,14 +444,14 @@ impl GlmOcrTextRotaryEmbedding {
 
         let cos = cos.to_dtype(dtype).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: cos cast",
                 e,
             )
         })?;
         let sin = sin.to_dtype(dtype).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: sin cast",
                 e,
             )
@@ -468,7 +468,7 @@ struct GlmOcrTextMLP {
 }
 
 impl GlmOcrTextMLP {
-    fn load(cfg: &GlmOcrTextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &GlmOcrTextConfig, vb: VarBuilder) -> Result<Self, Error> {
         let gate_up_proj = linear_no_bias(
             cfg.hidden_size,
             cfg.intermediate_size * 2,
@@ -488,20 +488,20 @@ impl GlmOcrTextMLP {
         })
     }
 
-    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, Error> {
         let up_states = self
             .gate_up_proj
             .forward(hidden_states)
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "text gate_up_proj forward", e))?;
         let mut parts = up_states.chunk(2, D::Minus1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: gate_up_proj chunk",
                 e,
             )
         })?;
         if parts.len() != 2 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "GLM-OCR: expected 2 chunks from gate_up_proj, got {}",
                     parts.len()
@@ -536,12 +536,12 @@ struct GlmOcrTextAttention {
 }
 
 impl GlmOcrTextAttention {
-    fn load(cfg: &GlmOcrTextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &GlmOcrTextConfig, vb: VarBuilder) -> Result<Self, Error> {
         if !cfg
             .num_attention_heads
             .is_multiple_of(cfg.num_key_value_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "GLM-OCR: num_attention_heads ({}) must be divisible by num_key_value_heads ({})",
                     cfg.num_attention_heads, cfg.num_key_value_heads
@@ -597,10 +597,10 @@ impl GlmOcrTextAttention {
         hidden_states: &Tensor,
         cos: &Tensor,
         sin: &Tensor,
-    ) -> Result<(Tensor, Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor, Tensor), Error> {
         let (b, seq_len, _) = hidden_states.dims3().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: attn hidden dims3",
                 e,
             )
@@ -623,7 +623,7 @@ impl GlmOcrTextAttention {
             .reshape((b, seq_len, self.num_heads, self.head_dim))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: q reshape",
                     e,
                 )
@@ -631,7 +631,7 @@ impl GlmOcrTextAttention {
             .transpose(1, 2)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: q transpose",
                     e,
                 )
@@ -639,7 +639,7 @@ impl GlmOcrTextAttention {
             .contiguous()
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: q contiguous",
                     e,
                 )
@@ -648,7 +648,7 @@ impl GlmOcrTextAttention {
             .reshape((b, seq_len, self.num_kv_heads, self.head_dim))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: k reshape",
                     e,
                 )
@@ -656,7 +656,7 @@ impl GlmOcrTextAttention {
             .transpose(1, 2)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: k transpose",
                     e,
                 )
@@ -664,7 +664,7 @@ impl GlmOcrTextAttention {
             .contiguous()
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: k contiguous",
                     e,
                 )
@@ -673,7 +673,7 @@ impl GlmOcrTextAttention {
             .reshape((b, seq_len, self.num_kv_heads, self.head_dim))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: v reshape",
                     e,
                 )
@@ -681,7 +681,7 @@ impl GlmOcrTextAttention {
             .transpose(1, 2)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: v transpose",
                     e,
                 )
@@ -689,7 +689,7 @@ impl GlmOcrTextAttention {
             .contiguous()
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: v contiguous",
                     e,
                 )
@@ -698,14 +698,14 @@ impl GlmOcrTextAttention {
         (q, k) = apply_rotary_pos_emb(&q, &k, cos, sin)?;
         q = q.contiguous().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: q contiguous post-rope",
                 e,
             )
         })?;
         k = k.contiguous().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: k contiguous post-rope",
                 e,
             )
@@ -720,10 +720,10 @@ impl GlmOcrTextAttention {
         cos: &Tensor,
         sin: &Tensor,
         attention_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (b, seq_len, _) = hidden_states.dims3().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: attn hidden dims3",
                 e,
             )
@@ -732,7 +732,7 @@ impl GlmOcrTextAttention {
 
         let (k, v) = self.kv_cache.borrow_mut().append(&k, &v).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: kv_cache append",
                 e,
             )
@@ -765,12 +765,12 @@ impl GlmOcrTextAttention {
         attn: &Tensor,
         batch: usize,
         seq_len: usize,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let attn = attn
             .transpose(1, 2)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: attn transpose",
                     e,
                 )
@@ -778,7 +778,7 @@ impl GlmOcrTextAttention {
             .reshape((batch, seq_len, self.num_heads * self.head_dim))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: attn reshape",
                     e,
                 )
@@ -790,7 +790,7 @@ impl GlmOcrTextAttention {
     }
 
     #[cfg(feature = "cuda")]
-    fn prepare_dynamic_cache(&self, query_len: usize, cache_len: usize) -> Result<(), OCRError> {
+    fn prepare_dynamic_cache(&self, query_len: usize, cache_len: usize) -> Result<(), Error> {
         let template = Tensor::zeros(
             (1, self.num_kv_heads, query_len, self.head_dim),
             self.k_proj.weight().dtype(),
@@ -811,19 +811,19 @@ impl GlmOcrTextAttention {
         sin: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (batch, query_len, _) = hidden_states
             .dims3()
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "dynamic attention hidden shape", e))?;
         if batch != 1 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "GLM-OCR CUDA-graph attention requires batch size 1".to_string(),
             });
         }
         let (q, k, v) = self.project_qkv(hidden_states, cos, sin)?;
         let cache = self.kv_cache.borrow();
         let cache_len = cache.storage_capacity();
-        let (cache_k, cache_v) = cache.storage().ok_or_else(|| OCRError::ConfigError {
+        let (cache_k, cache_v) = cache.storage().ok_or_else(|| Error::Config {
             message: "GLM-OCR dynamic KV storage is not initialized".to_string(),
         })?;
         drop(cache);
@@ -878,7 +878,7 @@ impl GlmOcrTextAttention {
     }
 
     #[cfg(feature = "cuda")]
-    fn set_kv_cache_len(&self, len: usize) -> Result<(), OCRError> {
+    fn set_kv_cache_len(&self, len: usize) -> Result<(), Error> {
         self.kv_cache
             .borrow_mut()
             .set_current_len(len)
@@ -897,7 +897,7 @@ pub(super) struct GlmOcrTextDecoderLayer {
 }
 
 impl GlmOcrTextDecoderLayer {
-    pub(super) fn load(cfg: &GlmOcrTextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    pub(super) fn load(cfg: &GlmOcrTextConfig, vb: VarBuilder) -> Result<Self, Error> {
         let self_attn = GlmOcrTextAttention::load(cfg, vb.clone())?;
         let mlp = GlmOcrTextMLP::load(cfg, vb.clone())?;
         let input_layernorm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))
@@ -936,7 +936,7 @@ impl GlmOcrTextDecoderLayer {
         cos: &Tensor,
         sin: &Tensor,
         attention_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let residual = hidden_states.clone();
         let hidden = self
             .input_layernorm
@@ -951,7 +951,7 @@ impl GlmOcrTextDecoderLayer {
             })?;
         let hidden = (&residual + &hidden).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: text residual add",
                 e,
             )
@@ -970,7 +970,7 @@ impl GlmOcrTextDecoderLayer {
         })?;
         (&residual + &hidden).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: text residual add mlp",
                 e,
             )
@@ -985,7 +985,7 @@ impl GlmOcrTextDecoderLayer {
         sin: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let residual = hidden_states.clone();
         let hidden = self
             .input_layernorm
@@ -1002,7 +1002,7 @@ impl GlmOcrTextDecoderLayer {
             })?;
         let hidden = (&residual + &hidden).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: text residual add",
                 e,
             )
@@ -1021,7 +1021,7 @@ impl GlmOcrTextDecoderLayer {
         })?;
         (&residual + &hidden).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: text residual add mlp",
                 e,
             )
@@ -1033,7 +1033,7 @@ impl GlmOcrTextDecoderLayer {
     }
 
     #[cfg(feature = "cuda")]
-    pub(super) fn trim_kv_cache(&self, len: usize) -> Result<(), OCRError> {
+    pub(super) fn trim_kv_cache(&self, len: usize) -> Result<(), Error> {
         self.self_attn
             .kv_cache
             .borrow_mut()
@@ -1046,7 +1046,7 @@ impl GlmOcrTextDecoderLayer {
         &self,
         query_len: usize,
         cache_len: usize,
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         self.self_attn.prepare_dynamic_cache(query_len, cache_len)
     }
 
@@ -1056,7 +1056,7 @@ impl GlmOcrTextDecoderLayer {
     }
 
     #[cfg(feature = "cuda")]
-    pub(super) fn set_kv_cache_len(&self, len: usize) -> Result<(), OCRError> {
+    pub(super) fn set_kv_cache_len(&self, len: usize) -> Result<(), Error> {
         self.self_attn.set_kv_cache_len(len)
     }
 }
@@ -1098,7 +1098,7 @@ pub struct GlmOcrTextModel {
 }
 
 impl GlmOcrTextModel {
-    pub fn load(cfg: &GlmOcrTextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    pub fn load(cfg: &GlmOcrTextConfig, vb: VarBuilder) -> Result<Self, Error> {
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("embed_tokens"))
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "text embed_tokens", e))?;
         let rotary_emb = GlmOcrTextRotaryEmbedding::new(cfg, vb.device())?;
@@ -1123,7 +1123,7 @@ impl GlmOcrTextModel {
         })
     }
 
-    pub fn embed(&self, input_ids: &Tensor) -> Result<Tensor, OCRError> {
+    pub fn embed(&self, input_ids: &Tensor) -> Result<Tensor, Error> {
         self.embed_tokens
             .forward(input_ids)
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "text embed forward", e))
@@ -1138,7 +1138,7 @@ impl GlmOcrTextModel {
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
         attention_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (cos, sin) = self.rotary_emb.forward(inputs_embeds, position_ids)?;
         self.forward_prepared(inputs_embeds, &cos, &sin, attention_mask)
     }
@@ -1149,7 +1149,7 @@ impl GlmOcrTextModel {
         cos: &Tensor,
         sin: &Tensor,
         attention_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let mut hidden_states = inputs_embeds.clone();
         for layer in &self.layers {
             hidden_states = layer.forward(&hidden_states, cos, sin, attention_mask)?;
@@ -1159,7 +1159,7 @@ impl GlmOcrTextModel {
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "text norm forward", e))
     }
 
-    fn project_logits(&self, hidden_states: &Tensor, lm_head: &Linear) -> Result<Tensor, OCRError> {
+    fn project_logits(&self, hidden_states: &Tensor, lm_head: &Linear) -> Result<Tensor, Error> {
         lm_head
             .forward(hidden_states)
             .and_then(|logits| logits.i((0, 0, ..)))
@@ -1171,7 +1171,7 @@ impl GlmOcrTextModel {
         &self,
         hidden_states: &Tensor,
         lm_head: &Linear,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         lm_head
             .forward(hidden_states)
             .and_then(|logits| logits.squeeze(0))
@@ -1183,7 +1183,7 @@ impl GlmOcrTextModel {
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
         lm_head: &Linear,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         #[cfg(feature = "cuda")]
         {
             let kv_len = self.kv_cache_len().saturating_add(1);
@@ -1205,7 +1205,7 @@ impl GlmOcrTextModel {
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
         lm_head: &Linear,
-    ) -> Result<(Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor), Error> {
         let query_len = inputs_embeds
             .dim(1)
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "verification query length", e))?;
@@ -1231,7 +1231,7 @@ impl GlmOcrTextModel {
         position_ids: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (cos, sin) = self.rotary_emb.forward(inputs_embeds, position_ids)?;
         let mut hidden_states = inputs_embeds.clone();
         for layer in &self.layers {
@@ -1248,7 +1248,7 @@ impl GlmOcrTextModel {
         prompt_len: usize,
         max_new_tokens: usize,
         lm_head: &Linear,
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         if std::env::var_os("OAR_VL_DISABLE_CUDA_GRAPH").is_some()
             || std::env::var_os("OAR_GLMOCR_DISABLE_CUDA_GRAPH").is_some()
         {
@@ -1295,7 +1295,7 @@ impl GlmOcrTextModel {
         max_new_tokens: usize,
         query_len: usize,
         lm_head: &Linear,
-    ) -> Result<Option<usize>, OCRError> {
+    ) -> Result<Option<usize>, Error> {
         if query_len == 0
             || std::env::var_os("OAR_VL_DISABLE_CUDA_GRAPH").is_some()
             || std::env::var_os("OAR_GLMOCR_DISABLE_CUDA_GRAPH").is_some()
@@ -1344,7 +1344,7 @@ impl GlmOcrTextModel {
     }
 
     #[cfg(feature = "cuda")]
-    fn capture_cuda_graph(&self, cache_len: usize, lm_head: &Linear) -> Result<(), OCRError> {
+    fn capture_cuda_graph(&self, cache_len: usize, lm_head: &Linear) -> Result<(), Error> {
         use candle_core::cuda_backend::cudarc::driver::sys::{
             CUgraphInstantiate_flags_enum, CUstreamCaptureMode_enum,
         };
@@ -1417,7 +1417,7 @@ impl GlmOcrTextModel {
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
             )
             .map_err(|e| cuda_graph_error("GLM-OCR", "end decoder CUDA graph capture", e))?
-            .ok_or_else(|| OCRError::ConfigError {
+            .ok_or_else(|| Error::Config {
                 message: "GLM-OCR decoder capture returned no graph".to_string(),
             })?;
         graph
@@ -1443,7 +1443,7 @@ impl GlmOcrTextModel {
         cache_len: usize,
         query_len: usize,
         lm_head: &Linear,
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         use candle_core::cuda_backend::cudarc::driver::sys::{
             CUgraphInstantiate_flags_enum, CUstreamCaptureMode_enum,
         };
@@ -1503,7 +1503,7 @@ impl GlmOcrTextModel {
                 .map_err(|e| {
                     candle_to_ocr_inference("GLM-OCR", "captured verification argmax", e)
                 })?;
-            Ok::<_, OCRError>((hidden, tokens))
+            Ok::<_, Error>((hidden, tokens))
         })();
         let (hidden_output, token_output) = match captured_output {
             Ok(output) => output,
@@ -1519,7 +1519,7 @@ impl GlmOcrTextModel {
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
             )
             .map_err(|e| cuda_graph_error("GLM-OCR", "end verification graph capture", e))?
-            .ok_or_else(|| OCRError::ConfigError {
+            .ok_or_else(|| Error::Config {
                 message: "GLM-OCR verification capture returned no graph".to_string(),
             })?;
         graph
@@ -1547,7 +1547,7 @@ impl GlmOcrTextModel {
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
         kv_len: usize,
-    ) -> Result<Option<Tensor>, OCRError> {
+    ) -> Result<Option<Tensor>, Error> {
         let captured_ref = self.decode_graph.borrow();
         let Some(captured) = captured_ref.as_ref() else {
             return Ok(None);
@@ -1590,7 +1590,7 @@ impl GlmOcrTextModel {
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
         kv_len: usize,
-    ) -> Result<Option<(Tensor, Tensor)>, OCRError> {
+    ) -> Result<Option<(Tensor, Tensor)>, Error> {
         let captured_ref = self.verification_graph.borrow();
         let Some(captured) = captured_ref.as_ref() else {
             return Ok(None);
@@ -1650,7 +1650,7 @@ impl GlmOcrTextModel {
     }
 
     #[cfg(feature = "cuda")]
-    pub(crate) fn trim_kv_cache(&self, len: usize) -> Result<(), OCRError> {
+    pub(crate) fn trim_kv_cache(&self, len: usize) -> Result<(), Error> {
         for layer in &self.layers {
             layer.trim_kv_cache(len)?;
         }

--- a/oar-ocr-vl/src/glmocr/vision.rs
+++ b/oar-ocr-vl/src/glmocr/vision.rs
@@ -1,11 +1,11 @@
 use super::config::GlmOcrVisionConfig;
 use crate::attention::on_compute_device;
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{D, DType, Device, IndexOp, Tensor};
 use candle_nn::{
     Conv2d, Conv2dConfig, Linear, Module, RmsNorm, VarBuilder, linear_no_bias, rms_norm,
 };
-use oar_ocr_core::core::OCRError;
 
 #[derive(Debug, Clone)]
 struct GlmOcrVisionPatchEmbed {
@@ -14,7 +14,7 @@ struct GlmOcrVisionPatchEmbed {
 }
 
 impl GlmOcrVisionPatchEmbed {
-    fn load(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let vb = vb.pp("patch_embed").pp("proj");
         let weight = vb
             .get(
@@ -38,7 +38,7 @@ impl GlmOcrVisionPatchEmbed {
             .reshape((cfg.hidden_size, in_features))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: reshape patch_embed weight",
                     e,
                 )
@@ -47,24 +47,24 @@ impl GlmOcrVisionPatchEmbed {
         Ok(Self { weight, bias })
     }
 
-    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, Error> {
         let w_t = self.weight.transpose(0, 1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: patch_embed weight transpose",
                 e,
             )
         })?;
         let out = hidden_states.matmul(&w_t).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: patch_embed matmul",
                 e,
             )
         })?;
         out.broadcast_add(&self.bias).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: patch_embed bias add",
                 e,
             )
@@ -78,7 +78,7 @@ struct GlmOcrVisionRotaryEmbedding {
 }
 
 impl GlmOcrVisionRotaryEmbedding {
-    fn new(dim: usize, device: &Device, dtype: DType) -> Result<Self, OCRError> {
+    fn new(dim: usize, device: &Device, dtype: DType) -> Result<Self, Error> {
         // Shared with MinerU2.5 / PaddleOCR-VL: `1 / theta^(i/dim)` computed in
         // f64 then narrowed to f32 (theta = 10000). The subsequent dtype cast
         // dominates any f64-vs-f32 difference at the model's working precision.
@@ -86,7 +86,7 @@ impl GlmOcrVisionRotaryEmbedding {
             .to_dtype(dtype)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: cast vision inv_freq",
                     e,
                 )
@@ -94,13 +94,13 @@ impl GlmOcrVisionRotaryEmbedding {
         Ok(Self { inv_freq })
     }
 
-    fn forward(&self, seqlen: usize) -> Result<Tensor, OCRError> {
+    fn forward(&self, seqlen: usize) -> Result<Tensor, Error> {
         let device = self.inv_freq.device();
         let dtype = self.inv_freq.dtype();
 
         let inv_len = self.inv_freq.dims1().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision inv_freq dims1",
                 e,
             )
@@ -121,7 +121,7 @@ impl GlmOcrVisionRotaryEmbedding {
         })
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision rope forward failed",
                 e,
             )
@@ -134,17 +134,17 @@ fn apply_rotary_pos_emb_vision(
     k: &Tensor,
     cos: &Tensor,
     sin: &Tensor,
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     let cos = cos.unsqueeze(D::Minus2).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: vision cos unsqueeze",
             e,
         )
     })?;
     let sin = sin.unsqueeze(D::Minus2).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: vision sin unsqueeze",
             e,
         )
@@ -155,21 +155,21 @@ fn apply_rotary_pos_emb_vision(
 
     let q_mul = q.broadcast_mul(&cos).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: vision q*cos",
             e,
         )
     })?;
     let q_rot_mul = q_rot.broadcast_mul(&sin).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: vision rotate_half(q)*sin",
             e,
         )
     })?;
     let q_out = (&q_mul + &q_rot_mul).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: vision q apply rope",
             e,
         )
@@ -177,21 +177,21 @@ fn apply_rotary_pos_emb_vision(
 
     let k_mul = k.broadcast_mul(&cos).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: vision k*cos",
             e,
         )
     })?;
     let k_rot_mul = k_rot.broadcast_mul(&sin).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: vision rotate_half(k)*sin",
             e,
         )
     })?;
     let k_out = (&k_mul + &k_rot_mul).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "GLM-OCR: vision k apply rope",
             e,
         )
@@ -211,7 +211,7 @@ struct GlmOcrVisionAttention {
 }
 
 impl GlmOcrVisionAttention {
-    fn load(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let qkv = candle_nn::linear_b(
             cfg.hidden_size,
             cfg.hidden_size * 3,
@@ -244,15 +244,10 @@ impl GlmOcrVisionAttention {
         })
     }
 
-    fn forward(
-        &self,
-        hidden_states: &Tensor,
-        cos: &Tensor,
-        sin: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let seq_len = hidden_states.dim(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision attention seq_len",
                 e,
             )
@@ -265,7 +260,7 @@ impl GlmOcrVisionAttention {
             .reshape((seq_len, 3, self.num_heads, self.head_dim))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision qkv reshape",
                     e,
                 )
@@ -273,21 +268,21 @@ impl GlmOcrVisionAttention {
 
         let q = qkv.i((.., 0, .., ..)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision q slice",
                 e,
             )
         })?;
         let k = qkv.i((.., 1, .., ..)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision k slice",
                 e,
             )
         })?;
         let v = qkv.i((.., 2, .., ..)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision v slice",
                 e,
             )
@@ -308,7 +303,7 @@ impl GlmOcrVisionAttention {
             .transpose(0, 1)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision q transpose",
                     e,
                 )
@@ -316,7 +311,7 @@ impl GlmOcrVisionAttention {
             .contiguous()
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision q contiguous",
                     e,
                 )
@@ -325,7 +320,7 @@ impl GlmOcrVisionAttention {
             .transpose(0, 1)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision k transpose",
                     e,
                 )
@@ -333,7 +328,7 @@ impl GlmOcrVisionAttention {
             .contiguous()
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision k contiguous",
                     e,
                 )
@@ -342,7 +337,7 @@ impl GlmOcrVisionAttention {
             .transpose(0, 1)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision v transpose",
                     e,
                 )
@@ -350,7 +345,7 @@ impl GlmOcrVisionAttention {
             .contiguous()
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision v contiguous",
                     e,
                 )
@@ -358,21 +353,21 @@ impl GlmOcrVisionAttention {
 
         let q = q.unsqueeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision q unsqueeze",
                 e,
             )
         })?;
         let k = k.unsqueeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision k unsqueeze",
                 e,
             )
         })?;
         let v = v.unsqueeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision v unsqueeze",
                 e,
             )
@@ -385,7 +380,7 @@ impl GlmOcrVisionAttention {
             .transpose(1, 2)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision attn transpose",
                     e,
                 )
@@ -393,7 +388,7 @@ impl GlmOcrVisionAttention {
             .reshape((seq_len, self.num_heads * self.head_dim))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision attn reshape",
                     e,
                 )
@@ -414,7 +409,7 @@ struct GlmOcrVisionMlp {
 }
 
 impl GlmOcrVisionMlp {
-    fn load(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let gate_proj = candle_nn::linear_b(
             cfg.hidden_size,
             cfg.intermediate_size,
@@ -445,7 +440,7 @@ impl GlmOcrVisionMlp {
         })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, Error> {
         let gate = self
             .gate_proj
             .forward(xs)
@@ -474,7 +469,7 @@ struct GlmOcrVisionBlock {
 }
 
 impl GlmOcrVisionBlock {
-    fn load_block(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load_block(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let norm1 = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("norm1"))
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "vision norm1", e))?;
         let norm2 = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("norm2"))
@@ -489,12 +484,7 @@ impl GlmOcrVisionBlock {
         })
     }
 
-    fn forward(
-        &self,
-        hidden_states: &Tensor,
-        cos: &Tensor,
-        sin: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let normed = self
             .norm1
             .forward(hidden_states)
@@ -502,7 +492,7 @@ impl GlmOcrVisionBlock {
         let attn_out = self.attn.forward(&normed, cos, sin)?;
         let hidden_states = (hidden_states + attn_out).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision residual add",
                 e,
             )
@@ -514,7 +504,7 @@ impl GlmOcrVisionBlock {
         let mlp_out = self.mlp.forward(&normed)?;
         (hidden_states + mlp_out).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision residual add mlp",
                 e,
             )
@@ -533,7 +523,7 @@ struct GlmOcrVisionPatchMerger {
 }
 
 impl GlmOcrVisionPatchMerger {
-    fn load(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let proj = linear_no_bias(cfg.out_hidden_size, cfg.out_hidden_size, vb.pp("proj"))
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "vision merger proj", e))?;
         let ln_cfg = candle_nn::LayerNormConfig {
@@ -565,7 +555,7 @@ impl GlmOcrVisionPatchMerger {
         })
     }
 
-    fn forward(&self, hidden_state: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_state: &Tensor) -> Result<Tensor, Error> {
         let hidden_state = self
             .proj
             .forward(hidden_state)
@@ -610,7 +600,7 @@ pub struct GlmOcrVisionModel {
 }
 
 impl GlmOcrVisionModel {
-    pub fn load(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    pub fn load(cfg: &GlmOcrVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let patch_embed = GlmOcrVisionPatchEmbed::load(cfg, vb.clone())?;
 
         let head_dim = cfg.hidden_size / cfg.num_heads;
@@ -657,7 +647,7 @@ impl GlmOcrVisionModel {
         })
     }
 
-    fn rot_pos_emb(&self, grid_thw: (usize, usize, usize)) -> Result<Tensor, OCRError> {
+    fn rot_pos_emb(&self, grid_thw: (usize, usize, usize)) -> Result<Tensor, Error> {
         let (_t, h, w) = grid_thw;
         let merge = self.cfg.spatial_merge_size;
         let device = self.patch_embed.weight.device();
@@ -673,7 +663,7 @@ impl GlmOcrVisionModel {
         })
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision hpos computation failed",
                 e,
             )
@@ -689,7 +679,7 @@ impl GlmOcrVisionModel {
         })
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision wpos computation failed",
                 e,
             )
@@ -697,7 +687,7 @@ impl GlmOcrVisionModel {
 
         let pos_ids = Tensor::stack(&[&hpos, &wpos], D::Minus1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision pos_ids stack",
                 e,
             )
@@ -707,7 +697,7 @@ impl GlmOcrVisionModel {
         let rotary_full = self.rotary_pos_emb.forward(max_grid)?;
         let pos_ids_flat = pos_ids.flatten(0, 1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision pos_ids flatten",
                 e,
             )
@@ -716,7 +706,7 @@ impl GlmOcrVisionModel {
             .index_select(&pos_ids_flat, 0)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision rotary index_select",
                     e,
                 )
@@ -724,21 +714,21 @@ impl GlmOcrVisionModel {
             .reshape((
                 pos_ids.dim(0).map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "GLM-OCR: vision pos_ids dim0",
                         e,
                     )
                 })?,
                 pos_ids.dim(1).map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "GLM-OCR: vision pos_ids dim1",
                         e,
                     )
                 })?,
                 rotary_full.dim(1).map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "GLM-OCR: vision rotary dim1",
                         e,
                     )
@@ -746,7 +736,7 @@ impl GlmOcrVisionModel {
             ))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision rotary reshape",
                     e,
                 )
@@ -754,7 +744,7 @@ impl GlmOcrVisionModel {
             .flatten(1, 2)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision rotary flatten",
                     e,
                 )
@@ -767,27 +757,27 @@ impl GlmOcrVisionModel {
         &self,
         pixel_values: &Tensor,
         grid_thw: (usize, usize, usize),
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let mut hidden_states = self.patch_embed.forward(pixel_values)?;
 
         let rotary_pos_emb = self.rot_pos_emb(grid_thw)?;
         let emb = Tensor::cat(&[&rotary_pos_emb, &rotary_pos_emb], D::Minus1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision rotary cat",
                 e,
             )
         })?;
         let cos = emb.cos().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision cos",
                 e,
             )
         })?;
         let sin = emb.sin().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision sin",
                 e,
             )
@@ -805,7 +795,7 @@ impl GlmOcrVisionModel {
         let merge = self.cfg.spatial_merge_size;
         let seq_len = hidden_states.dim(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "GLM-OCR: vision seq_len",
                 e,
             )
@@ -819,7 +809,7 @@ impl GlmOcrVisionModel {
             ))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision merge reshape",
                     e,
                 )
@@ -827,7 +817,7 @@ impl GlmOcrVisionModel {
             .permute((0, 3, 1, 2))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision merge permute",
                     e,
                 )
@@ -841,7 +831,7 @@ impl GlmOcrVisionModel {
             .reshape((
                 hidden.dim(0).map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "GLM-OCR: vision downsample dim0",
                         e,
                     )
@@ -850,7 +840,7 @@ impl GlmOcrVisionModel {
             ))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "GLM-OCR: vision downsample reshape",
                     e,
                 )

--- a/oar-ocr-vl/src/hpd_parsing/config.rs
+++ b/oar-ocr-vl/src/hpd_parsing/config.rs
@@ -1,5 +1,5 @@
+use crate::error::Error;
 use crate::mineru_diffusion::SdarConfig;
-use oar_ocr_core::core::OCRError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -66,17 +66,17 @@ fn default_max_patches() -> usize {
 }
 
 impl HpdParsingConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         let cfg: Self = crate::utils::load_json_config(path, "HPD-Parsing", "config.json")?;
         cfg.validate()?;
         Ok(cfg)
     }
 
-    pub fn image_tokens_per_tile(&self) -> Result<usize, OCRError> {
+    pub fn image_tokens_per_tile(&self) -> Result<usize, Error> {
         let grid = self.force_image_size / self.vision_config.patch_size;
         let downsample = (1.0 / self.downsample_ratio).round() as usize;
         if downsample == 0 || !grid.is_multiple_of(downsample) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HPD-Parsing patch grid {grid} is incompatible with downsample_ratio {}",
                     self.downsample_ratio
@@ -86,7 +86,7 @@ impl HpdParsingConfig {
         Ok((grid / downsample).pow(2))
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         let vision = &self.vision_config;
         if vision.hidden_size == 0
             || vision.intermediate_size == 0
@@ -97,7 +97,7 @@ impl HpdParsingConfig {
             || self.min_dynamic_patch == 0
             || self.max_dynamic_patch < self.min_dynamic_patch
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "HPD-Parsing dimensions and patch limits must be non-zero and ordered"
                     .to_string(),
             });
@@ -109,14 +109,14 @@ impl HpdParsingConfig {
                 .is_multiple_of(vision.num_attention_heads)
             || !self.force_image_size.is_multiple_of(vision.patch_size)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message:
                     "HPD-Parsing requires RGB square InternViT tiles with a valid head/patch split"
                         .to_string(),
             });
         }
         if vision.hidden_act != "gelu" || vision.norm_type != "layer_norm" {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HPD-Parsing unsupported InternViT activation/norm: {}/{}",
                     vision.hidden_act, vision.norm_type
@@ -124,7 +124,7 @@ impl HpdParsingConfig {
             });
         }
         if !(0.0 < self.downsample_ratio && self.downsample_ratio <= 1.0) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "HPD-Parsing downsample_ratio must be in (0, 1]".to_string(),
             });
         }

--- a/oar-ocr-vl/src/hpd_parsing/model.rs
+++ b/oar-ocr-vl/src/hpd_parsing/model.rs
@@ -3,12 +3,12 @@ use super::processing::{HpdImageInputs, preprocess_image};
 use super::vision::HpdVisionModel;
 #[cfg(feature = "cuda")]
 use crate::cuda_kernels::{ArgmaxFirstBf16, ArgmaxFirstF32};
+use crate::error::Error;
 use crate::mineru_diffusion::text::{SdarKvCache, SdarModel};
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{D, DType, Device, IndexOp, Tensor};
 use candle_nn::{Linear, Module, RmsNorm, VarBuilder, linear_no_bias, rms_norm};
 use image::RgbImage;
-use oar_ocr_core::core::OCRError;
 use std::collections::VecDeque;
 use std::path::Path;
 use tokenizers::Tokenizer;
@@ -41,16 +41,16 @@ impl Default for HpdGenerationConfig {
 }
 
 impl HpdGenerationConfig {
-    fn validate(&self) -> Result<(), OCRError> {
+    fn validate(&self) -> Result<(), Error> {
         if self.use_mtp && self.num_speculative_tokens == 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message:
                     "HPD-Parsing num_speculative_tokens must be non-zero when P-MTP is enabled"
                         .to_string(),
             });
         }
         if self.max_active_branches == 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "HPD-Parsing max_active_branches must be non-zero".to_string(),
             });
         }
@@ -91,7 +91,7 @@ struct MtpHead {
 }
 
 impl MtpHead {
-    fn load(cfg: &crate::mineru_diffusion::SdarConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &crate::mineru_diffusion::SdarConfig, vb: VarBuilder) -> Result<Self, Error> {
         let load_linear = |input, output, vb, name| {
             linear_no_bias(input, output, vb)
                 .map_err(|e| candle_to_ocr_inference(MODEL_NAME, name, e))
@@ -138,7 +138,7 @@ impl MtpHead {
         })
     }
 
-    fn step(&self, hidden: &Tensor, previous_embedding: &Tensor) -> Result<Tensor, OCRError> {
+    fn step(&self, hidden: &Tensor, previous_embedding: &Tensor) -> Result<Tensor, Error> {
         let hidden = self
             .pre_fc_norm_hidden
             .forward(hidden)
@@ -165,7 +165,7 @@ impl MtpHead {
         self.norm
             .forward(&(fused + mlp).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HPD P-MTP residual",
                     e,
                 )
@@ -219,14 +219,13 @@ pub struct HpdParsing {
 }
 
 impl HpdParsing {
-    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, OCRError> {
+    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, Error> {
         let model_dir = model_dir.as_ref();
         let cfg = HpdParsingConfig::from_path(model_dir.join("config.json"))?;
-        let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| {
-            OCRError::ConfigError {
+        let tokenizer =
+            Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| Error::Config {
                 message: format!("HPD-Parsing failed to load tokenizer.json: {e}"),
-            }
-        })?;
+            })?;
         let image_context_token_id = require_token(&tokenizer, IMAGE_CONTEXT_TOKEN, Some(151671))?;
         require_token(&tokenizer, "<img>", Some(151669))?;
         require_token(&tokenizer, "</img>", Some(151670))?;
@@ -270,7 +269,7 @@ impl HpdParsing {
         &self,
         images: &[RgbImage],
         generation: &HpdGenerationConfig,
-    ) -> Vec<Result<String, OCRError>> {
+    ) -> Vec<Result<String, Error>> {
         images
             .iter()
             .map(|image| {
@@ -286,9 +285,9 @@ impl HpdParsing {
         images: &[RgbImage],
         prompts: &[impl AsRef<str>],
         generation: &HpdGenerationConfig,
-    ) -> Vec<Result<String, OCRError>> {
+    ) -> Vec<Result<String, Error>> {
         if images.len() != prompts.len() {
-            return vec![Err(OCRError::InvalidInput {
+            return vec![Err(Error::InvalidInput {
                 message: format!(
                     "HPD-Parsing image count {} != prompt count {}",
                     images.len(),
@@ -312,7 +311,7 @@ impl HpdParsing {
         image: &RgbImage,
         instruction: &str,
         generation: &HpdGenerationConfig,
-    ) -> Result<HpdOutput, OCRError> {
+    ) -> Result<HpdOutput, Error> {
         generation.validate()?;
         if generation.max_new_tokens == 0 {
             return Ok(HpdOutput {
@@ -326,12 +325,12 @@ impl HpdParsing {
         let image_inputs = preprocess_image(image, &self.cfg, &self.device, self.dtype)?;
         let image_tokens = self.cfg.image_tokens_per_tile()? * image_inputs.num_tiles;
         let prompt = build_prompt(instruction, image_tokens);
-        let encoding =
-            self.tokenizer
-                .encode(prompt, false)
-                .map_err(|e| OCRError::InvalidInput {
-                    message: format!("HPD-Parsing tokenizer encode failed: {e}"),
-                })?;
+        let encoding = self
+            .tokenizer
+            .encode(prompt, false)
+            .map_err(|e| Error::InvalidInput {
+                message: format!("HPD-Parsing tokenizer encode failed: {e}"),
+            })?;
         let prompt_ids = encoding.get_ids();
         validate_generation_length(
             prompt_ids.len(),
@@ -385,7 +384,7 @@ impl HpdParsing {
         &self,
         input_ids: &[u32],
         image_inputs: &HpdImageInputs,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let token_tensor = Tensor::new(input_ids, &self.device)
             .and_then(|x| x.unsqueeze(0))
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "create prompt IDs", e))?;
@@ -404,7 +403,7 @@ impl HpdParsing {
             .dim(0)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read image token count", e))?;
         if positions.len() != image_len || positions.is_empty() {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "HPD-Parsing image placeholder count {} != image embedding count {image_len}",
                     positions.len()
@@ -417,7 +416,7 @@ impl HpdParsing {
             .enumerate()
             .any(|(offset, &position)| position != start + offset)
         {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "HPD-Parsing image placeholders must be contiguous".to_string(),
             });
         }
@@ -442,14 +441,14 @@ impl HpdParsing {
         max_new_tokens: usize,
         kind: BranchKind,
         allow_fork: bool,
-    ) -> Result<BranchState, OCRError> {
+    ) -> Result<BranchState, Error> {
         let hidden = self.lm_forward(first_embeddings, &mut cache)?;
         let producer_hidden = last_hidden(&hidden)?;
         let pending_token = select_last_greedy(&self.text.lm_logits(&hidden)?)?;
         let mut tokens = Vec::new();
         tokens
             .try_reserve_exact(max_new_tokens)
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("HPD-Parsing cannot reserve generated tokens: {e}"),
             })?;
         Ok(BranchState {
@@ -468,7 +467,7 @@ impl HpdParsing {
         &self,
         parent: BranchState,
         generation: &HpdGenerationConfig,
-    ) -> Result<SchedulerOutput, OCRError> {
+    ) -> Result<SchedulerOutput, Error> {
         let mut active = vec![parent];
         let mut waiting = VecDeque::new();
         let mut parent_tokens = None;
@@ -506,7 +505,7 @@ impl HpdParsing {
                     .max_position_embeddings
                     .saturating_sub(event.prefix_len + 1);
                 if remaining == 0 {
-                    return Err(OCRError::InvalidInput {
+                    return Err(Error::InvalidInput {
                         message: format!(
                             "HPD-Parsing child at KV position {} has no context capacity",
                             event.prefix_len
@@ -555,7 +554,7 @@ impl HpdParsing {
             }
         }
 
-        let parent_tokens = parent_tokens.ok_or_else(|| OCRError::InvalidInput {
+        let parent_tokens = parent_tokens.ok_or_else(|| Error::InvalidInput {
             message: "HPD scheduler terminated without a parent result".to_string(),
         })?;
         Ok(SchedulerOutput {
@@ -565,10 +564,7 @@ impl HpdParsing {
         })
     }
 
-    fn advance_greedy_batch(
-        &self,
-        branches: &mut [BranchState],
-    ) -> Result<Vec<ForkEvent>, OCRError> {
+    fn advance_greedy_batch(&self, branches: &mut [BranchState]) -> Result<Vec<ForkEvent>, Error> {
         let ids = branches.iter().map(|b| b.pending_token).collect::<Vec<_>>();
         let input = Tensor::from_vec(ids, (branches.len(), 1), &self.device)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "create greedy batch", e))?;
@@ -607,7 +603,7 @@ impl HpdParsing {
         branches: &mut [BranchState],
         generation: &HpdGenerationConfig,
         stats: &mut HpdRuntimeStats,
-    ) -> Result<Vec<ForkEvent>, OCRError> {
+    ) -> Result<Vec<ForkEvent>, Error> {
         let batch = branches.len();
         let k = branches
             .iter()
@@ -723,7 +719,7 @@ impl HpdParsing {
             self.stop_token_ids.contains(&token) || branch.tokens.len() >= branch.max_new_tokens;
     }
 
-    fn lm_forward(&self, embeddings: &Tensor, cache: &mut SdarKvCache) -> Result<Tensor, OCRError> {
+    fn lm_forward(&self, embeddings: &Tensor, cache: &mut SdarKvCache) -> Result<Tensor, Error> {
         let seq_len = embeddings
             .dim(1)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read decoder input length", e))?;
@@ -733,10 +729,10 @@ impl HpdParsing {
             .forward_causal(embeddings, &positions, cache, true)
     }
 
-    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, Error> {
         decode_protocol_tokens(&self.tokenizer, tokens, &self.stop_token_ids)
             .map(|text| text.trim().to_string())
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("HPD-Parsing tokenizer decode failed: {e}"),
             })
     }
@@ -765,20 +761,14 @@ fn build_prompt(instruction: &str, image_tokens: usize) -> String {
     prompt
 }
 
-fn require_token(
-    tokenizer: &Tokenizer,
-    token: &str,
-    expected: Option<u32>,
-) -> Result<u32, OCRError> {
-    let id = tokenizer
-        .token_to_id(token)
-        .ok_or_else(|| OCRError::ConfigError {
-            message: format!("HPD-Parsing tokenizer is missing {token:?}"),
-        })?;
+fn require_token(tokenizer: &Tokenizer, token: &str, expected: Option<u32>) -> Result<u32, Error> {
+    let id = tokenizer.token_to_id(token).ok_or_else(|| Error::Config {
+        message: format!("HPD-Parsing tokenizer is missing {token:?}"),
+    })?;
     if let Some(expected) = expected
         && id != expected
     {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "HPD-Parsing token {token:?} id mismatch: tokenizer {id} != config {expected}"
             ),
@@ -791,15 +781,14 @@ fn validate_generation_length(
     prompt_len: usize,
     max_new_tokens: usize,
     context_limit: usize,
-) -> Result<(), OCRError> {
-    let requested =
-        prompt_len
-            .checked_add(max_new_tokens)
-            .ok_or_else(|| OCRError::InvalidInput {
-                message: "HPD-Parsing requested sequence length overflows usize".to_string(),
-            })?;
+) -> Result<(), Error> {
+    let requested = prompt_len
+        .checked_add(max_new_tokens)
+        .ok_or_else(|| Error::InvalidInput {
+            message: "HPD-Parsing requested sequence length overflows usize".to_string(),
+        })?;
     if requested > context_limit {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "HPD-Parsing prompt ({prompt_len}) plus max_new_tokens ({max_new_tokens}) exceeds context limit {context_limit}"
             ),
@@ -808,7 +797,7 @@ fn validate_generation_length(
     Ok(())
 }
 
-fn last_hidden(hidden: &Tensor) -> Result<Tensor, OCRError> {
+fn last_hidden(hidden: &Tensor) -> Result<Tensor, Error> {
     let len = hidden
         .dim(1)
         .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read hidden length", e))?;
@@ -817,7 +806,7 @@ fn last_hidden(hidden: &Tensor) -> Result<Tensor, OCRError> {
         .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "select last hidden", e))
 }
 
-fn greedy_batch_rows(logits: &Tensor) -> Result<Vec<Vec<u32>>, OCRError> {
+fn greedy_batch_rows(logits: &Tensor) -> Result<Vec<Vec<u32>>, Error> {
     let (batch, seq_len, vocab) = logits
         .dims3()
         .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read batched logits shape", e))?;
@@ -825,7 +814,7 @@ fn greedy_batch_rows(logits: &Tensor) -> Result<Vec<Vec<u32>>, OCRError> {
     if logits.device().is_cuda() && matches!(logits.dtype(), DType::BF16 | DType::F32) {
         let rows = batch
             .checked_mul(seq_len)
-            .ok_or_else(|| OCRError::InvalidInput {
+            .ok_or_else(|| Error::InvalidInput {
                 message: "HPD batched logits row count overflows usize".to_string(),
             })?;
         let logits = logits
@@ -847,7 +836,7 @@ fn greedy_batch_rows(logits: &Tensor) -> Result<Vec<Vec<u32>>, OCRError> {
         .and_then(|ids| ids.to_vec2::<u32>())
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HPD batched verification argmax",
                 e,
             )
@@ -870,18 +859,18 @@ fn decode_protocol_tokens(
     tokenizer.decode(&visible, false)
 }
 
-fn greedy_batch_last(logits: &Tensor) -> Result<Vec<u32>, OCRError> {
+fn greedy_batch_last(logits: &Tensor) -> Result<Vec<u32>, Error> {
     let rows = greedy_batch_rows(logits)?;
     rows.into_iter()
         .map(|row| {
-            row.last().copied().ok_or_else(|| OCRError::InvalidInput {
+            row.last().copied().ok_or_else(|| Error::InvalidInput {
                 message: "HPD received an empty logits row".to_string(),
             })
         })
         .collect()
 }
 
-fn select_last_greedy(logits: &Tensor) -> Result<u32, OCRError> {
+fn select_last_greedy(logits: &Tensor) -> Result<u32, Error> {
     let (_, seq_len, vocab) = logits
         .dims3()
         .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read logits shape", e))?;
@@ -911,7 +900,7 @@ fn select_last_greedy(logits: &Tensor) -> Result<u32, OCRError> {
         .and_then(|id| id.to_scalar::<u32>())
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HPD greedy argmax",
                 e,
             )

--- a/oar-ocr-vl/src/hpd_parsing/processing.rs
+++ b/oar-ocr-vl/src/hpd_parsing/processing.rs
@@ -1,8 +1,8 @@
 use super::config::HpdParsingConfig;
+use crate::error::Error;
 use crate::utils::image::{image_to_chw, patchify_merge_grouped};
 use candle_core::{DType, Device, Tensor};
 use image::{RgbImage, imageops::FilterType};
-use oar_ocr_core::core::OCRError;
 
 const IMAGENET_MEAN: [f32; 3] = [0.485, 0.456, 0.406];
 const IMAGENET_STD: [f32; 3] = [0.229, 0.224, 0.225];
@@ -19,9 +19,9 @@ pub fn preprocess_image(
     cfg: &HpdParsingConfig,
     device: &Device,
     dtype: DType,
-) -> Result<HpdImageInputs, OCRError> {
+) -> Result<HpdImageInputs, Error> {
     if image.width() == 0 || image.height() == 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "HPD-Parsing cannot process an empty image".to_string(),
         });
     }

--- a/oar-ocr-vl/src/hpd_parsing/vision.rs
+++ b/oar-ocr-vl/src/hpd_parsing/vision.rs
@@ -3,21 +3,17 @@ use crate::attention::{
     VISION_CHUNKED_ATTN_CHUNK_SIZE, VISION_CHUNKED_ATTN_SEQ_THRESHOLD, chunked_vision_attention,
     flash_attention, scaled_dot_product_attention,
 };
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{IndexOp, Tensor};
 use candle_nn::{
     LayerNorm, LayerNormConfig, Linear, Module, VarBuilder, layer_norm, linear, linear_no_bias,
 };
-use oar_ocr_core::core::OCRError;
 
 const MODEL_NAME: &str = "HPD-Parsing";
 
-fn proc_err(stage: &'static str, error: candle_core::Error) -> OCRError {
-    candle_to_ocr_processing(
-        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
-        stage,
-        error,
-    )
+fn proc_err(stage: &'static str, error: candle_core::Error) -> Error {
+    candle_to_ocr_processing(crate::error::ProcessingStage::TensorOperation, stage, error)
 }
 
 #[derive(Debug, Clone)]
@@ -30,7 +26,7 @@ struct InternAttention {
 }
 
 impl InternAttention {
-    fn load(cfg: &HpdVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &HpdVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let qkv = if cfg.qkv_bias {
             linear(cfg.hidden_size, cfg.hidden_size * 3, vb.pp("qkv"))
         } else {
@@ -51,7 +47,7 @@ impl InternAttention {
         })
     }
 
-    fn forward(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         let (batch, seq_len, _) = hidden
             .dims3()
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read vision attention shape", e))?;
@@ -60,7 +56,7 @@ impl InternAttention {
             .forward(hidden)
             .and_then(|x| x.reshape((batch, seq_len, 3, self.num_heads, self.head_dim)))
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "project vision qkv", e))?;
-        let prepare = |index| -> Result<Tensor, OCRError> {
+        let prepare = |index| -> Result<Tensor, Error> {
             qkv.i((.., .., index, .., ..))
                 .and_then(|x| x.transpose(1, 2))
                 .and_then(|x| x.contiguous())
@@ -99,7 +95,7 @@ struct InternMlp {
 }
 
 impl InternMlp {
-    fn load(cfg: &HpdVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &HpdVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         Ok(Self {
             fc1: linear(cfg.hidden_size, cfg.intermediate_size, vb.pp("fc1"))
                 .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision MLP fc1", e))?,
@@ -108,7 +104,7 @@ impl InternMlp {
         })
     }
 
-    fn forward(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         let hidden = self
             .fc1
             .forward(hidden)
@@ -131,7 +127,7 @@ struct InternBlock {
 }
 
 impl InternBlock {
-    fn load(cfg: &HpdVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &HpdVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let norm_cfg = LayerNormConfig {
             eps: cfg.layer_norm_eps,
             ..Default::default()
@@ -152,7 +148,7 @@ impl InternBlock {
         })
     }
 
-    fn forward(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         let attention = self
             .norm1
             .forward(hidden)
@@ -189,7 +185,7 @@ pub struct HpdVisionModel {
 }
 
 impl HpdVisionModel {
-    pub fn load(cfg: &HpdParsingConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    pub fn load(cfg: &HpdParsingConfig, vb: VarBuilder) -> Result<Self, Error> {
         let vision = &cfg.vision_config;
         let patch_dim = vision.num_channels * vision.patch_size * vision.patch_size;
         let patch_weight = vb
@@ -267,12 +263,12 @@ impl HpdVisionModel {
     }
 
     /// Encode `(tiles, grid², patch_dim)` to `(tiles * image_tokens, llm_hidden)`.
-    pub fn forward(&self, patches: &Tensor) -> Result<Tensor, OCRError> {
+    pub fn forward(&self, patches: &Tensor) -> Result<Tensor, Error> {
         let (tiles, patch_count, patch_width) = patches
             .dims3()
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read image patch shape", e))?;
         if patch_count != self.grid * self.grid {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "HPD-Parsing received {patch_count} patches per tile, expected {}",
                     self.grid * self.grid
@@ -359,7 +355,7 @@ mod tests {
     }
 
     #[test]
-    fn qkv_bias_config_controls_only_qkv_projection() -> Result<(), OCRError> {
+    fn qkv_bias_config_controls_only_qkv_projection() -> Result<(), Error> {
         for qkv_bias in [false, true] {
             let variables = VarMap::new();
             let vb = VarBuilder::from_varmap(&variables, DType::F32, &Device::Cpu);

--- a/oar-ocr-vl/src/hunyuanocr/config.rs
+++ b/oar-ocr-vl/src/hunyuanocr/config.rs
@@ -1,4 +1,4 @@
-use oar_ocr_core::core::OCRError;
+use crate::error::Error;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -95,7 +95,7 @@ pub struct HunyuanOcrConfig {
 }
 
 impl HunyuanOcrConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         crate::utils::load_json_config(path, "HunyuanOCR", "config.json")
     }
 
@@ -127,11 +127,11 @@ pub struct HunyuanOcrImageProcessorConfig {
 }
 
 impl HunyuanOcrImageProcessorConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         crate::utils::load_json_config(path, "HunyuanOCR", "preprocessor_config.json")
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         crate::utils::validate_image_mean_std("HunyuanOCR", &self.image_mean, &self.image_std)?;
         crate::utils::validate_patch_merge_temporal(
             "HunyuanOCR",

--- a/oar-ocr-vl/src/hunyuanocr/dflash.rs
+++ b/oar-ocr-vl/src/hunyuanocr/dflash.rs
@@ -15,19 +15,19 @@ use crate::attention::{RotaryEmbedding, flash_attention, scaled_dot_product_atte
 use crate::cuda_kernels::ArgmaxFirstBf16;
 #[cfg(feature = "cuda")]
 use crate::decoder_graph::{CudaGraphKvLengths, cuda_graph_error, sync_graph_tensor};
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing, rotate_half};
 use candle_core::{D, DType, Device, Tensor};
 use candle_nn::{Linear, Module, RmsNorm, VarBuilder, linear_no_bias, rms_norm};
-use oar_ocr_core::core::OCRError;
 use serde::Deserialize;
 use std::cell::RefCell;
 use std::path::Path;
 
 const ROPE_CACHE_LEN: usize = 16_384;
 
-fn tensor_err(message: &'static str, error: candle_core::Error) -> OCRError {
+fn tensor_err(message: &'static str, error: candle_core::Error) -> Error {
     candle_to_ocr_processing(
-        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+        crate::error::ProcessingStage::TensorOperation,
         message,
         error,
     )
@@ -56,16 +56,16 @@ pub struct DFlashConfig {
 }
 
 impl DFlashConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         crate::utils::load_json_config(path, "HunyuanOCR DFlash", "config.json")
     }
 
-    fn validate(&self) -> Result<(), OCRError> {
+    fn validate(&self) -> Result<(), Error> {
         if self.block_size < 2
             || self.num_hidden_layers == 0
             || self.dflash_config.target_layer_ids.is_empty()
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "HunyuanOCR DFlash: block size must be at least 2, and layer count and target layers must be non-zero".to_string(),
             });
         }
@@ -73,7 +73,7 @@ impl DFlashConfig {
             .num_attention_heads
             .is_multiple_of(self.num_key_value_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR DFlash: {} attention heads is not divisible by {} KV heads",
                     self.num_attention_heads, self.num_key_value_heads
@@ -130,7 +130,7 @@ impl ContextKv {
         template_k: &Tensor,
         template_v: &Tensor,
         required: usize,
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         let (_, heads, _, head_dim) = template_k
             .dims4()
             .map_err(|e| tensor_err("HunyuanOCR DFlash: context template shape", e))?;
@@ -214,7 +214,7 @@ impl ContextKv {
     }
 
     #[cfg(feature = "cuda")]
-    fn initialize_storage(&mut self, template: &Tensor) -> Result<(), OCRError> {
+    fn initialize_storage(&mut self, template: &Tensor) -> Result<(), Error> {
         self.ensure_capacity(template, template, self.capacity)
     }
 
@@ -226,7 +226,7 @@ impl ContextKv {
             .map(|((k, v), table)| (k, v, table))
     }
 
-    fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(), OCRError> {
+    fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(), Error> {
         let added = k
             .dim(2)
             .map_err(|e| tensor_err("HunyuanOCR DFlash: context K length", e))?;
@@ -282,9 +282,9 @@ impl ContextKv {
     /// Place the transient bonus+mask K/V immediately after the accepted
     /// context. The logical context length is unchanged, so the next accepted
     /// append overwrites this tail instead of copying the whole history.
-    fn with_queries(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor), OCRError> {
+    fn with_queries(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor), Error> {
         if self.len == 0 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "HunyuanOCR DFlash: context cache is empty".to_string(),
             });
         }
@@ -334,7 +334,7 @@ impl ContextKv {
     }
 }
 
-fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, OCRError> {
+fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
     let a = x
         .broadcast_mul(cos)
         .map_err(|e| tensor_err("HunyuanOCR DFlash: rope x*cos", e))?;
@@ -358,7 +358,7 @@ struct DFlashAttention {
 }
 
 impl DFlashAttention {
-    fn load(cfg: &DFlashConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &DFlashConfig, vb: VarBuilder) -> Result<Self, Error> {
         let q_proj = linear_no_bias(
             cfg.hidden_size,
             cfg.num_attention_heads * cfg.head_dim,
@@ -408,7 +408,7 @@ impl DFlashAttention {
         projected: &Tensor,
         heads: usize,
         norm: Option<&RmsNorm>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (batch, seq_len, _) = projected
             .dims3()
             .map_err(|e| tensor_err("HunyuanOCR DFlash: projected dims", e))?;
@@ -427,7 +427,7 @@ impl DFlashAttention {
             .map_err(|e| tensor_err("HunyuanOCR DFlash: projection transpose", e))
     }
 
-    fn qkv_weights(&self) -> Result<(Tensor, Tensor), OCRError> {
+    fn qkv_weights(&self) -> Result<(Tensor, Tensor), Error> {
         let q_width = self.num_heads * self.head_dim;
         let kv_width = self.num_kv_heads * self.head_dim;
         let k = self
@@ -450,7 +450,7 @@ impl DFlashAttention {
         cos: &Tensor,
         sin: &Tensor,
         cache: &mut ContextKv,
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         let k = self.shape_projected(raw_k, self.num_kv_heads, Some(&self.k_norm))?;
         let k = apply_rope(&k, cos, sin)?;
         let v = self.shape_projected(raw_v, self.num_kv_heads, None)?;
@@ -463,7 +463,7 @@ impl DFlashAttention {
         cos: &Tensor,
         sin: &Tensor,
         cos_sin: Option<&Tensor>,
-    ) -> Result<(Tensor, Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor, Tensor), Error> {
         #[cfg(not(feature = "cuda"))]
         let _ = cos_sin;
         let q_width = self.num_heads * self.head_dim;
@@ -550,7 +550,7 @@ impl DFlashAttention {
         cos: &Tensor,
         sin: &Tensor,
         cos_sin: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         #[cfg(not(feature = "cuda"))]
         let _ = cos_sin;
         #[cfg(feature = "cuda")]
@@ -575,7 +575,7 @@ impl DFlashAttention {
         query_k: &Tensor,
         query_v: &Tensor,
         cache: &mut ContextKv,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (k, v) = cache.with_queries(query_k, query_v)?;
         // Compute GQA without physically repeating the full context K/V cache
         // across all query heads.
@@ -606,15 +606,13 @@ impl DFlashAttention {
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
         cache: &ContextKv,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (_, _, query_len, _) = q
             .dims4()
             .map_err(|e| tensor_err("HunyuanOCR DFlash: dynamic Q dimensions", e))?;
-        let (cache_k, cache_v, block_table) =
-            cache.storage().ok_or_else(|| OCRError::ConfigError {
-                message: "HunyuanOCR DFlash: dynamic context storage is not initialized"
-                    .to_string(),
-            })?;
+        let (cache_k, cache_v, block_table) = cache.storage().ok_or_else(|| Error::Config {
+            message: "HunyuanOCR DFlash: dynamic context storage is not initialized".to_string(),
+        })?;
         let append = DynamicPagedKvAppend {
             query_len,
             cache_len: CONTEXT_KV_INITIAL_CAPACITY,
@@ -651,7 +649,7 @@ impl DFlashAttention {
         .map_err(|e| candle_to_ocr_inference("HunyuanOCR DFlash", "dynamic flash attention", e))
     }
 
-    fn flatten_attention_output(&self, output: &Tensor) -> Result<Tensor, OCRError> {
+    fn flatten_attention_output(&self, output: &Tensor) -> Result<Tensor, Error> {
         let (batch, _, query_len, _) = output
             .dims4()
             .map_err(|e| tensor_err("HunyuanOCR DFlash: attention output dimensions", e))?;
@@ -661,7 +659,7 @@ impl DFlashAttention {
             .map_err(|e| tensor_err("HunyuanOCR DFlash: attention output reshape", e))
     }
 
-    fn project_attention_output(&self, output: &Tensor) -> Result<Tensor, OCRError> {
+    fn project_attention_output(&self, output: &Tensor) -> Result<Tensor, Error> {
         self.o_proj
             .forward(output)
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR DFlash", "o_proj", e))
@@ -676,7 +674,7 @@ struct DFlashMlp {
 }
 
 impl DFlashMlp {
-    fn load(cfg: &DFlashConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &DFlashConfig, vb: VarBuilder) -> Result<Self, Error> {
         let gate_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR DFlash", "load gate_proj", e))?;
         let up_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))
@@ -693,7 +691,7 @@ impl DFlashMlp {
         })
     }
 
-    fn forward(&self, input: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, input: &Tensor) -> Result<Tensor, Error> {
         let gate_up = self
             .gate_up_proj
             .forward(input)
@@ -734,7 +732,7 @@ struct DFlashLayer {
 }
 
 impl DFlashLayer {
-    fn load(cfg: &DFlashConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &DFlashConfig, vb: VarBuilder) -> Result<Self, Error> {
         let input_layernorm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR DFlash", "load input_layernorm", e))?;
         let post_attention_layernorm = rms_norm(
@@ -760,7 +758,7 @@ impl DFlashLayer {
         sin: &Tensor,
         cos_sin: Option<&Tensor>,
         cache: &mut ContextKv,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (q, k, v) = self.project_qkv_eager(hidden, cos, sin, cos_sin)?;
         let attention = self.self_attn.attend_projected(&q, &k, &v, cache)?;
         let attention = self.self_attn.flatten_attention_output(&attention)?;
@@ -773,7 +771,7 @@ impl DFlashLayer {
         cos: &Tensor,
         sin: &Tensor,
         cos_sin: Option<&Tensor>,
-    ) -> Result<(Tensor, Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor, Tensor), Error> {
         let normed = self
             .input_layernorm
             .forward(hidden)
@@ -781,11 +779,7 @@ impl DFlashLayer {
         self.self_attn.project_qkv(&normed, cos, sin, cos_sin)
     }
 
-    fn post_attention_eager(
-        &self,
-        hidden: &Tensor,
-        attention: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    fn post_attention_eager(&self, hidden: &Tensor, attention: &Tensor) -> Result<Tensor, Error> {
         let attention = self.self_attn.project_attention_output(attention)?;
         #[cfg(feature = "cuda")]
         if hidden.device().is_cuda()
@@ -835,7 +829,7 @@ impl DFlashLayer {
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
         cache: &ContextKv,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (q, k, v) = self.project_qkv_eager(hidden, cos, sin, cos_sin)?;
         let attention = self.self_attn.attend_projected_dynamic(
             &q,
@@ -898,7 +892,7 @@ impl DFlashModel {
         dtype: DType,
         device: &Device,
         lm_head_weight: &Tensor,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         let model_dir = model_dir.as_ref();
         let cfg = DFlashConfig::from_path(model_dir.join("config.json"))?;
         cfg.validate()?;
@@ -906,7 +900,7 @@ impl DFlashModel {
             .dims2()
             .map_err(|e| tensor_err("HunyuanOCR DFlash: target LM head shape", e))?;
         if target_vocab_size != cfg.vocab_size || target_hidden_size != cfg.hidden_size {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR DFlash: target LM head shape {target_vocab_size}x{target_hidden_size} does not match draft vocab/hidden {}x{}",
                     cfg.vocab_size, cfg.hidden_size
@@ -980,7 +974,7 @@ impl DFlashModel {
         &self.cfg
     }
 
-    pub(crate) fn prepare_cuda_graph(&self) -> Result<(), OCRError> {
+    pub(crate) fn prepare_cuda_graph(&self) -> Result<(), Error> {
         #[cfg(feature = "cuda")]
         {
             if std::env::var_os("OAR_HUNYUAN_DISABLE_CUDA_GRAPH").is_some() {
@@ -1020,7 +1014,7 @@ impl DFlashModel {
         self.decode_graph.borrow_mut().take();
     }
 
-    fn rope(&self, start: usize, len: usize) -> Result<(Tensor, Tensor), OCRError> {
+    fn rope(&self, start: usize, len: usize) -> Result<(Tensor, Tensor), Error> {
         if start + len <= ROPE_CACHE_LEN {
             let cos = self
                 .rope_cos
@@ -1038,7 +1032,7 @@ impl DFlashModel {
         self.rotary.forward_multi_axis(&positions, self.dtype)
     }
 
-    fn transform_target(&self, aux_hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn transform_target(&self, aux_hidden: &Tensor) -> Result<Tensor, Error> {
         let hidden = self
             .fc
             .forward(aux_hidden)
@@ -1054,7 +1048,7 @@ impl DFlashModel {
         cos: &Tensor,
         sin: &Tensor,
         caches: &mut [ContextKv],
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         let projected = self
             .context_kv_proj
             .forward(target)
@@ -1077,7 +1071,7 @@ impl DFlashModel {
         Ok(())
     }
 
-    pub(crate) fn reset_context(&self, aux_hidden: &Tensor) -> Result<(), OCRError> {
+    pub(crate) fn reset_context(&self, aux_hidden: &Tensor) -> Result<(), Error> {
         #[cfg(feature = "cuda")]
         let _cuda_htod_cache = match &self.device {
             Device::Cuda(device) => Some(device.enable_cuda_graph_htod_cache()),
@@ -1099,7 +1093,7 @@ impl DFlashModel {
         self.append_projected_context(&target, &cos, &sin, &mut caches)
     }
 
-    pub(crate) fn append_context(&self, aux_hidden: &Tensor) -> Result<(), OCRError> {
+    pub(crate) fn append_context(&self, aux_hidden: &Tensor) -> Result<(), Error> {
         #[cfg(feature = "cuda")]
         let _cuda_htod_cache = match &self.device {
             Device::Cuda(device) => Some(device.enable_cuda_graph_htod_cache()),
@@ -1134,7 +1128,7 @@ impl DFlashModel {
         sin: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let caches = self.caches.borrow();
         let cos_sin = if query_embeds.dtype() == DType::BF16 {
             Some(
@@ -1161,7 +1155,7 @@ impl DFlashModel {
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR DFlash", "dynamic final norm", e))
     }
 
-    fn proposals_from_hidden(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn proposals_from_hidden(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         let num_spec = self.cfg.block_size.saturating_sub(1);
         let draft_rows = hidden
             .narrow(1, 1, num_spec)
@@ -1182,7 +1176,7 @@ impl DFlashModel {
     }
 
     #[cfg(feature = "cuda")]
-    fn capture_cuda_graph(&self) -> Result<(), OCRError> {
+    fn capture_cuda_graph(&self) -> Result<(), Error> {
         use candle_core::cuda_backend::cudarc::driver::sys::{
             CUgraphInstantiate_flags_enum, CUstreamCaptureMode_enum,
         };
@@ -1262,7 +1256,7 @@ impl DFlashModel {
                 kv_lengths.tensor(),
             )?;
             let proposals = self.proposals_from_hidden(&hidden)?;
-            Ok::<_, OCRError>((hidden, proposals))
+            Ok::<_, Error>((hidden, proposals))
         })();
         let (hidden_output, proposals_output) = match captured_output {
             Ok(output) => output,
@@ -1278,7 +1272,7 @@ impl DFlashModel {
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
             )
             .map_err(|e| cuda_graph_error("HunyuanOCR DFlash", "end full draft graph capture", e))?
-            .ok_or_else(|| OCRError::ConfigError {
+            .ok_or_else(|| Error::Config {
                 message: "HunyuanOCR DFlash full graph capture returned no graph".to_string(),
             })?;
         graph
@@ -1310,7 +1304,7 @@ impl DFlashModel {
         cos: &Tensor,
         sin: &Tensor,
         total_kv_len: usize,
-    ) -> Result<Option<Tensor>, OCRError> {
+    ) -> Result<Option<Tensor>, Error> {
         if total_kv_len > CONTEXT_KV_INITIAL_CAPACITY {
             self.invalidate_cuda_graph();
             return Ok(None);
@@ -1351,7 +1345,7 @@ impl DFlashModel {
     /// Run the bonus+mask query block and project all mask rows into draft
     /// proposals. CUDA graph replay includes both the shared LM head and the
     /// argmax so they do not incur per-round host dispatch.
-    pub(crate) fn forward_proposals(&self, query_embeds: &Tensor) -> Result<Tensor, OCRError> {
+    pub(crate) fn forward_proposals(&self, query_embeds: &Tensor) -> Result<Tensor, Error> {
         #[cfg(feature = "cuda")]
         let _cuda_htod_cache = match &self.device {
             Device::Cuda(device) => Some(device.enable_cuda_graph_htod_cache()),

--- a/oar-ocr-vl/src/hunyuanocr/llm.rs
+++ b/oar-ocr-vl/src/hunyuanocr/llm.rs
@@ -10,13 +10,13 @@ use crate::attention::{
 use crate::decoder_graph::{
     CudaGraphKvLengths, cuda_graph_error, decoder_attention_is_causal, sync_graph_tensor,
 };
+use crate::error::Error;
 use crate::kv_trim::TrimmableKvCache;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing, rotate_half};
 #[cfg(feature = "cuda")]
 use candle_core::Device;
 use candle_core::{D, Tensor};
 use candle_nn::Module;
-use oar_ocr_core::core::OCRError;
 use std::cell::RefCell;
 
 const DECODE_ROPE_CACHE_LEN: usize = 16_384;
@@ -54,7 +54,7 @@ fn apply_xdrope_rotary_pos_emb(
     k: &Tensor,
     cos: &Tensor,
     sin: &Tensor,
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     // Match upstream HF (`apply_rotary_pos_emb_xdrope`): apply the rotary
     // mix in F32, then cast q/k back to the original dtype.
     use candle_core::DType;
@@ -68,7 +68,7 @@ fn apply_xdrope_rotary_pos_emb(
 
     let q_mul = q_f32.broadcast_mul(cos).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "HunyuanOCR: xdrope q*cos failed",
             e,
         )
@@ -76,7 +76,7 @@ fn apply_xdrope_rotary_pos_emb(
     let q_half = rotate_half(&q_f32)?;
     let q_half_mul = q_half.broadcast_mul(sin).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "HunyuanOCR: xdrope rotate_half(q)*sin failed",
             e,
         )
@@ -84,7 +84,7 @@ fn apply_xdrope_rotary_pos_emb(
     let q_rot = (&q_mul + &q_half_mul)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: xdrope apply on q failed",
                 e,
             )
@@ -94,7 +94,7 @@ fn apply_xdrope_rotary_pos_emb(
 
     let k_mul = k_f32.broadcast_mul(cos).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "HunyuanOCR: xdrope k*cos failed",
             e,
         )
@@ -102,7 +102,7 @@ fn apply_xdrope_rotary_pos_emb(
     let k_half = rotate_half(&k_f32)?;
     let k_half_mul = k_half.broadcast_mul(sin).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "HunyuanOCR: xdrope rotate_half(k)*sin failed",
             e,
         )
@@ -110,7 +110,7 @@ fn apply_xdrope_rotary_pos_emb(
     let k_rot = (&k_mul + &k_half_mul)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: xdrope apply on k failed",
                 e,
             )
@@ -128,7 +128,7 @@ struct HunyuanMlp {
 }
 
 impl HunyuanMlp {
-    fn load(cfg: &HunyuanOcrConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &HunyuanOcrConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let gate_proj =
             candle_nn::linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))
                 .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "load gate_proj", e))?;
@@ -148,7 +148,7 @@ impl HunyuanMlp {
         })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, Error> {
         let gate_up = self
             .gate_up_proj
             .forward(xs)
@@ -195,12 +195,12 @@ struct HunyuanAttention {
 }
 
 impl HunyuanAttention {
-    fn load(cfg: &HunyuanOcrConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &HunyuanOcrConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         if !cfg
             .num_attention_heads
             .is_multiple_of(cfg.num_key_value_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR: num_attention_heads ({}) must be divisible by num_key_value_heads ({})",
                     cfg.num_attention_heads, cfg.num_key_value_heads
@@ -276,7 +276,7 @@ impl HunyuanAttention {
         cos: &Tensor,
         sin: &Tensor,
         cos_sin: Option<&Tensor>,
-    ) -> Result<(Tensor, Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor, Tensor), Error> {
         #[cfg(not(feature = "cuda"))]
         let _ = cos_sin;
         let (b, seq_len, _) = hidden_states
@@ -492,7 +492,7 @@ impl HunyuanAttention {
         v: &Tensor,
         model_dtype: candle_core::DType,
         causal_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (b, _, seq_len, _) = q
             .dims4()
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "projected Q dims", e))?;
@@ -534,7 +534,7 @@ impl HunyuanAttention {
         model_dtype: candle_core::DType,
         batch: usize,
         seq_len: usize,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let attn_output = attn_output
             .to_dtype(model_dtype)
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "attn output model dtype", e))?
@@ -549,7 +549,7 @@ impl HunyuanAttention {
     }
 
     #[cfg(feature = "cuda")]
-    fn prepare_dynamic_cache(&self, query_len: usize, cache_len: usize) -> Result<(), OCRError> {
+    fn prepare_dynamic_cache(&self, query_len: usize, cache_len: usize) -> Result<(), Error> {
         let device = self.qkv_proj.weight().device();
         let template = Tensor::zeros(
             (1, self.num_kv_heads, query_len, self.head_dim),
@@ -572,19 +572,19 @@ impl HunyuanAttention {
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
         model_dtype: candle_core::DType,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (batch, _, query_len, _) = q
             .dims4()
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "dynamic Q dims", e))?;
         if batch != 1 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "HunyuanOCR dynamic CUDA-graph attention requires batch size 1"
                     .to_string(),
             });
         }
         let cache = self.kv_cache.borrow();
         let cache_len = cache.storage_capacity();
-        let (cache_k, cache_v) = cache.storage().ok_or_else(|| OCRError::ConfigError {
+        let (cache_k, cache_v) = cache.storage().ok_or_else(|| Error::Config {
             message: "HunyuanOCR dynamic KV storage is not initialized".to_string(),
         })?;
         drop(cache);
@@ -633,7 +633,7 @@ impl HunyuanAttention {
         self.kv_cache.borrow_mut().reset();
     }
 
-    fn trim_kv_cache(&self, len: usize) -> Result<(), OCRError> {
+    fn trim_kv_cache(&self, len: usize) -> Result<(), Error> {
         self.kv_cache
             .borrow_mut()
             .trim_to(len)
@@ -645,7 +645,7 @@ impl HunyuanAttention {
     }
 
     #[cfg(feature = "cuda")]
-    fn set_kv_cache_len(&self, len: usize) -> Result<(), OCRError> {
+    fn set_kv_cache_len(&self, len: usize) -> Result<(), Error> {
         self.kv_cache
             .borrow_mut()
             .set_current_len(len)
@@ -690,7 +690,7 @@ struct HunyuanDecoderLayer {
 }
 
 impl HunyuanDecoderLayer {
-    fn load(cfg: &HunyuanOcrConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &HunyuanOcrConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let self_attn = HunyuanAttention::load(cfg, vb.pp("self_attn"))?;
         let mlp = HunyuanMlp::load(cfg, vb.pp("mlp"))?;
         let input_layernorm =
@@ -717,7 +717,7 @@ impl HunyuanDecoderLayer {
         sin: &Tensor,
         cos_sin: Option<&Tensor>,
         causal_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let normalized = self
             .input_layernorm
             .forward(hidden_states)
@@ -738,7 +738,7 @@ impl HunyuanDecoderLayer {
         cos_sin: Option<&Tensor>,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let normalized = self
             .input_layernorm
             .forward(hidden_states)
@@ -759,7 +759,7 @@ impl HunyuanDecoderLayer {
         &self,
         hidden_states: &Tensor,
         attention: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         #[cfg(feature = "cuda")]
         if hidden_states.device().is_cuda()
             && hidden_states.dtype() == candle_core::DType::BF16
@@ -805,7 +805,7 @@ impl HunyuanDecoderLayer {
         self.self_attn.clear_kv_cache();
     }
 
-    fn trim_kv_cache(&self, len: usize) -> Result<(), OCRError> {
+    fn trim_kv_cache(&self, len: usize) -> Result<(), Error> {
         self.self_attn.trim_kv_cache(len)
     }
 
@@ -814,7 +814,7 @@ impl HunyuanDecoderLayer {
     }
 
     #[cfg(feature = "cuda")]
-    fn set_kv_cache_len(&self, len: usize) -> Result<(), OCRError> {
+    fn set_kv_cache_len(&self, len: usize) -> Result<(), Error> {
         self.self_attn.set_kv_cache_len(len)
     }
 }
@@ -849,7 +849,7 @@ pub struct HunyuanLlm {
 }
 
 impl HunyuanLlm {
-    pub fn load(cfg: &HunyuanOcrConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    pub fn load(cfg: &HunyuanOcrConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let embed_tokens =
             candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("embed_tokens"))
                 .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "load embed_tokens", e))?;
@@ -899,7 +899,7 @@ impl HunyuanLlm {
         })
     }
 
-    pub fn embed(&self, input_ids: &Tensor) -> Result<Tensor, OCRError> {
+    pub fn embed(&self, input_ids: &Tensor) -> Result<Tensor, Error> {
         self.embed_tokens
             .forward(input_ids)
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "embed tokens", e))
@@ -914,7 +914,7 @@ impl HunyuanLlm {
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
         causal_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         Ok(self
             .forward_with_aux(inputs_embeds, position_ids, causal_mask, &[])?
             .hidden_states)
@@ -931,7 +931,7 @@ impl HunyuanLlm {
         position_ids: &Tensor,
         causal_mask: Option<&Tensor>,
         aux_layer_ids: &[usize],
-    ) -> Result<HunyuanLlmOutput, OCRError> {
+    ) -> Result<HunyuanLlmOutput, Error> {
         use candle_core::DType;
 
         let (cos, sin) = self
@@ -959,7 +959,7 @@ impl HunyuanLlm {
         start: usize,
         causal_mask: Option<&Tensor>,
         aux_layer_ids: &[usize],
-    ) -> Result<HunyuanLlmOutput, OCRError> {
+    ) -> Result<HunyuanLlmOutput, Error> {
         let len = inputs_embeds
             .dim(1)
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "decode sequence length", e))?;
@@ -1001,7 +1001,7 @@ impl HunyuanLlm {
         sin: &Tensor,
         kv_len: usize,
         aux_layer_ids: &[usize],
-    ) -> Result<Option<HunyuanLlmOutput>, OCRError> {
+    ) -> Result<Option<HunyuanLlmOutput>, Error> {
         let captured_ref = self.decode_graph.borrow();
         let Some(captured) = captured_ref.as_ref() else {
             return Ok(None);
@@ -1054,7 +1054,7 @@ impl HunyuanLlm {
         sin: &Tensor,
         causal_mask: Option<&Tensor>,
         aux_layer_ids: &[usize],
-    ) -> Result<HunyuanLlmOutput, OCRError> {
+    ) -> Result<HunyuanLlmOutput, Error> {
         #[cfg(feature = "cuda")]
         {
             let incoming_len = inputs_embeds.dim(1).map_err(|e| {
@@ -1083,7 +1083,7 @@ impl HunyuanLlm {
             .iter()
             .any(|&id| id == 0 || id > self.layers.len())
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR: DFlash target layer ids must be in 1..={}, got {:?}",
                     self.layers.len(),
@@ -1140,7 +1140,7 @@ impl HunyuanLlm {
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
         aux_layer_ids: &[usize],
-    ) -> Result<HunyuanLlmOutput, OCRError> {
+    ) -> Result<HunyuanLlmOutput, Error> {
         let mut hidden_states = inputs_embeds.clone();
         let cos_sin = if inputs_embeds.dtype() == candle_core::DType::BF16 {
             Some(Tensor::cat(&[cos, sin], 0).map_err(|e| {
@@ -1183,7 +1183,7 @@ impl HunyuanLlm {
     }
 
     #[cfg(feature = "cuda")]
-    fn project_logits(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+    fn project_logits(&self, hidden_states: &Tensor) -> Result<Tensor, Error> {
         let (batch_size, sequence_length, hidden_size) = hidden_states
             .dims3()
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "graph hidden shape", e))?;
@@ -1213,7 +1213,7 @@ impl HunyuanLlm {
         &self,
         query_len: usize,
         aux_layer_ids: &[usize],
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         if std::env::var_os("OAR_HUNYUAN_DISABLE_CUDA_GRAPH").is_some() {
             #[cfg(feature = "cuda")]
             self.invalidate_cuda_graph();
@@ -1256,7 +1256,7 @@ impl HunyuanLlm {
         &self,
         prompt_len: usize,
         max_new_tokens: usize,
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         if std::env::var_os("OAR_HUNYUAN_DISABLE_CUDA_GRAPH").is_some()
             || std::env::var_os("OAR_HUNYUAN_DISABLE_AR_CUDA_GRAPH").is_some()
         {
@@ -1308,7 +1308,7 @@ impl HunyuanLlm {
         cos_template: &Tensor,
         sin_template: &Tensor,
         aux_layer_ids: &[usize],
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         use candle_core::cuda_backend::cudarc::driver::sys::{
             CUgraphInstantiate_flags_enum, CUstreamCaptureMode_enum,
         };
@@ -1380,7 +1380,7 @@ impl HunyuanLlm {
                 aux_layer_ids,
             )?;
             let logits = self.project_logits(&output.hidden_states)?;
-            Ok::<_, OCRError>((output, logits))
+            Ok::<_, Error>((output, logits))
         })();
         let (output, logits_output) = match captured_output {
             Ok(output) => output,
@@ -1398,7 +1398,7 @@ impl HunyuanLlm {
             .map_err(|e| {
                 cuda_graph_error("HunyuanOCR", "end full target decoder graph capture", e)
             })?
-            .ok_or_else(|| OCRError::ConfigError {
+            .ok_or_else(|| Error::Config {
                 message: "HunyuanOCR full target decoder capture returned no graph".to_string(),
             })?;
         let aux_output = output.aux_hidden_states;
@@ -1448,7 +1448,7 @@ impl HunyuanLlm {
         self.invalidate_cuda_graph();
     }
 
-    pub(crate) fn trim_kv_cache(&self, len: usize) -> Result<(), OCRError> {
+    pub(crate) fn trim_kv_cache(&self, len: usize) -> Result<(), Error> {
         for layer in &self.layers {
             layer.trim_kv_cache(len)?;
         }

--- a/oar-ocr-vl/src/hunyuanocr/model.rs
+++ b/oar-ocr-vl/src/hunyuanocr/model.rs
@@ -14,10 +14,10 @@ use crate::attention::{
 };
 #[cfg(feature = "cuda")]
 use crate::cuda_kernels::ArgmaxFirstF32;
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{D, DType, Device, IndexOp, Tensor};
 use image::RgbImage;
-use oar_ocr_core::core::OCRError;
 use std::path::Path;
 use tokenizers::Tokenizer;
 
@@ -70,7 +70,7 @@ fn argmax_with_repetition_penalty_cpu(
     logits: &Tensor,
     seen: &[u32],
     penalty: f32,
-) -> Result<u32, OCRError> {
+) -> Result<u32, Error> {
     let mut vec = logits
         .to_dtype(DType::F32)
         .and_then(|t| t.to_vec1::<f32>())
@@ -144,13 +144,13 @@ fn batched_argmax_with_unique_repetition_parts(
     common: &[u32],
     row_extras: &[&[u32]],
     penalty: f32,
-) -> Result<Vec<u32>, OCRError> {
+) -> Result<Vec<u32>, Error> {
     let vocab_size = logits
         .dim(D::Minus1)
         .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "repetition penalty vocab", e))?;
     let rows = logits.elem_count() / vocab_size;
     if row_extras.len() != rows {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "HunyuanOCR: repetition penalty got {} suffix rows for {rows} logits rows",
                 row_extras.len()
@@ -239,7 +239,7 @@ fn dflash_argmax_with_host_proposals(
     repetition_history: &RepetitionHistory,
     proposals: &[u32],
     penalty: f32,
-) -> Result<Vec<u32>, OCRError> {
+) -> Result<Vec<u32>, Error> {
     let mut row_extras = Vec::with_capacity(proposals.len() + 1);
     let mut proposal_prefix = Vec::with_capacity(proposals.len());
     for prefix_len in 0..=proposals.len() {
@@ -266,7 +266,7 @@ fn dflash_argmax_with_repetition_penalty(
     history: &Tensor,
     proposals: &Tensor,
     penalty: f32,
-) -> Result<Vec<u32>, OCRError> {
+) -> Result<Vec<u32>, Error> {
     let vocab_size = logits
         .dim(D::Minus1)
         .map_err(|e| candle_to_ocr_inference("HunyuanOCR DFlash", "penalty vocab", e))?;
@@ -275,7 +275,7 @@ fn dflash_argmax_with_repetition_penalty(
         .dims1()
         .map_err(|e| candle_to_ocr_inference("HunyuanOCR DFlash", "proposal count", e))?;
     if rows != proposal_count + 1 {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "HunyuanOCR DFlash: {rows} target rows do not match {proposal_count} proposals"
             ),
@@ -291,7 +291,7 @@ fn dflash_argmax_with_repetition_penalty(
 }
 
 #[cfg(feature = "cuda")]
-fn mark_repetition_history(history: &Tensor, token_ids: &[u32]) -> Result<(), OCRError> {
+fn mark_repetition_history(history: &Tensor, token_ids: &[u32]) -> Result<(), Error> {
     if token_ids.is_empty() {
         return Ok(());
     }
@@ -307,7 +307,7 @@ fn argmax_with_device_repetition_history(
     logits: &Tensor,
     history: &Tensor,
     penalty: f32,
-) -> Result<u32, OCRError> {
+) -> Result<u32, Error> {
     let vocab_size = logits
         .dim(D::Minus1)
         .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "device penalty vocab", e))?;
@@ -328,13 +328,13 @@ fn batched_argmax_with_repetition_penalty(
     logits: &Tensor,
     seen_rows: &[&[u32]],
     penalty: f32,
-) -> Result<Vec<u32>, OCRError> {
+) -> Result<Vec<u32>, Error> {
     let vocab_size = logits
         .dim(D::Minus1)
         .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "repetition penalty vocab", e))?;
     let rows = logits.elem_count() / vocab_size;
     if seen_rows.len() != rows {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "HunyuanOCR: repetition penalty got {} history rows for {rows} logits rows",
                 seen_rows.len()
@@ -360,7 +360,7 @@ fn argmax_with_unique_repetition_penalty(
     logits: &Tensor,
     seen: &[u32],
     penalty: f32,
-) -> Result<u32, OCRError> {
+) -> Result<u32, Error> {
     batched_argmax_with_unique_repetition_parts(logits, seen, &[&[]], penalty)
         .map(|tokens| tokens[0])
 }
@@ -386,7 +386,7 @@ pub struct HunyuanOcr {
 }
 
 impl HunyuanOcr {
-    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, OCRError> {
+    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, Error> {
         let model_dir = model_dir.as_ref();
 
         let cfg = HunyuanOcrConfig::from_path(model_dir.join("config.json"))?;
@@ -394,11 +394,10 @@ impl HunyuanOcr {
         let image_cfg =
             HunyuanOcrImageProcessorConfig::from_path(model_dir.join("preprocessor_config.json"))?;
 
-        let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| {
-            OCRError::ConfigError {
+        let tokenizer =
+            Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| Error::Config {
                 message: format!("failed to load HunyuanOCR tokenizer.json: {e}"),
-            }
-        })?;
+            })?;
 
         let mut stop_token_ids = Vec::new();
         stop_token_ids.push(cfg.eod_token_id);
@@ -459,10 +458,10 @@ impl HunyuanOcr {
         model_dir: impl AsRef<Path>,
         dflash_dir: impl AsRef<Path>,
         device: Device,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         let mut model = Self::from_dir(model_dir, device)?;
         if model.version != HunyuanOcrVersion::V1_5 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "HunyuanOCR: DFlash requires the 1.5 checkpoint".to_string(),
             });
         }
@@ -475,7 +474,7 @@ impl HunyuanOcr {
         if dflash.config().hidden_size != model.cfg.hidden_size
             || dflash.config().vocab_size != model.cfg.vocab_size
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR: DFlash target mismatch (hidden/vocab draft={}/{}, target={}/{})",
                     dflash.config().hidden_size,
@@ -492,7 +491,7 @@ impl HunyuanOcr {
             .iter()
             .any(|&id| id >= model.cfg.num_hidden_layers)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR: invalid DFlash target layers {:?} for {}-layer target",
                     dflash.config().dflash_config.target_layer_ids,
@@ -518,7 +517,7 @@ impl HunyuanOcr {
     pub fn from_dir_with_dflash(
         model_dir: impl AsRef<Path>,
         device: Device,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         let model_dir = model_dir.as_ref();
         Self::from_dirs(model_dir, model_dir.join("dflash"), device)
     }
@@ -530,9 +529,9 @@ impl HunyuanOcr {
     /// Override the checkpoint/reference repetition penalty used by greedy
     /// decoding. A value of `1.0` disables the processor, matching the
     /// official DFlash speed-benchmark configuration.
-    pub fn set_repetition_penalty(&mut self, penalty: f64) -> Result<(), OCRError> {
+    pub fn set_repetition_penalty(&mut self, penalty: f64) -> Result<(), Error> {
         if !penalty.is_finite() || penalty < 1.0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR: repetition penalty must be finite and >= 1.0, got {penalty}"
                 ),
@@ -575,12 +574,12 @@ impl HunyuanOcr {
         images: &[RgbImage],
         instructions: &[impl AsRef<str>],
         max_new_tokens: usize,
-    ) -> Vec<Result<String, OCRError>> {
+    ) -> Vec<Result<String, Error>> {
         if images.is_empty() {
             return Vec::new();
         }
         if images.len() != instructions.len() {
-            return vec![Err(OCRError::InvalidInput {
+            return vec![Err(Error::InvalidInput {
                 message: format!(
                     "HunyuanOCR: images count ({}) != instructions count ({})",
                     images.len(),
@@ -598,7 +597,7 @@ impl HunyuanOcr {
                 let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
-                        Err(OCRError::InvalidInput {
+                        Err(Error::InvalidInput {
                             message: msg.clone(),
                         })
                     })
@@ -615,12 +614,12 @@ impl HunyuanOcr {
         images: &[RgbImage],
         instructions: &[impl AsRef<str>],
         max_new_tokens: usize,
-    ) -> Vec<Result<Vec<u32>, OCRError>> {
+    ) -> Vec<Result<Vec<u32>, Error>> {
         if images.is_empty() {
             return Vec::new();
         }
         if images.len() != instructions.len() {
-            return vec![Err(OCRError::InvalidInput {
+            return vec![Err(Error::InvalidInput {
                 message: format!(
                     "HunyuanOCR: images count ({}) != instructions count ({})",
                     images.len(),
@@ -635,7 +634,7 @@ impl HunyuanOcr {
                 let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
-                        Err(OCRError::InvalidInput {
+                        Err(Error::InvalidInput {
                             message: msg.clone(),
                         })
                     })
@@ -650,7 +649,7 @@ impl HunyuanOcr {
         images: &[RgbImage],
         instructions: &[impl AsRef<str>],
         max_new_tokens: usize,
-    ) -> Result<Vec<Vec<u32>>, OCRError> {
+    ) -> Result<Vec<Vec<u32>>, Error> {
         let batch_size = images.len();
 
         // 1. Preprocess all images and build prompts
@@ -672,7 +671,7 @@ impl HunyuanOcr {
             let enc = self
                 .tokenizer
                 .encode(prompt, false)
-                .map_err(|e| OCRError::InvalidInput {
+                .map_err(|e| Error::InvalidInput {
                     message: format!("HunyuanOCR: tokenizer encode failed: {e}"),
                 })?;
 
@@ -708,7 +707,7 @@ impl HunyuanOcr {
                     image_inputs.grid_thw_merged.2,
                 )
             {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: format!(
                         "HunyuanOCR: merged grid mismatch: vision={:?} preprocessor={:?}",
                         merged_hw, image_inputs.grid_thw_merged
@@ -723,7 +722,7 @@ impl HunyuanOcr {
                 .dims2()
                 .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "image_embeds dims2", e))?;
             if inner_len != img_len {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: format!(
                         "HunyuanOCR: image-token run length mismatch: tokens={inner_len} embeds={img_len}"
                     ),
@@ -858,12 +857,10 @@ impl HunyuanOcr {
                 mask.as_ref(),
                 &aux_layer_ids,
             )?;
-            let aux = output
-                .aux_hidden_states
-                .ok_or_else(|| OCRError::ConfigError {
-                    message: "HunyuanOCR DFlash: target did not return auxiliary hidden states"
-                        .to_string(),
-                })?;
+            let aux = output.aux_hidden_states.ok_or_else(|| Error::Config {
+                message: "HunyuanOCR DFlash: target did not return auxiliary hidden states"
+                    .to_string(),
+            })?;
             dflash.reset_context(&aux)?;
             output.hidden_states
         } else {
@@ -884,7 +881,7 @@ impl HunyuanOcr {
         // DFlash currently targets the latency-sensitive single-document path.
         // Multi-image calls retain the existing true-batch autoregressive path.
         if let Some(dflash) = active_dflash {
-            let initial_logits = logits_list.pop().ok_or_else(|| OCRError::ConfigError {
+            let initial_logits = logits_list.pop().ok_or_else(|| Error::Config {
                 message: "HunyuanOCR DFlash: missing target prefill logits".to_string(),
             })?;
             let tokens =
@@ -1057,7 +1054,7 @@ impl HunyuanOcr {
         initial_logits: Tensor,
         prompt_len: usize,
         max_new_tokens: usize,
-    ) -> Result<Vec<u32>, OCRError> {
+    ) -> Result<Vec<u32>, Error> {
         if max_new_tokens == 0 {
             self.llm.clear_kv_cache();
             dflash.clear_context();
@@ -1076,7 +1073,7 @@ impl HunyuanOcr {
 
         let num_spec = dflash.config().block_size.saturating_sub(1);
         if num_spec == 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "HunyuanOCR DFlash: block_size must include at least one mask position"
                     .to_string(),
             });
@@ -1167,13 +1164,10 @@ impl HunyuanOcr {
                 verify_mask.as_ref(),
                 &target_layers,
             )?;
-            let aux = output
-                .aux_hidden_states
-                .ok_or_else(|| OCRError::ConfigError {
-                    message:
-                        "HunyuanOCR DFlash: target verification did not return auxiliary states"
-                            .to_string(),
-                })?;
+            let aux = output.aux_hidden_states.ok_or_else(|| Error::Config {
+                message: "HunyuanOCR DFlash: target verification did not return auxiliary states"
+                    .to_string(),
+            })?;
             let target_logits = if let Some(logits) = output.logits.as_ref() {
                 logits.squeeze(0).map_err(|e| {
                     candle_to_ocr_inference("HunyuanOCR DFlash", "graph target logits", e)
@@ -1209,12 +1203,12 @@ impl HunyuanOcr {
                     if self.device.is_cuda() && self.dtype == DType::BF16 {
                         dflash_argmax_with_repetition_penalty(
                             &target_logits,
-                            repetition_history_device.as_ref().ok_or_else(|| {
-                                OCRError::ConfigError {
+                            repetition_history_device
+                                .as_ref()
+                                .ok_or_else(|| Error::Config {
                                     message: "HunyuanOCR DFlash: missing CUDA repetition history"
                                         .to_string(),
-                                }
-                            })?,
+                                })?,
                             &proposals,
                             self.repetition_penalty as f32,
                         )?
@@ -1336,7 +1330,7 @@ impl HunyuanOcr {
         Ok(generated)
     }
 
-    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, Error> {
         self.decode_generated_tokens(tokens)
     }
 
@@ -1344,10 +1338,10 @@ impl HunyuanOcr {
     /// `decode_tokens` only applies `trim()` post-process, so this is
     /// effectively an alias provided for API symmetry with backends that do
     /// have non-trivial post-process (PaddleOCR-VL / GLM-OCR).
-    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, Error> {
         self.tokenizer
             .decode(tokens, true)
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("HunyuanOCR: tokenizer decode failed: {e}"),
             })
     }
@@ -1356,14 +1350,14 @@ impl HunyuanOcr {
         &self.tokenizer
     }
 
-    fn decode_generated_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    fn decode_generated_tokens(&self, tokens: &[u32]) -> Result<String, Error> {
         Ok(self.decode_tokens_raw(tokens)?.trim().to_string())
     }
 
-    fn logits_from_hidden(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn logits_from_hidden(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         let hidden = hidden.unsqueeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: unsqueeze hidden failed",
                 e,
             )
@@ -1371,7 +1365,7 @@ impl HunyuanOcr {
         let w = self.llm.token_embedding_weight();
         let wt = w.transpose(0, 1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: transpose embedding weight failed",
                 e,
             )
@@ -1383,11 +1377,11 @@ impl HunyuanOcr {
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "squeeze logits", e))
     }
 
-    fn logits_from_hidden_batch(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn logits_from_hidden_batch(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         let w = self.llm.token_embedding_weight();
         let wt = w.transpose(0, 1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: transpose embedding weight failed",
                 e,
             )
@@ -1417,7 +1411,7 @@ fn expand_image_tokens_in_place(
     input_ids: &mut Vec<u32>,
     cfg: &HunyuanOcrConfig,
     image_inputs: &HunyuanOcrImageInputs,
-) -> Result<(), OCRError> {
+) -> Result<(), Error> {
     let (_, hm, wm) = image_inputs.grid_thw_merged;
     // Upstream processor: num_image_tokens = patch_h * (patch_w + 1) + 2
     // (processing_hunyuan_vl.py:62). The `+ 2` covers the perceive step's
@@ -1426,7 +1420,7 @@ fn expand_image_tokens_in_place(
     // no `image_newline_token_id` interleaving.
     let expected_tokens = hm.saturating_mul(wm.saturating_add(1)).saturating_add(2);
     if expected_tokens == 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "HunyuanOCR: empty merged grid".to_string(),
         });
     }
@@ -1442,7 +1436,7 @@ fn expand_image_tokens_in_place(
         }
     }
     let Some(pos) = placeholder else {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "HunyuanOCR: prompt is missing image placeholder tokens".to_string(),
         });
     };
@@ -1455,18 +1449,18 @@ fn expand_image_tokens_in_place(
     Ok(())
 }
 
-fn find_image_span(input_ids: &[u32], cfg: &HunyuanOcrConfig) -> Result<(usize, usize), OCRError> {
+fn find_image_span(input_ids: &[u32], cfg: &HunyuanOcrConfig) -> Result<(usize, usize), Error> {
     let start_pos = input_ids
         .iter()
         .position(|&id| id == cfg.image_start_token_id)
-        .ok_or_else(|| OCRError::InvalidInput {
+        .ok_or_else(|| Error::InvalidInput {
             message: "HunyuanOCR: image_start_token_id not found in input_ids".to_string(),
         })?;
     let end_pos = input_ids[start_pos + 1..]
         .iter()
         .position(|&id| id == cfg.image_end_token_id)
         .map(|p| start_pos + 1 + p)
-        .ok_or_else(|| OCRError::InvalidInput {
+        .ok_or_else(|| Error::InvalidInput {
             message: "HunyuanOCR: image_end_token_id not found after image_start_token_id"
                 .to_string(),
         })?;
@@ -1477,7 +1471,7 @@ fn build_position_ids(
     input_ids: &[u32],
     cfg: &HunyuanOcrConfig,
     image_inputs: &HunyuanOcrImageInputs,
-) -> Result<Tensor, OCRError> {
+) -> Result<Tensor, Error> {
     let seq_len = input_ids.len();
     // 4-axis XDRoPE position ids matching the upstream HF processor exactly:
     //   the upstream Transformers Hunyuan-VL processor, lines 74-94.
@@ -1509,7 +1503,7 @@ fn build_position_ids(
         let start = first + 1;
         let replace_num = (wm + 1) * hm;
         if start + replace_num > seq_len {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "HunyuanOCR: image span ({} positions starting at {}) exceeds input length {}",
                     replace_num, start, seq_len
@@ -1533,7 +1527,7 @@ fn build_position_ids(
     )
     .map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "HunyuanOCR: build position_ids tensor failed",
             e,
         )

--- a/oar-ocr-vl/src/hunyuanocr/processing.rs
+++ b/oar-ocr-vl/src/hunyuanocr/processing.rs
@@ -1,11 +1,11 @@
 use super::config::{HunyuanOcrImageProcessorConfig, HunyuanOcrVersion, HunyuanOcrVisionConfig};
+use crate::error::Error;
 use crate::utils::{
     candle_to_ocr_processing,
     image::{clamp_to_max_image_size, image_to_chw, smart_resize},
 };
 use candle_core::{DType, Device, Tensor};
 use image::{RgbImage, imageops::FilterType};
-use oar_ocr_core::core::OCRError;
 
 #[derive(Debug, Clone)]
 pub struct HunyuanOcrImageInputs {
@@ -20,9 +20,9 @@ pub fn smart_resize_token_limited(
     min_pixels: u32,
     max_pixels: u32,
     max_tokens: usize,
-) -> Result<(u32, u32), OCRError> {
+) -> Result<(u32, u32), Error> {
     if factor == 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "HunyuanOCR smart_resize_token_limited: factor must be > 0".to_string(),
         });
     }
@@ -41,7 +41,7 @@ pub fn smart_resize_token_limited(
         // Reduce the larger axis (in merged-grid units) first to keep aspect ratio roughly intact.
         if wm >= hm {
             if rw <= factor {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: "HunyuanOCR smart_resize_token_limited: cannot satisfy max_tokens"
                         .to_string(),
                 });
@@ -49,7 +49,7 @@ pub fn smart_resize_token_limited(
             rw -= factor;
         } else {
             if rh <= factor {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: "HunyuanOCR smart_resize_token_limited: cannot satisfy max_tokens"
                         .to_string(),
                 });
@@ -68,10 +68,10 @@ pub fn preprocess_image(
     version: HunyuanOcrVersion,
     device: &Device,
     dtype: DType,
-) -> Result<HunyuanOcrImageInputs, OCRError> {
+) -> Result<HunyuanOcrImageInputs, Error> {
     cfg.validate()?;
     if vision_cfg.patch_size != cfg.patch_size {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "HunyuanOCR patch_size mismatch: preprocessor {} != vision_config {}",
                 cfg.patch_size, vision_cfg.patch_size
@@ -79,7 +79,7 @@ pub fn preprocess_image(
         });
     }
     if vision_cfg.spatial_merge_size != cfg.merge_size {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "HunyuanOCR merge_size mismatch: preprocessor {} != vision_config.spatial_merge_size {}",
                 cfg.merge_size, vision_cfg.spatial_merge_size
@@ -120,7 +120,7 @@ pub fn preprocess_image(
     };
 
     if rh % factor != 0 || rw % factor != 0 {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "HunyuanOCR preprocess produced non-divisible dims: {rh}x{rw} not divisible by factor={factor}"
             ),
@@ -138,7 +138,7 @@ pub fn preprocess_image(
     let pixel_values = Tensor::from_vec(data, (1usize, 3usize, rh as usize, rw as usize), device)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: failed to create pixel_values tensor",
                 e,
             )
@@ -146,7 +146,7 @@ pub fn preprocess_image(
         .to_dtype(dtype)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: failed to cast pixel_values dtype",
                 e,
             )

--- a/oar-ocr-vl/src/hunyuanocr/vision.rs
+++ b/oar-ocr-vl/src/hunyuanocr/vision.rs
@@ -1,9 +1,9 @@
 use super::config::{HunyuanOcrVersion, HunyuanOcrVisionConfig};
 use crate::attention::flash_attention;
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{D, DType, Device, IndexOp, Tensor};
 use candle_nn::{Conv2d, Conv2dConfig, LayerNorm, LayerNormConfig, Linear, Module};
-use oar_ocr_core::core::OCRError;
 use rayon::prelude::*;
 use std::sync::Arc;
 
@@ -28,7 +28,7 @@ impl VisionEmbeddings {
         cfg: &HunyuanOcrVisionConfig,
         version: HunyuanOcrVersion,
         vb: candle_nn::VarBuilder,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         let conv_cfg = Conv2dConfig {
             stride: cfg.patch_size,
             padding: 0,
@@ -60,7 +60,7 @@ impl VisionEmbeddings {
         // the 2048px learned positional base (16,384 patches + cls slot).
         // The input grid is interpolated from this base, matching upstream.
         if cfg.patch_size == 0 || !cfg.max_image_size.is_multiple_of(cfg.patch_size) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR: max_image_size {} must be divisible by patch_size {}",
                     cfg.max_image_size, cfg.patch_size
@@ -71,7 +71,7 @@ impl VisionEmbeddings {
         let num_positions = position_edge
             .checked_mul(position_edge)
             .and_then(|positions| positions.checked_add(cfg.cat_extra_token))
-            .ok_or_else(|| OCRError::ConfigError {
+            .ok_or_else(|| Error::Config {
                 message: "HunyuanOCR: position embedding size overflow".to_string(),
             })?;
         let position_embedding =
@@ -82,13 +82,13 @@ impl VisionEmbeddings {
         let pos_w = position_embedding.embeddings();
         let (loaded_positions, position_dim) = pos_w.dims2().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: vit position_embedding dims2 failed",
                 e,
             )
         })?;
         if loaded_positions < 2 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR: vit position_embedding is too small: {loaded_positions}"
                 ),
@@ -97,7 +97,7 @@ impl VisionEmbeddings {
         let num_patch_positions = loaded_positions - 1;
         let position_grid = (num_patch_positions as f64).sqrt() as usize;
         if position_grid * position_grid != num_patch_positions {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR: vit patch position grid is not square: num={num_patch_positions}"
                 ),
@@ -113,7 +113,7 @@ impl VisionEmbeddings {
             .and_then(|x| x.to_vec1::<f32>())
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: cache vit patch position embedding failed",
                     e,
                 )
@@ -135,9 +135,9 @@ impl VisionEmbeddings {
         width: usize,
         device: &Device,
         dtype: DType,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         if height == 0 || width == 0 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "HunyuanOCR: vit interpolate_patch_pos requires height/width > 0, got {height}x{width}"
                 ),
@@ -156,7 +156,7 @@ impl VisionEmbeddings {
         Tensor::from_vec(out, (height * width, self.position_dim), device)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: vit interpolated patch pos tensor failed",
                     e,
                 )
@@ -164,7 +164,7 @@ impl VisionEmbeddings {
             .to_dtype(dtype)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: vit interpolated patch pos cast failed",
                     e,
                 )
@@ -191,9 +191,9 @@ impl VisionAttention {
         cfg: &HunyuanOcrVisionConfig,
         layer_idx: usize,
         vb: candle_nn::VarBuilder,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         if !cfg.hidden_size.is_multiple_of(cfg.num_attention_heads) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "HunyuanOCR: vit hidden_size {} not divisible by num_attention_heads {}",
                     cfg.hidden_size, cfg.num_attention_heads
@@ -222,10 +222,10 @@ impl VisionAttention {
         })
     }
 
-    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, Error> {
         let (b, seq_len, _) = hidden_states.dims3().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: vit attn hidden_states dims3 failed",
                 e,
             )
@@ -318,7 +318,7 @@ impl VisionAttention {
             (kt, v.clone())
         };
 
-        let attend_chunk = |q_in: &Tensor| -> Result<Tensor, OCRError> {
+        let attend_chunk = |q_in: &Tensor| -> Result<Tensor, Error> {
             let q_use = if use_f32 {
                 q_in.to_dtype(DType::F32)
                     .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "vit attn q to f32", e))?
@@ -392,7 +392,7 @@ struct VisionMlp {
 }
 
 impl VisionMlp {
-    fn load(cfg: &HunyuanOcrVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &HunyuanOcrVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let fc1 = candle_nn::linear(
             cfg.hidden_size,
             cfg.intermediate_size,
@@ -408,7 +408,7 @@ impl VisionMlp {
         Ok(Self { fc1, fc2 })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, Error> {
         let hidden = self
             .fc1
             .forward(xs)
@@ -442,7 +442,7 @@ impl VisionEncoderLayer {
         cfg: &HunyuanOcrVisionConfig,
         layer_idx: usize,
         vb: candle_nn::VarBuilder,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         let self_attn = VisionAttention::load(cfg, layer_idx, vb.pp("self_attn"))?;
         let mlp = VisionMlp::load(cfg, vb.pp("mlp"))?;
 
@@ -469,7 +469,7 @@ impl VisionEncoderLayer {
         })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, Error> {
         let residual = xs;
         let hidden = self
             .input_layernorm
@@ -506,7 +506,7 @@ struct VisionPerceive {
 }
 
 impl VisionPerceive {
-    fn load(cfg: &HunyuanOcrVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &HunyuanOcrVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let before_rms =
             candle_nn::rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("before_rms")).map_err(
                 |e| candle_to_ocr_inference("HunyuanOCR", "load perceive before_rms", e),
@@ -572,7 +572,7 @@ impl VisionPerceive {
         })
     }
 
-    fn forward(&self, patch_tokens: &Tensor, h: usize, w: usize) -> Result<Tensor, OCRError> {
+    fn forward(&self, patch_tokens: &Tensor, h: usize, w: usize) -> Result<Tensor, Error> {
         let patch_tokens = self
             .before_rms
             .forward(patch_tokens)
@@ -580,13 +580,13 @@ impl VisionPerceive {
 
         let d = patch_tokens.dim(D::Minus1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: perceive patch_tokens dim failed",
                 e,
             )
         })?;
         if d != self.hidden_size {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "HunyuanOCR: unexpected vit hidden dim {d}, expected {}",
                     self.hidden_size
@@ -598,7 +598,7 @@ impl VisionPerceive {
             .reshape((h, w, d))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: perceive reshape hwd failed",
                     e,
                 )
@@ -606,7 +606,7 @@ impl VisionPerceive {
             .permute((2, 0, 1))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: perceive permute to chw failed",
                     e,
                 )
@@ -614,7 +614,7 @@ impl VisionPerceive {
             .unsqueeze(0)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: perceive add batch dim failed",
                     e,
                 )
@@ -636,13 +636,13 @@ impl VisionPerceive {
 
         let (_b, c, h2, w2) = feat.dims4().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: perceive feat dims4 failed",
                 e,
             )
         })?;
         if c != 4608 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!("HunyuanOCR: unexpected perceive channel dim {c}, expected 4608"),
             });
         }
@@ -653,7 +653,7 @@ impl VisionPerceive {
             .reshape((1usize, 4608usize, 1usize, 1usize))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: reshape image_newline failed",
                     e,
                 )
@@ -661,14 +661,14 @@ impl VisionPerceive {
             .expand((1usize, 4608usize, h2, 1usize))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: expand image_newline column failed",
                     e,
                 )
             })?;
         let feat = Tensor::cat(&[&feat, &newline], 3).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: concat newline column failed",
                 e,
             )
@@ -679,7 +679,7 @@ impl VisionPerceive {
             .permute((0, 2, 3, 1))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: permute perceive tokens failed",
                     e,
                 )
@@ -687,7 +687,7 @@ impl VisionPerceive {
             .reshape((h2 * (w2 + 1), 4608usize))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: reshape perceive tokens failed",
                     e,
                 )
@@ -712,14 +712,14 @@ impl VisionPerceive {
         // the upstream weights but is never used in the forward path.
         let begin = self.image_begin.reshape((1usize, 1024usize)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: reshape image_begin failed",
                 e,
             )
         })?;
         let end = self.image_end.reshape((1usize, 1024usize)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: reshape image_end failed",
                 e,
             )
@@ -732,7 +732,7 @@ impl VisionPerceive {
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "perceive image_end to dtype", e))?;
         let cat = Tensor::cat(&[&begin, &tokens, &end], 0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: concat begin/tokens/end failed",
                 e,
             )
@@ -756,7 +756,7 @@ impl HunyuanVisionModel {
         cfg: &HunyuanOcrVisionConfig,
         version: HunyuanOcrVersion,
         vb: candle_nn::VarBuilder,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         let embeddings = VisionEmbeddings::load(cfg, version, vb.pp("embeddings"))?;
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         for i in 0..cfg.num_hidden_layers {
@@ -778,16 +778,16 @@ impl HunyuanVisionModel {
     /// Produce image token embeddings suitable for replacing the image-token span in the LLM input.
     ///
     /// Returned shape: (1 + Hm*(Wm+1) + 1, out_hidden=1024) where Hm/Wm are merged-grid sizes.
-    pub fn forward(&self, pixel_values: &Tensor) -> Result<(Tensor, (usize, usize)), OCRError> {
+    pub fn forward(&self, pixel_values: &Tensor) -> Result<(Tensor, (usize, usize)), Error> {
         let (_b, _c, rh, rw) = pixel_values.dims4().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: pixel_values dims4 failed",
                 e,
             )
         })?;
         if rh % self.cfg.patch_size != 0 || rw % self.cfg.patch_size != 0 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "HunyuanOCR: pixel_values {rw}x{rh} not divisible by patch_size={}",
                     self.cfg.patch_size
@@ -808,13 +808,13 @@ impl HunyuanVisionModel {
             })?;
         let (_b2, _c2, ph, pw) = patches.dims4().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: vit patches dims4 failed",
                 e,
             )
         })?;
         if ph != h || pw != w {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "HunyuanOCR: vit patch grid mismatch: expected {h}x{w} got {ph}x{pw}"
                 ),
@@ -823,7 +823,7 @@ impl HunyuanVisionModel {
 
         let patches = patches.squeeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: squeeze batch from vit patch embeddings failed",
                 e,
             )
@@ -833,7 +833,7 @@ impl HunyuanVisionModel {
             .permute((1, 2, 0))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: permute patches to hwd failed",
                     e,
                 )
@@ -841,7 +841,7 @@ impl HunyuanVisionModel {
             .reshape((h * w, self.cfg.hidden_size))
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "HunyuanOCR: reshape patches to seq failed",
                     e,
                 )
@@ -852,7 +852,7 @@ impl HunyuanVisionModel {
                 .interpolate_patch_pos(h, w, pixel_values.device(), patches.dtype())?;
         let patch_tokens = patches.broadcast_add(&patch_pos).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: add vit patch pos embedding failed",
                 e,
             )
@@ -865,7 +865,7 @@ impl HunyuanVisionModel {
         // propagated. Prepending one adds attention noise across all layers.
         let hidden = patch_tokens.unsqueeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: add batch dim to vit tokens failed",
                 e,
             )
@@ -875,7 +875,7 @@ impl HunyuanVisionModel {
         for (i, layer) in self.layers.iter().enumerate() {
             hidden_states = layer
                 .forward(&hidden_states)
-                .map_err(|e| OCRError::Inference {
+                .map_err(|e| Error::Inference {
                     model_name: "HunyuanOCR".to_string(),
                     context: format!("vit encoder layer {i} forward failed"),
                     source: Box::new(e),
@@ -885,7 +885,7 @@ impl HunyuanVisionModel {
         // No extra token to drop now (see above). Just unbatch.
         let patch_out = hidden_states.squeeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "HunyuanOCR: squeeze vit patch outputs failed",
                 e,
             )
@@ -894,7 +894,7 @@ impl HunyuanVisionModel {
         if !h.is_multiple_of(self.cfg.spatial_merge_size)
             || !w.is_multiple_of(self.cfg.spatial_merge_size)
         {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "HunyuanOCR: vit grid {h}x{w} not divisible by spatial_merge_size={}",
                     self.cfg.spatial_merge_size

--- a/oar-ocr-vl/src/layout.rs
+++ b/oar-ocr-vl/src/layout.rs
@@ -1,0 +1,102 @@
+//! Backend-agnostic layout detection interface used by [`DocParser`].
+//!
+//! [`DocParser`] only needs a per-page list of boxes, already in reading order.
+//! Expressing that as the [`LayoutSource`] trait keeps the parser independent
+//! of *how* layout is produced.
+//!
+//! [`PpDocLayout`](crate::PpDocLayout) is the built-in implementation. To run
+//! layout detection somewhere else — an ONNX model, a remote service, a cached
+//! run — implement the trait over it:
+//!
+//! ```no_run
+//! use image::RgbImage;
+//! use oar_ocr_vl::Error;
+//! use oar_ocr_vl::{LayoutDetections, LayoutSource};
+//!
+//! struct MyDetector;
+//!
+//! impl LayoutSource for MyDetector {
+//!     fn detect(&self, image: &RgbImage) -> Result<LayoutDetections, Error> {
+//!         let _ = image;
+//!         Ok(LayoutDetections::new(Vec::new()))
+//!     }
+//! }
+//! ```
+//!
+//! [`DocParser`]: crate::DocParser
+
+use crate::error::Error;
+use crate::geometry::BoundingBox;
+use image::RgbImage;
+use serde::{Deserialize, Serialize};
+
+/// One region reported by a detector, before it becomes a
+/// [`LayoutElement`](crate::LayoutElement).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayoutDetectionElement {
+    /// Region bounds in page pixels.
+    pub bbox: BoundingBox,
+    /// Raw label emitted by the model.
+    pub element_type: String,
+    /// Confidence in `[0, 1]`.
+    pub score: f32,
+}
+
+/// Layout detections for a single page, in reading order.
+#[derive(Debug, Clone, Default)]
+pub struct LayoutDetections {
+    /// Detected regions, in reading order.
+    pub elements: Vec<LayoutDetectionElement>,
+}
+
+impl LayoutDetections {
+    /// Wraps regions that are already in reading order.
+    pub fn new(elements: Vec<LayoutDetectionElement>) -> Self {
+        Self { elements }
+    }
+}
+
+/// A source of layout detections for a page image.
+///
+/// Implement this to plug a custom detector into
+/// [`DocParser::parse`](crate::DocParser::parse).
+pub trait LayoutSource {
+    /// Detects layout regions in a single page image.
+    ///
+    /// Elements must come back in reading order: [`DocParser`] numbers them as
+    /// given and never reorders them. PP-DocLayoutV2/V3 predict reading order
+    /// directly; a detector that does not must sort before returning.
+    ///
+    /// [`DocParser`]: crate::DocParser
+    fn detect(&self, image: &RgbImage) -> Result<LayoutDetections, Error>;
+}
+
+impl<T: LayoutSource + ?Sized> LayoutSource for &T {
+    fn detect(&self, image: &RgbImage) -> Result<LayoutDetections, Error> {
+        (**self).detect(image)
+    }
+}
+
+/// A [`LayoutSource`] backed by a precomputed detection list.
+///
+/// Useful for testing and for callers that obtain layout from an external
+/// service or a cached run.
+#[derive(Debug, Clone, Default)]
+pub struct StaticLayout {
+    detections: LayoutDetections,
+}
+
+impl StaticLayout {
+    /// Wraps regions that are already in reading order.
+    pub fn new(elements: Vec<LayoutDetectionElement>) -> Self {
+        Self {
+            detections: LayoutDetections::new(elements),
+        }
+    }
+}
+
+impl LayoutSource for StaticLayout {
+    fn detect(&self, _image: &RgbImage) -> Result<LayoutDetections, Error> {
+        Ok(self.detections.clone())
+    }
+}

--- a/oar-ocr-vl/src/lib.rs
+++ b/oar-ocr-vl/src/lib.rs
@@ -16,8 +16,19 @@
 //! - `monkeyocrv2` - MonkeyOCRv2-S/B-Parsing full-page and region parsing
 //! - `ovisocr2` - OvisOCR2 end-to-end page-to-Markdown parser (Qwen3.5)
 //! - `doc_parser` - Unified document parsing with pluggable recognition backends
+//! - `pp_doclayout` - Native PP-DocLayoutV2/V3 layout detection and reading
+//!   order
+//! - `layout` - Backend-agnostic [`LayoutSource`] trait feeding `doc_parser`
 //! - `utils` - Device parsing, candle helpers, markdown, OTSL conversion
 //! - `attention` - Unified attention shared by all models
+//!
+//! [`LayoutSource`]: layout::LayoutSource
+//!
+//! ## Candle only
+//!
+//! Everything here runs on Candle, including layout detection via
+//! [`PpDocLayout`], so `ort` never enters the dependency tree. To source layout
+//! from somewhere else, implement [`LayoutSource`].
 //!
 //! GPU acceleration is gated behind the `cuda` feature. Parse device strings
 //! with [`utils::parse_device`]:
@@ -33,15 +44,21 @@
 //! ```
 
 // Core model modules
+pub mod crop;
 pub mod doc_parser;
+pub mod error;
+pub mod geometry;
 pub mod glmocr;
 pub mod hpd_parsing;
 pub mod hunyuanocr;
+pub mod layout;
 pub mod mineru;
 pub mod mineru_diffusion;
 pub mod monkeyocrv2;
 pub mod ovisocr2;
 pub mod paddleocr_vl;
+pub mod pp_doclayout;
+pub mod structure;
 pub mod utils;
 
 // Shared attention implementation
@@ -74,3 +91,8 @@ pub use monkeyocrv2::{MonkeyOcrV2, MonkeyOcrV2Task};
 pub use ovisocr2::OvisOcr2;
 
 pub use doc_parser::{DocParser, DocParserConfig, RecognitionBackend, RecognitionTask};
+pub use error::{Error, ProcessingStage, Result};
+pub use geometry::{BoundingBox, Point};
+pub use layout::{LayoutDetectionElement, LayoutDetections, LayoutSource, StaticLayout};
+pub use pp_doclayout::{PpDocLayout, PpDocLayoutVersion};
+pub use structure::{LayoutElement, LayoutElementType, StructureResult, TableResult, TableType};

--- a/oar-ocr-vl/src/mineru/config.rs
+++ b/oar-ocr-vl/src/mineru/config.rs
@@ -1,4 +1,4 @@
-use oar_ocr_core::core::OCRError;
+use crate::error::Error;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -119,13 +119,13 @@ impl MinerUConfig {
         self.tie_word_embeddings || self.text_config.tie_word_embeddings
     }
 
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         crate::utils::load_json_config(path, "MinerU2.5", "config.json")
     }
 
-    pub fn head_dim(&self) -> Result<usize, OCRError> {
+    pub fn head_dim(&self) -> Result<usize, Error> {
         if !self.hidden_size.is_multiple_of(self.num_attention_heads) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU2.5: hidden_size {} not divisible by num_attention_heads {}",
                     self.hidden_size, self.num_attention_heads
@@ -170,14 +170,14 @@ pub struct MinerUImageSize {
 }
 
 impl MinerUImageProcessorConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         crate::utils::load_json_config(path, "MinerU2.5", "preprocessor_config.json")
     }
 
-    pub fn pixel_bounds(&self) -> Result<(u32, u32), OCRError> {
+    pub fn pixel_bounds(&self) -> Result<(u32, u32), Error> {
         if let Some(size) = &self.size {
             if size.shortest_edge == 0 || size.longest_edge == 0 {
-                return Err(OCRError::ConfigError {
+                return Err(Error::Config {
                     message: "MinerU2.5 size.shortest_edge/longest_edge must be > 0".to_string(),
                 });
             }
@@ -186,17 +186,17 @@ impl MinerUImageProcessorConfig {
 
         match (self.min_pixels, self.max_pixels) {
             (Some(min_pixels), Some(max_pixels)) => Ok((min_pixels, max_pixels)),
-            _ => Err(OCRError::ConfigError {
+            _ => Err(Error::Config {
                 message: "MinerU2.5 preprocessor_config missing size or min/max pixels".to_string(),
             }),
         }
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         if self.do_normalize {
             crate::utils::validate_image_mean_std("MinerU2.5", &self.image_mean, &self.image_std)?;
             if self.image_std.contains(&0.0) {
-                return Err(OCRError::ConfigError {
+                return Err(Error::Config {
                     message: "MinerU2.5 image_std values must be non-zero".to_string(),
                 });
             }
@@ -210,12 +210,12 @@ impl MinerUImageProcessorConfig {
         if self.do_resize {
             let (min_pixels, max_pixels) = self.pixel_bounds()?;
             if min_pixels == 0 || max_pixels == 0 {
-                return Err(OCRError::ConfigError {
+                return Err(Error::Config {
                     message: "MinerU2.5 min/max pixels must be > 0".to_string(),
                 });
             }
             if min_pixels > max_pixels {
-                return Err(OCRError::ConfigError {
+                return Err(Error::Config {
                     message: format!(
                         "MinerU2.5 min_pixels ({min_pixels}) must be <= max_pixels ({max_pixels})"
                     ),
@@ -223,7 +223,7 @@ impl MinerUImageProcessorConfig {
             }
         }
         if self.do_rescale && self.rescale_factor <= 0.0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "MinerU2.5 rescale_factor must be > 0".to_string(),
             });
         }

--- a/oar-ocr-vl/src/mineru/model.rs
+++ b/oar-ocr-vl/src/mineru/model.rs
@@ -7,12 +7,12 @@ use crate::attention::{
 };
 #[cfg(feature = "cuda")]
 use crate::cuda_kernels::{ArgmaxFirstBf16, ArgmaxFirstF32, MaskTokenIds};
+use crate::error::Error;
+use crate::structure::LayoutElementType;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::{Linear, Module, VarBuilder, linear_no_bias};
 use image::RgbImage;
-use oar_ocr_core::core::OCRError;
-use oar_ocr_core::domain::structure::LayoutElementType;
 use rand::distr::weighted::WeightedIndex;
 use rand::prelude::*;
 use serde::Deserialize;
@@ -128,14 +128,14 @@ struct MinerUGenerationConfig {
 }
 
 impl MinerU {
-    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, OCRError> {
+    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, Error> {
         let model_dir = model_dir.as_ref();
         let cfg = MinerUConfig::from_path(model_dir.join("config.json"))?;
         let image_cfg =
             MinerUImageProcessorConfig::from_path(model_dir.join("preprocessor_config.json"))?;
 
         if image_cfg.merge_size != cfg.vision_config.spatial_merge_size {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU2.5 merge_size mismatch: preprocessor {} != vision {}",
                     image_cfg.merge_size, cfg.vision_config.spatial_merge_size
@@ -143,7 +143,7 @@ impl MinerU {
             });
         }
         if image_cfg.patch_size != cfg.vision_config.patch_size {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU2.5 patch_size mismatch: preprocessor {} != vision {}",
                     image_cfg.patch_size, cfg.vision_config.patch_size
@@ -151,11 +151,10 @@ impl MinerU {
             });
         }
 
-        let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| {
-            OCRError::ConfigError {
+        let tokenizer =
+            Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| Error::Config {
                 message: format!("failed to load MinerU2.5 tokenizer.json: {e}"),
-            }
-        })?;
+            })?;
 
         let gen_cfg = load_generation_config(model_dir.join("generation_config.json"));
         let repetition_penalty = gen_cfg
@@ -188,7 +187,7 @@ impl MinerU {
         if let Some(tok_image_id) = tokenizer.token_to_id("<|image_pad|>")
             && tok_image_id != cfg.image_token_id
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU2.5 image_token_id mismatch: tokenizer {tok_image_id} != config {}",
                     cfg.image_token_id
@@ -291,12 +290,12 @@ impl MinerU {
         images: &[RgbImage],
         instructions: &[impl AsRef<str>],
         max_new_tokens: usize,
-    ) -> Vec<Result<String, OCRError>> {
+    ) -> Vec<Result<String, Error>> {
         if images.is_empty() {
             return Vec::new();
         }
         if images.len() != instructions.len() {
-            return vec![Err(OCRError::InvalidInput {
+            return vec![Err(Error::InvalidInput {
                 message: format!(
                     "MinerU2.5: images count ({}) != instructions count ({})",
                     images.len(),
@@ -314,7 +313,7 @@ impl MinerU {
                 let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
-                        Err(OCRError::InvalidInput {
+                        Err(Error::InvalidInput {
                             message: msg.clone(),
                         })
                     })
@@ -331,12 +330,12 @@ impl MinerU {
         images: &[RgbImage],
         instructions: &[impl AsRef<str>],
         max_new_tokens: usize,
-    ) -> Vec<Result<Vec<u32>, OCRError>> {
+    ) -> Vec<Result<Vec<u32>, Error>> {
         if images.is_empty() {
             return Vec::new();
         }
         if images.len() != instructions.len() {
-            return vec![Err(OCRError::InvalidInput {
+            return vec![Err(Error::InvalidInput {
                 message: format!(
                     "MinerU2.5: images count ({}) != instructions count ({})",
                     images.len(),
@@ -351,7 +350,7 @@ impl MinerU {
                 let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
-                        Err(OCRError::InvalidInput {
+                        Err(Error::InvalidInput {
                             message: msg.clone(),
                         })
                     })
@@ -365,7 +364,7 @@ impl MinerU {
         images: &[RgbImage],
         instructions: &[impl AsRef<str>],
         max_new_tokens: usize,
-    ) -> Result<Vec<Vec<u32>>, OCRError> {
+    ) -> Result<Vec<Vec<u32>>, Error> {
         let batch_size = images.len();
 
         let image_inputs = preprocess_images(images, &self.image_cfg, &self.device, self.dtype)?;
@@ -386,7 +385,7 @@ impl MinerU {
             let enc = self
                 .tokenizer
                 .encode(prompt, false)
-                .map_err(|e| OCRError::InvalidInput {
+                .map_err(|e| Error::InvalidInput {
                     message: format!("MinerU2.5: tokenizer encode failed: {e}"),
                 })?;
 
@@ -403,7 +402,7 @@ impl MinerU {
             .dim(0)
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "image_embeds dim", e))?;
         if actual_embeds != expected_embeds {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "MinerU2.5: image embeds count mismatch: got {actual_embeds}, expected {expected_embeds}"
                 ),
@@ -412,7 +411,7 @@ impl MinerU {
 
         let seq_lens: Vec<usize> = all_input_ids.iter().map(|ids| ids.len()).collect();
         let Some(&max_seq_len) = seq_lens.iter().max() else {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "MinerU2.5: empty batch is not supported".to_string(),
             });
         };
@@ -442,7 +441,7 @@ impl MinerU {
             if let Some(first_pos) = first_img_pos {
                 let image_end = first_pos + image_token_count;
                 if image_end > seq_len {
-                    return Err(OCRError::InvalidInput {
+                    return Err(Error::InvalidInput {
                         message: format!(
                             "MinerU2.5: image token span out of range: {image_end} > {seq_len}"
                         ),
@@ -660,7 +659,7 @@ impl MinerU {
         Ok(generated)
     }
 
-    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, Error> {
         self.decode_generated_tokens(tokens)
     }
 
@@ -669,7 +668,7 @@ impl MinerU {
     /// there is no markdown / wrapping / layout post-process at this layer
     /// (layout-aware reordering happens in `two_step_extract`, not here).
     /// This alias exists for API symmetry with PaddleOCR-VL / GLM-OCR.
-    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, Error> {
         self.decode_generated_tokens(tokens)
     }
 
@@ -690,7 +689,7 @@ impl MinerU {
         }
     }
 
-    fn decode_generated_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    fn decode_generated_tokens(&self, tokens: &[u32]) -> Result<String, Error> {
         // Filter out bos/eos/pad tokens before decoding (matching official implementation).
         let filtered: Vec<u32> = tokens
             .iter()
@@ -699,7 +698,7 @@ impl MinerU {
             .collect();
         self.tokenizer
             .decode(&filtered, false) // skip_special_tokens=false to preserve special tokens
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("decode failed: {e}"),
             })
     }
@@ -742,7 +741,7 @@ fn select_next_token(
     logits: &Tensor,
     history: &[u32],
     params: &SamplingParams,
-) -> Result<u32, OCRError> {
+) -> Result<u32, Error> {
     // The official MinerU generation config uses top_k=1 and
     // repetition_penalty=1, so decoding is greedy even though do_sample=true.
     // Keep the full vocabulary on-device for that common path. The custom
@@ -809,7 +808,7 @@ fn select_greedy_token_cuda(
     logits: &Tensor,
     history: &[u32],
     no_repeat_ngram_size: usize,
-) -> Result<u32, OCRError> {
+) -> Result<u32, Error> {
     let vocab_size = logits.elem_count();
     let logits = logits
         .reshape((1, vocab_size))
@@ -827,7 +826,7 @@ fn select_greedy_token_cuda(
         DType::BF16 => logits.apply_op1_no_bwd(&ArgmaxFirstBf16),
         DType::F32 => logits.apply_op1_no_bwd(&ArgmaxFirstF32),
         dtype => {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!("MinerU2.5: unsupported GPU greedy logits dtype {dtype:?}"),
             });
         }
@@ -1008,14 +1007,14 @@ fn expand_image_tokens(
     input_ids: &[u32],
     image_token_id: u32,
     image_token_counts: &[usize],
-) -> Result<Vec<u32>, OCRError> {
+) -> Result<Vec<u32>, Error> {
     let mut out: Vec<u32> = Vec::new();
     let mut idx = 0usize;
     for &id in input_ids {
         if id == image_token_id {
             let count = image_token_counts
                 .get(idx)
-                .ok_or_else(|| OCRError::InvalidInput {
+                .ok_or_else(|| Error::InvalidInput {
                     message: "MinerU2.5: image token count mismatch".to_string(),
                 })?;
             out.extend(std::iter::repeat_n(image_token_id, *count));
@@ -1025,7 +1024,7 @@ fn expand_image_tokens(
         }
     }
     if idx != image_token_counts.len() {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "MinerU2.5: image token count mismatch".to_string(),
         });
     }
@@ -1040,7 +1039,7 @@ fn get_rope_index(
     video_token_id: u32,
     spatial_merge_size: usize,
     device: &Device,
-) -> Result<(Tensor, i64), OCRError> {
+) -> Result<(Tensor, i64), Error> {
     // Qwen2-VL multimodal RoPE has three position axes: temporal, height, width.
     const NUM_ROPE_AXES: usize = 3;
     let image_token_id = cfg.image_token_id;
@@ -1050,13 +1049,13 @@ fn get_rope_index(
             image_count += 1;
         }
         if input_ids[i] == vision_start_token_id && input_ids[i + 1] == video_token_id {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "MinerU2.5: video inputs are not supported".to_string(),
             });
         }
     }
     if image_count != image_grid_thw.len() {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "MinerU2.5: image count mismatch between prompt ({image_count}) and image_grid_thw ({})",
                 image_grid_thw.len()
@@ -1073,7 +1072,7 @@ fn get_rope_index(
             .iter()
             .position(|&id| id == image_token_id)
             .map(|p| st + p)
-            .ok_or_else(|| OCRError::InvalidInput {
+            .ok_or_else(|| Error::InvalidInput {
                 message: format!(
                     "MinerU2.5: expected image token for image[{image_index}] but none found"
                 ),
@@ -1115,7 +1114,7 @@ fn get_rope_index(
     }
 
     if positions.len() != input_ids.len() {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "MinerU2.5: rope position ids length mismatch: got {}, expected {}",
                 positions.len(),
@@ -1137,7 +1136,7 @@ fn get_rope_index(
     let position_ids = Tensor::from_vec(pos_ids, (NUM_ROPE_AXES, 1usize, input_ids.len()), device)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: build position_ids tensor failed",
                 e,
             )

--- a/oar-ocr-vl/src/mineru/processing.rs
+++ b/oar-ocr-vl/src/mineru/processing.rs
@@ -1,10 +1,10 @@
 use super::config::MinerUImageProcessorConfig;
+use crate::error::Error;
 use crate::utils::image::{
     image_to_chw, patchify_merge_grouped, pil_resample_to_filter_type, smart_resize,
 };
 use candle_core::{DType, Device, Tensor};
 use image::{RgbImage, imageops::FilterType};
-use oar_ocr_core::core::OCRError;
 
 #[derive(Debug, Clone)]
 pub struct MinerUImageInputs {
@@ -17,10 +17,10 @@ pub fn preprocess_images(
     cfg: &MinerUImageProcessorConfig,
     device: &Device,
     dtype: DType,
-) -> Result<MinerUImageInputs, OCRError> {
+) -> Result<MinerUImageInputs, Error> {
     cfg.validate()?;
     if images.is_empty() {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "MinerU2.5: no images provided".to_string(),
         });
     }
@@ -61,7 +61,7 @@ pub fn preprocess_images(
     for img in images {
         let (h, w) = (img.height(), img.width());
         if cfg.do_resize && (h < factor || w < factor) {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!("MinerU2.5: height/width must be >= factor {factor}, got {h}x{w}"),
             });
         }
@@ -78,7 +78,7 @@ pub fn preprocess_images(
         };
 
         if rh % patch != 0 || rw % patch != 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU2.5 preprocess produced non-divisible dims: {rh}x{rw} not divisible by patch_size={patch}"
                 ),
@@ -88,7 +88,7 @@ pub fn preprocess_images(
         let grid_h = (rh / patch) as usize;
         let grid_w = (rw / patch) as usize;
         if !grid_h.is_multiple_of(merge) || !grid_w.is_multiple_of(merge) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU2.5 preprocess produced grid not divisible by merge_size={merge}: {grid_h}x{grid_w}"
                 ),
@@ -125,8 +125,8 @@ pub fn preprocess_images(
         );
 
         if flat_patches.len() != num_patches * patch_dim {
-            return Err(OCRError::Processing {
-                kind: oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            return Err(Error::Processing {
+                kind: crate::error::ProcessingStage::TensorOperation,
                 context: format!(
                     "MinerU2.5: patch extraction mismatch, got {} expected {}",
                     flat_patches.len(),
@@ -147,14 +147,14 @@ pub fn preprocess_images(
     let total_patches = all_patches.len() / patch_dim;
 
     let pixel_values = Tensor::from_vec(all_patches, (total_patches, patch_dim), device)
-        .map_err(|e| OCRError::Processing {
-            kind: oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+        .map_err(|e| Error::Processing {
+            kind: crate::error::ProcessingStage::TensorOperation,
             context: "MinerU2.5: failed to create pixel_values tensor".to_string(),
             source: Box::new(e),
         })?
         .to_dtype(dtype)
-        .map_err(|e| OCRError::Processing {
-            kind: oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+        .map_err(|e| Error::Processing {
+            kind: crate::error::ProcessingStage::TensorOperation,
             context: "MinerU2.5: failed to convert pixel_values to target dtype".to_string(),
             source: Box::new(e),
         })?;

--- a/oar-ocr-vl/src/mineru/text.rs
+++ b/oar-ocr-vl/src/mineru/text.rs
@@ -9,6 +9,7 @@ use crate::decoder_graph::{
     CudaGraphKvLengths, SingleTokenDecoderCudaGraph, cuda_graph_error, decoder_attention_is_causal,
     sync_graph_tensor,
 };
+use crate::error::Error;
 #[cfg(feature = "cuda")]
 use crate::hunyuanocr::dynamic_kv::DynamicKvAppend;
 use crate::kv_trim::TrimmableKvCache;
@@ -19,7 +20,6 @@ use candle_core::{IndexOp, Tensor};
 use candle_nn::{
     Embedding, Linear, Module, VarBuilder, embedding, linear, linear_no_bias, rms_norm,
 };
-use oar_ocr_core::core::OCRError;
 use std::cell::RefCell;
 use std::sync::Arc;
 
@@ -32,13 +32,13 @@ fn apply_multimodal_rotary_pos_emb(
     cos: &Tensor,
     sin: &Tensor,
     mrope_section: &[usize],
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     let cos = select_rope_sections(cos, mrope_section, 3)?;
     let sin = select_rope_sections(sin, mrope_section, 3)?;
 
     let q_mul = q.broadcast_mul(&cos).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: mrope q*cos failed",
             e,
         )
@@ -46,14 +46,14 @@ fn apply_multimodal_rotary_pos_emb(
     let q_half = rotate_half(q)?;
     let q_half_mul = q_half.broadcast_mul(&sin).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: mrope rotate_half(q)*sin failed",
             e,
         )
     })?;
     let q_rot = (&q_mul + &q_half_mul).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: mrope apply on q failed",
             e,
         )
@@ -61,7 +61,7 @@ fn apply_multimodal_rotary_pos_emb(
 
     let k_mul = k.broadcast_mul(&cos).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: mrope k*cos failed",
             e,
         )
@@ -69,14 +69,14 @@ fn apply_multimodal_rotary_pos_emb(
     let k_half = rotate_half(k)?;
     let k_half_mul = k_half.broadcast_mul(&sin).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: mrope rotate_half(k)*sin failed",
             e,
         )
     })?;
     let k_rot = (&k_mul + &k_half_mul).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: mrope apply on k failed",
             e,
         )
@@ -93,7 +93,7 @@ struct MinerUMlp {
 }
 
 impl MinerUMlp {
-    fn load(cfg: &MinerUConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MinerUConfig, vb: VarBuilder) -> Result<Self, Error> {
         let gate_proj = linear_no_bias(
             cfg.hidden_size,
             cfg.intermediate_size,
@@ -115,7 +115,7 @@ impl MinerUMlp {
         })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, Error> {
         let gate = self
             .gate_proj
             .forward(xs)
@@ -150,12 +150,12 @@ struct MinerUAttention {
 }
 
 impl MinerUAttention {
-    fn load(cfg: &MinerUConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MinerUConfig, vb: VarBuilder) -> Result<Self, Error> {
         if !cfg
             .num_attention_heads
             .is_multiple_of(cfg.num_key_value_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU2.5: num_attention_heads ({}) must be divisible by num_key_value_heads ({})",
                     cfg.num_attention_heads, cfg.num_key_value_heads
@@ -211,7 +211,7 @@ impl MinerUAttention {
         hidden_states: &Tensor,
         cos: &Tensor,
         sin: &Tensor,
-    ) -> Result<(Tensor, Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor, Tensor), Error> {
         let (b, seq_len, _) = hidden_states
             .dims3()
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "attn hidden_states dims3", e))?;
@@ -260,7 +260,7 @@ impl MinerUAttention {
         cos: &Tensor,
         sin: &Tensor,
         attention_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (b, seq_len, _) = hidden_states
             .dims3()
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "attn hidden_states dims3", e))?;
@@ -299,7 +299,7 @@ impl MinerUAttention {
         attn_output: &Tensor,
         batch: usize,
         seq_len: usize,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let attn_output = attn_output
             .transpose(1, 2)
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "attn output transpose", e))?
@@ -312,7 +312,7 @@ impl MinerUAttention {
     }
 
     #[cfg(feature = "cuda")]
-    fn prepare_dynamic_cache(&self, query_len: usize, cache_len: usize) -> Result<(), OCRError> {
+    fn prepare_dynamic_cache(&self, query_len: usize, cache_len: usize) -> Result<(), Error> {
         let template = Tensor::zeros(
             (1, self.num_kv_heads, query_len, self.head_dim),
             self.k_proj.weight().dtype(),
@@ -333,19 +333,19 @@ impl MinerUAttention {
         sin: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (batch, query_len, _) = hidden_states.dims3().map_err(|e| {
             candle_to_ocr_inference("MinerU2.5", "dynamic attention hidden shape", e)
         })?;
         if batch != 1 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "MinerU2.5 CUDA-graph attention requires batch size 1".to_string(),
             });
         }
         let (q, k, v) = self.project_qkv(hidden_states, cos, sin)?;
         let cache = self.kv_cache.borrow();
         let cache_len = cache.storage_capacity();
-        let (cache_k, cache_v) = cache.storage().ok_or_else(|| OCRError::ConfigError {
+        let (cache_k, cache_v) = cache.storage().ok_or_else(|| Error::Config {
             message: "MinerU2.5 dynamic KV storage is not initialized".to_string(),
         })?;
         drop(cache);
@@ -400,7 +400,7 @@ impl MinerUAttention {
     }
 
     #[cfg(feature = "cuda")]
-    fn set_kv_cache_len(&self, len: usize) -> Result<(), OCRError> {
+    fn set_kv_cache_len(&self, len: usize) -> Result<(), Error> {
         self.kv_cache
             .borrow_mut()
             .set_current_len(len)
@@ -416,7 +416,7 @@ pub struct MinerUDecoderLayer {
 }
 
 impl MinerUDecoderLayer {
-    fn load(cfg: &MinerUConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MinerUConfig, vb: VarBuilder) -> Result<Self, Error> {
         let self_attn = MinerUAttention::load(cfg, vb.clone())?;
         let mlp = MinerUMlp::load(cfg, vb.clone())?;
         let input_layernorm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))
@@ -441,7 +441,7 @@ impl MinerUDecoderLayer {
         cos: &Tensor,
         sin: &Tensor,
         attention_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let residual = hidden_states.clone();
         let hidden_states = self
             .input_layernorm
@@ -452,7 +452,7 @@ impl MinerUDecoderLayer {
             .forward(&hidden_states, cos, sin, attention_mask)?;
         let hidden_states = (&residual + &hidden_states).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: attn residual add failed",
                 e,
             )
@@ -466,7 +466,7 @@ impl MinerUDecoderLayer {
         let hidden_states = self.mlp.forward(&hidden_states)?;
         (&residual + &hidden_states).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: mlp residual add failed",
                 e,
             )
@@ -481,7 +481,7 @@ impl MinerUDecoderLayer {
         sin: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let residual = hidden_states.clone();
         let hidden_states = self
             .input_layernorm
@@ -492,7 +492,7 @@ impl MinerUDecoderLayer {
                 .forward_dynamic(&hidden_states, cos, sin, query_lengths, kv_lengths)?;
         let hidden_states = (&residual + &hidden_states).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: attn residual add failed",
                 e,
             )
@@ -506,7 +506,7 @@ impl MinerUDecoderLayer {
         let hidden_states = self.mlp.forward(&hidden_states)?;
         (&residual + &hidden_states).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: mlp residual add failed",
                 e,
             )
@@ -523,7 +523,7 @@ impl MinerUDecoderLayer {
     }
 
     #[cfg(feature = "cuda")]
-    fn set_kv_cache_len(&self, len: usize) -> Result<(), OCRError> {
+    fn set_kv_cache_len(&self, len: usize) -> Result<(), Error> {
         self.self_attn.set_kv_cache_len(len)
     }
 }
@@ -538,7 +538,7 @@ pub struct MinerUTextModel {
 }
 
 impl MinerUTextModel {
-    pub fn load(cfg: &MinerUConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    pub fn load(cfg: &MinerUConfig, vb: VarBuilder) -> Result<Self, Error> {
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("embed_tokens"))
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "load embed_tokens", e))?;
 
@@ -568,7 +568,7 @@ impl MinerUTextModel {
         })
     }
 
-    pub fn embed(&self, input_ids: &Tensor) -> Result<Tensor, OCRError> {
+    pub fn embed(&self, input_ids: &Tensor) -> Result<Tensor, Error> {
         self.embed_tokens
             .forward(input_ids)
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "embed forward", e))
@@ -579,7 +579,7 @@ impl MinerUTextModel {
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
         attention_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (cos, sin) = self
             .rotary_emb
             .forward_multi_axis(position_ids, inputs_embeds.dtype())?;
@@ -593,7 +593,7 @@ impl MinerUTextModel {
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "norm forward", e))
     }
 
-    fn project_logits(&self, hidden_states: &Tensor, lm_head: &Linear) -> Result<Tensor, OCRError> {
+    fn project_logits(&self, hidden_states: &Tensor, lm_head: &Linear) -> Result<Tensor, Error> {
         lm_head
             .forward(hidden_states)
             .and_then(|logits| logits.i((0, 0, ..)))
@@ -606,7 +606,7 @@ impl MinerUTextModel {
         position_ids: &Tensor,
         attention_mask: Option<&Tensor>,
         lm_head: &Linear,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         #[cfg(feature = "cuda")]
         {
             let kv_len = self.kv_cache_len().saturating_add(1);
@@ -625,7 +625,7 @@ impl MinerUTextModel {
         position_ids: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (cos, sin) = self
             .rotary_emb
             .forward_multi_axis(position_ids, inputs_embeds.dtype())?;
@@ -644,7 +644,7 @@ impl MinerUTextModel {
         prompt_len: usize,
         max_new_tokens: usize,
         lm_head: &Linear,
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         if std::env::var_os("OAR_VL_DISABLE_CUDA_GRAPH").is_some()
             || std::env::var_os("OAR_MINERU_DISABLE_CUDA_GRAPH").is_some()
         {
@@ -686,7 +686,7 @@ impl MinerUTextModel {
     }
 
     #[cfg(feature = "cuda")]
-    fn capture_cuda_graph(&self, cache_len: usize, lm_head: &Linear) -> Result<(), OCRError> {
+    fn capture_cuda_graph(&self, cache_len: usize, lm_head: &Linear) -> Result<(), Error> {
         use candle_core::cuda_backend::cudarc::driver::sys::{
             CUgraphInstantiate_flags_enum, CUstreamCaptureMode_enum,
         };
@@ -759,7 +759,7 @@ impl MinerUTextModel {
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
             )
             .map_err(|e| cuda_graph_error("MinerU2.5", "end decoder CUDA graph capture", e))?
-            .ok_or_else(|| OCRError::ConfigError {
+            .ok_or_else(|| Error::Config {
                 message: "MinerU2.5 decoder capture returned no graph".to_string(),
             })?;
         graph
@@ -785,7 +785,7 @@ impl MinerUTextModel {
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
         kv_len: usize,
-    ) -> Result<Option<Tensor>, OCRError> {
+    ) -> Result<Option<Tensor>, Error> {
         let captured_ref = self.decode_graph.borrow();
         let Some(captured) = captured_ref.as_ref() else {
             return Ok(None);

--- a/oar-ocr-vl/src/mineru/vision.rs
+++ b/oar-ocr-vl/src/mineru/vision.rs
@@ -3,29 +3,29 @@ use crate::attention::{
     VISION_CHUNKED_ATTN_CHUNK_SIZE, VISION_CHUNKED_ATTN_SEQ_THRESHOLD, chunked_vision_attention,
     on_compute_device, scaled_dot_product_attention,
 };
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::{LayerNorm, LayerNormConfig, Linear, Module, VarBuilder, layer_norm, linear};
-use oar_ocr_core::core::OCRError;
 
-fn quick_gelu(xs: &Tensor) -> Result<Tensor, OCRError> {
+fn quick_gelu(xs: &Tensor) -> Result<Tensor, Error> {
     let scaled = (xs * 1.702).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: quick_gelu scale failed",
             e,
         )
     })?;
     let sig = candle_nn::ops::sigmoid(&scaled).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: quick_gelu sigmoid failed",
             e,
         )
     })?;
     (xs * sig).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: quick_gelu multiply failed",
             e,
         )
@@ -40,30 +40,30 @@ enum VisionAct {
 }
 
 impl VisionAct {
-    fn from_str(name: &str) -> Result<Self, OCRError> {
+    fn from_str(name: &str) -> Result<Self, Error> {
         match name {
             "quick_gelu" => Ok(Self::QuickGelu),
             "gelu" | "gelu_new" | "gelu_pytorch_tanh" => Ok(Self::Gelu),
             "silu" => Ok(Self::Silu),
-            _ => Err(OCRError::ConfigError {
+            _ => Err(Error::Config {
                 message: format!("MinerU2.5: unsupported vision hidden_act '{name}'"),
             }),
         }
     }
 
-    fn forward(self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(self, xs: &Tensor) -> Result<Tensor, Error> {
         match self {
             Self::QuickGelu => quick_gelu(xs),
             Self::Gelu => xs.gelu_erf().map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "MinerU2.5: vision gelu failed",
                     e,
                 )
             }),
             Self::Silu => candle_nn::ops::silu(xs).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "MinerU2.5: vision silu failed",
                     e,
                 )
@@ -77,19 +77,19 @@ fn apply_rotary_pos_emb_vision(
     k: &Tensor,
     cos: &Tensor,
     sin: &Tensor,
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     let orig_q_dtype = q.dtype();
     let orig_k_dtype = k.dtype();
     let q = q.to_dtype(DType::F32).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision q cast failed",
             e,
         )
     })?;
     let k = k.to_dtype(DType::F32).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision k cast failed",
             e,
         )
@@ -99,7 +99,7 @@ fn apply_rotary_pos_emb_vision(
         .unsqueeze(1)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision cos unsqueeze failed",
                 e,
             )
@@ -107,7 +107,7 @@ fn apply_rotary_pos_emb_vision(
         .to_dtype(DType::F32)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision cos cast failed",
                 e,
             )
@@ -116,7 +116,7 @@ fn apply_rotary_pos_emb_vision(
         .unsqueeze(1)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision sin unsqueeze failed",
                 e,
             )
@@ -124,7 +124,7 @@ fn apply_rotary_pos_emb_vision(
         .to_dtype(DType::F32)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision sin cast failed",
                 e,
             )
@@ -135,21 +135,21 @@ fn apply_rotary_pos_emb_vision(
         .broadcast_mul(&cos)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision q*cos failed",
                 e,
             )
         })?
         .broadcast_add(&q_rot.broadcast_mul(&sin).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision rotate_half(q)*sin failed",
                 e,
             )
         })?)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision q rope add failed",
                 e,
             )
@@ -160,21 +160,21 @@ fn apply_rotary_pos_emb_vision(
         .broadcast_mul(&cos)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision k*cos failed",
                 e,
             )
         })?
         .broadcast_add(&k_rot.broadcast_mul(&sin).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision rotate_half(k)*sin failed",
                 e,
             )
         })?)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision k rope add failed",
                 e,
             )
@@ -182,14 +182,14 @@ fn apply_rotary_pos_emb_vision(
 
     let q_embed = q_embed.to_dtype(orig_q_dtype).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision q_embed cast back failed",
             e,
         )
     })?;
     let k_embed = k_embed.to_dtype(orig_k_dtype).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision k_embed cast back failed",
             e,
         )
@@ -205,12 +205,12 @@ struct VisionRotaryEmbedding {
 }
 
 impl VisionRotaryEmbedding {
-    fn new(dim: usize, theta: f64, device: &Device) -> Result<Self, OCRError> {
+    fn new(dim: usize, theta: f64, device: &Device) -> Result<Self, Error> {
         let inv_freq = crate::utils::vision_inv_freq(dim, theta, "MinerU2.5", device)?;
         Ok(Self { inv_freq, dim })
     }
 
-    fn forward(&self, seqlen: usize, device: &Device) -> Result<Tensor, OCRError> {
+    fn forward(&self, seqlen: usize, device: &Device) -> Result<Tensor, Error> {
         // Use on_compute_device to handle Metal's lack of support for arange
         on_compute_device(device, |compute_device| {
             let seq = Tensor::arange(0u32, seqlen as u32, compute_device)?.to_dtype(DType::F32)?;
@@ -222,7 +222,7 @@ impl VisionRotaryEmbedding {
         })
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision rope forward failed",
                 e,
             )
@@ -240,7 +240,7 @@ struct PatchEmbed {
 }
 
 impl PatchEmbed {
-    fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let patch_dim =
             cfg.in_channels() * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size;
         let weight = match vb.get((cfg.embed_dim, patch_dim), "patch_embed.proj.weight") {
@@ -266,17 +266,17 @@ impl PatchEmbed {
         Ok(Self { weight })
     }
 
-    fn forward(&self, patches: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, patches: &Tensor) -> Result<Tensor, Error> {
         let weight_t = self.weight.transpose(0, 1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: patch_embed weight transpose failed",
                 e,
             )
         })?;
         let patches = patches.to_dtype(self.weight.dtype()).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: patch_embed input cast failed",
                 e,
             )
@@ -297,14 +297,14 @@ struct VisionAttention {
 }
 
 impl VisionAttention {
-    fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let qkv = linear(cfg.embed_dim, cfg.embed_dim * 3, vb.pp("attn.qkv"))
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "load vision qkv", e))?;
         let proj = linear(cfg.embed_dim, cfg.embed_dim, vb.pp("attn.proj"))
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "load vision proj", e))?;
 
         if !cfg.embed_dim.is_multiple_of(cfg.num_heads) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU2.5: vision embed_dim {} not divisible by num_heads {}",
                     cfg.embed_dim, cfg.num_heads
@@ -322,12 +322,7 @@ impl VisionAttention {
         })
     }
 
-    fn forward(
-        &self,
-        hidden_states: &Tensor,
-        cos: &Tensor,
-        sin: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let seq_len = hidden_states
             .dim(0)
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "vision hidden_states dim", e))?;
@@ -401,7 +396,7 @@ struct VisionMlp {
 }
 
 impl VisionMlp {
-    fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let hidden_dim = cfg.mlp_hidden_dim();
         let fc1 = linear(cfg.embed_dim, hidden_dim, vb.pp("mlp.fc1"))
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "load vision fc1", e))?;
@@ -411,7 +406,7 @@ impl VisionMlp {
         Ok(Self { fc1, fc2, act })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, Error> {
         let x = self
             .fc1
             .forward(xs)
@@ -432,7 +427,7 @@ struct VisionBlock {
 }
 
 impl VisionBlock {
-    fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let norm_cfg = LayerNormConfig {
             eps: 1e-6,
             ..Default::default()
@@ -451,12 +446,7 @@ impl VisionBlock {
         })
     }
 
-    fn forward(
-        &self,
-        hidden_states: &Tensor,
-        cos: &Tensor,
-        sin: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let normed = self
             .norm1
             .forward(hidden_states)
@@ -464,7 +454,7 @@ impl VisionBlock {
         let attn_out = self.attn.forward(&normed, cos, sin)?;
         let hidden_states = (hidden_states + attn_out).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision attn residual failed",
                 e,
             )
@@ -477,7 +467,7 @@ impl VisionBlock {
         let mlp_out = self.mlp.forward(&normed)?;
         (hidden_states + mlp_out).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: vision mlp residual failed",
                 e,
             )
@@ -495,7 +485,7 @@ struct PatchMerger {
 }
 
 impl PatchMerger {
-    fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let norm_cfg = LayerNormConfig {
             eps: 1e-6,
             ..Default::default()
@@ -516,13 +506,13 @@ impl PatchMerger {
         })
     }
 
-    fn forward(&self, x: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
         let num_patches = x
             .dim(0)
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "merger dim", e))?;
         let group = self.merge_size * self.merge_size;
         if num_patches % group != 0 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "MinerU2.5: merger expects num_patches divisible by {}, got {}",
                     group, num_patches
@@ -542,7 +532,7 @@ impl PatchMerger {
             .map_err(|e| candle_to_ocr_inference("MinerU2.5", "merger mlp1", e))?;
         let x = x.gelu_erf().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU2.5: merger gelu failed",
                 e,
             )
@@ -562,7 +552,7 @@ pub struct MinerUVisionModel {
 }
 
 impl MinerUVisionModel {
-    pub fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    pub fn load(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         Self::load_inner(cfg, vb, true)
     }
 
@@ -572,10 +562,7 @@ impl MinerUVisionModel {
     /// with an external abstractor instead. Pair with [`forward_tokens`].
     ///
     /// [`forward_tokens`]: MinerUVisionModel::forward_tokens
-    pub(crate) fn load_backbone(
-        cfg: &MinerUVisionConfig,
-        vb: VarBuilder,
-    ) -> Result<Self, OCRError> {
+    pub(crate) fn load_backbone(cfg: &MinerUVisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         Self::load_inner(cfg, vb, false)
     }
 
@@ -583,7 +570,7 @@ impl MinerUVisionModel {
         cfg: &MinerUVisionConfig,
         vb: VarBuilder,
         with_merger: bool,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         let patch_embed = PatchEmbed::load(cfg, vb.clone())?;
         let mut blocks = Vec::with_capacity(cfg.depth);
         for i in 0..cfg.depth {
@@ -597,7 +584,7 @@ impl MinerUVisionModel {
         };
         let head_dim = cfg.embed_dim / cfg.num_heads;
         if !head_dim.is_multiple_of(2) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU2.5: head_dim {} must be even for rotary embeddings",
                     head_dim
@@ -621,7 +608,7 @@ impl MinerUVisionModel {
         &self,
         pixel_values: &Tensor,
         grid_thw: &[(usize, usize, usize)],
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let max_grid = grid_thw
             .iter()
             .map(|(_, h, w)| (*h).max(*w))
@@ -666,8 +653,8 @@ impl MinerUVisionModel {
         &self,
         pixel_values: &Tensor,
         grid_thw: &[(usize, usize, usize)],
-    ) -> Result<Tensor, OCRError> {
-        let merger = self.merger.as_ref().ok_or_else(|| OCRError::ConfigError {
+    ) -> Result<Tensor, Error> {
+        let merger = self.merger.as_ref().ok_or_else(|| Error::Config {
             message: "MinerU2.5: vision merger not loaded (backbone-only model)".to_string(),
         })?;
         let mut outputs: Vec<Tensor> = Vec::with_capacity(grid_thw.len());
@@ -724,7 +711,7 @@ fn build_vision_pos_emb(
     w: usize,
     merge_size: usize,
     device: &Device,
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     let mut hpos: Vec<i64> = Vec::with_capacity(t * h * w);
     let mut wpos: Vec<i64> = Vec::with_capacity(t * h * w);
     for _ in 0..t {
@@ -743,42 +730,42 @@ fn build_vision_pos_emb(
     let num_patches = hpos.len();
     let hpos = Tensor::from_vec(hpos, (num_patches, 1usize), device).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision hpos tensor failed",
             e,
         )
     })?;
     let wpos = Tensor::from_vec(wpos, (num_patches, 1usize), device).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision wpos tensor failed",
             e,
         )
     })?;
     let hpos = hpos.broadcast_as((num_patches, freq_dim)).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision hpos broadcast failed",
             e,
         )
     })?;
     let hpos = hpos.contiguous().map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision hpos contiguous failed",
             e,
         )
     })?;
     let wpos = wpos.broadcast_as((num_patches, freq_dim)).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision wpos broadcast failed",
             e,
         )
     })?;
     let wpos = wpos.contiguous().map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision wpos contiguous failed",
             e,
         )
@@ -796,14 +783,14 @@ fn build_vision_pos_emb(
         .map_err(|e| candle_to_ocr_inference("MinerU2.5", "vision emb cat", e))?;
     let cos = emb.cos().map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision cos failed",
             e,
         )
     })?;
     let sin = emb.sin().map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "MinerU2.5: vision sin failed",
             e,
         )

--- a/oar-ocr-vl/src/mineru_diffusion/config.rs
+++ b/oar-ocr-vl/src/mineru_diffusion/config.rs
@@ -6,8 +6,8 @@
 //! multimodal token ids, the mask token used by the diffusion denoiser, and
 //! the vision projector type.
 
+use crate::error::Error;
 use crate::mineru::MinerUVisionConfig;
-use oar_ocr_core::core::OCRError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -58,12 +58,12 @@ pub struct SdarConfig {
 
 impl SdarConfig {
     /// Resolve the per-head dimension, honouring the explicit `head_dim`.
-    pub fn head_dim(&self) -> Result<usize, OCRError> {
+    pub fn head_dim(&self) -> Result<usize, Error> {
         if let Some(hd) = self.head_dim {
             return Ok(hd);
         }
         if !self.hidden_size.is_multiple_of(self.num_attention_heads) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU-Diffusion: hidden_size {} not divisible by num_attention_heads {}",
                     self.hidden_size, self.num_attention_heads
@@ -98,14 +98,14 @@ pub struct MinerUDiffusionConfig {
 }
 
 impl MinerUDiffusionConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         crate::utils::load_json_config(path, "MinerU-Diffusion", "config.json")
     }
 
     /// Spatial merge factor encoded in `vision_projector_type`
     /// (`patch_merger2x` / `pm2x` -> 2). Falls back to the vision tower's
     /// `spatial_merge_size` when the type carries no explicit factor.
-    pub fn projector_merge_size(&self) -> Result<usize, OCRError> {
+    pub fn projector_merge_size(&self) -> Result<usize, Error> {
         parse_merge_size(
             &self.vision_projector_type,
             self.vision_config.spatial_merge_size,
@@ -116,7 +116,7 @@ impl MinerUDiffusionConfig {
 /// Parse the spatial merge factor out of a `vision_projector_type` string
 /// (`patch_merger2x` / `pm2x` -> 2). Returns `fallback` when the type carries
 /// no explicit factor; errors on a malformed factor.
-fn parse_merge_size(projector_type: &str, fallback: usize) -> Result<usize, OCRError> {
+fn parse_merge_size(projector_type: &str, fallback: usize) -> Result<usize, Error> {
     let digits: String = projector_type
         .trim()
         .trim_start_matches("patch_merger")
@@ -128,7 +128,7 @@ fn parse_merge_size(projector_type: &str, fallback: usize) -> Result<usize, OCRE
     if digits.is_empty() {
         return Ok(fallback);
     }
-    digits.parse::<usize>().map_err(|_| OCRError::ConfigError {
+    digits.parse::<usize>().map_err(|_| Error::Config {
         message: format!("MinerU-Diffusion: unsupported vision_projector_type '{projector_type}'"),
     })
 }

--- a/oar-ocr-vl/src/mineru_diffusion/model.rs
+++ b/oar-ocr-vl/src/mineru_diffusion/model.rs
@@ -15,13 +15,13 @@ use super::projector::VisionAbstractor;
 use super::text::{SdarKvCache, SdarModel};
 #[cfg(feature = "cuda")]
 use crate::cuda_kernels::SampleWithConfidence;
+use crate::error::Error;
 use crate::mineru::MinerUImageProcessorConfig;
 use crate::mineru::processing::preprocess_images;
 use crate::mineru::vision::MinerUVisionModel;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{DType, Device, Tensor};
 use image::RgbImage;
-use oar_ocr_core::core::OCRError;
 use rand::SeedableRng;
 use rand::distr::weighted::WeightedIndex;
 use rand::prelude::*;
@@ -75,12 +75,8 @@ impl Default for DiffusionGenerationConfig {
     }
 }
 
-fn proc_err(msg: &'static str, e: candle_core::Error) -> OCRError {
-    candle_to_ocr_processing(
-        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
-        msg,
-        e,
-    )
+fn proc_err(msg: &'static str, e: candle_core::Error) -> Error {
+    candle_to_ocr_processing(crate::error::ProcessingStage::TensorOperation, msg, e)
 }
 
 pub struct MinerUDiffusion {
@@ -99,7 +95,7 @@ pub struct MinerUDiffusion {
 }
 
 impl MinerUDiffusion {
-    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, OCRError> {
+    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, Error> {
         let model_dir = model_dir.as_ref();
         let cfg = MinerUDiffusionConfig::from_path(model_dir.join("config.json"))?;
         let mut image_cfg =
@@ -114,16 +110,15 @@ impl MinerUDiffusion {
         }
         image_cfg.validate()?;
 
-        let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| {
-            OCRError::ConfigError {
+        let tokenizer =
+            Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| Error::Config {
                 message: format!("failed to load MinerU-Diffusion tokenizer.json: {e}"),
-            }
-        })?;
+            })?;
 
         if let Some(tok_image_id) = tokenizer.token_to_id("<|image_pad|>")
             && tok_image_id != cfg.image_token_id
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU-Diffusion image_token_id mismatch: tokenizer {tok_image_id} != config {}",
                     cfg.image_token_id
@@ -190,7 +185,7 @@ impl MinerUDiffusion {
         image: &RgbImage,
         instruction: &str,
         gen_cfg: &DiffusionGenerationConfig,
-    ) -> Result<String, OCRError> {
+    ) -> Result<String, Error> {
         let tokens = self.generate_token_ids(image, instruction, gen_cfg)?;
         self.decode_tokens(&tokens, true)
     }
@@ -204,7 +199,7 @@ impl MinerUDiffusion {
         image: &RgbImage,
         instruction: &str,
         gen_cfg: &DiffusionGenerationConfig,
-    ) -> Result<String, OCRError> {
+    ) -> Result<String, Error> {
         let tokens = self.generate_token_ids(image, instruction, gen_cfg)?;
         self.decode_tokens(&tokens, false)
     }
@@ -216,9 +211,9 @@ impl MinerUDiffusion {
         image: &RgbImage,
         instruction: &str,
         gen_cfg: &DiffusionGenerationConfig,
-    ) -> Result<Vec<u32>, OCRError> {
+    ) -> Result<Vec<u32>, Error> {
         if gen_cfg.block_length == 0 || !gen_cfg.gen_length.is_multiple_of(gen_cfg.block_length) {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "MinerU-Diffusion: gen_length ({}) must be a positive multiple of block_length ({})",
                     gen_cfg.gen_length, gen_cfg.block_length
@@ -246,7 +241,7 @@ impl MinerUDiffusion {
         let enc = self
             .tokenizer
             .encode(prompt, false)
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("MinerU-Diffusion: tokenizer encode failed: {e}"),
             })?;
         let input_ids = expand_image_tokens(enc.get_ids(), self.image_token_id, num_image_tokens)?;
@@ -267,10 +262,10 @@ impl MinerUDiffusion {
         Ok(generated[..cut].to_vec())
     }
 
-    fn decode_tokens(&self, tokens: &[u32], skip_special: bool) -> Result<String, OCRError> {
+    fn decode_tokens(&self, tokens: &[u32], skip_special: bool) -> Result<String, Error> {
         self.tokenizer
             .decode(tokens, skip_special)
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("MinerU-Diffusion: tokenizer decode failed: {e}"),
             })
     }
@@ -280,7 +275,7 @@ impl MinerUDiffusion {
         input_ids: &[u32],
         image_features: &Tensor,
         num_image_tokens: usize,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let seq_len = input_ids.len();
         let input_ids_t = Tensor::new(input_ids.to_vec(), &self.device)
             .and_then(|t| t.reshape((1, seq_len)))
@@ -290,7 +285,7 @@ impl MinerUDiffusion {
         if let Some(first_pos) = input_ids.iter().position(|&id| id == self.image_token_id) {
             let image_end = first_pos + num_image_tokens;
             if image_end > seq_len {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: format!(
                         "MinerU-Diffusion: image token span out of range: {image_end} > {seq_len}"
                     ),
@@ -331,7 +326,7 @@ impl MinerUDiffusion {
         prompt_len: usize,
         gen_cfg: &DiffusionGenerationConfig,
         rng: &mut StdRng,
-    ) -> Result<Vec<u32>, OCRError> {
+    ) -> Result<Vec<u32>, Error> {
         let block = gen_cfg.block_length;
         let gen_blocks = gen_cfg.gen_length / block;
         let mut cache = SdarKvCache::new(self.text.num_layers());
@@ -415,7 +410,7 @@ impl MinerUDiffusion {
         Ok(generated)
     }
 
-    fn embed_tokens_block(&self, tokens: &[u32]) -> Result<Tensor, OCRError> {
+    fn embed_tokens_block(&self, tokens: &[u32]) -> Result<Tensor, Error> {
         let t = Tensor::new(tokens.to_vec(), &self.device)
             .and_then(|t| t.reshape((1, tokens.len())))
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "block tokens tensor", e))?;
@@ -425,7 +420,7 @@ impl MinerUDiffusion {
     /// Additive block-causal mask `(1, 1, P, P)`: blocks of `block` tokens are
     /// causal at block granularity (full attention within/earlier blocks),
     /// aligned to the END of the prompt — matching the reference construction.
-    fn block_causal_mask(&self, prompt_len: usize, block: usize) -> Result<Tensor, OCRError> {
+    fn block_causal_mask(&self, prompt_len: usize, block: usize) -> Result<Tensor, Error> {
         let data = block_causal_mask_data(prompt_len, block);
         Tensor::from_vec(data, (1, 1, prompt_len, prompt_len), &self.device)
             .and_then(|t| t.to_dtype(self.dtype))
@@ -448,10 +443,10 @@ fn build_prompt(instruction: &str) -> String {
     )
 }
 
-fn expand_image_tokens(ids: &[u32], image_token: u32, n: usize) -> Result<Vec<u32>, OCRError> {
+fn expand_image_tokens(ids: &[u32], image_token: u32, n: usize) -> Result<Vec<u32>, Error> {
     let count = ids.iter().filter(|&&id| id == image_token).count();
     if count != 1 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "MinerU-Diffusion: expected exactly one image placeholder token, found {count}"
             ),
@@ -491,7 +486,7 @@ fn sample_tokens_and_conf(
     top_k: usize,
     top_p: f32,
     rng: &mut StdRng,
-) -> Result<(Vec<u32>, Vec<f32>), OCRError> {
+) -> Result<(Vec<u32>, Vec<f32>), Error> {
     #[cfg(feature = "cuda")]
     if matches!(logits.device(), Device::Cuda(_))
         && matches!(logits.dtype(), DType::BF16 | DType::F32)
@@ -559,7 +554,7 @@ fn sample_tokens_and_conf_cuda(
     logits: &Tensor,
     temperature: f32,
     rng: &mut StdRng,
-) -> Result<(Vec<u32>, Vec<f32>), OCRError> {
+) -> Result<(Vec<u32>, Vec<f32>), Error> {
     let logits = logits
         .squeeze(0)
         .and_then(|t| t.contiguous())

--- a/oar-ocr-vl/src/mineru_diffusion/projector.rs
+++ b/oar-ocr-vl/src/mineru_diffusion/projector.rs
@@ -7,10 +7,10 @@
 //! With `merge_size = 2` it consumes 4 vision patches per produced token,
 //! matching the image-token budget (`prod(grid_thw) / merge_size²`).
 
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::Tensor;
 use candle_nn::{LayerNorm, LayerNormConfig, Linear, Module, VarBuilder, layer_norm, linear};
-use oar_ocr_core::core::OCRError;
 
 #[derive(Debug)]
 pub struct VisionAbstractor {
@@ -32,7 +32,7 @@ impl VisionAbstractor {
         context_dim: usize,
         out_dim: usize,
         merge_size: usize,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         let norm_cfg = LayerNormConfig {
             eps: 1e-6,
             ..Default::default()
@@ -54,7 +54,7 @@ impl VisionAbstractor {
 
     /// `x`: per-patch hidden states `(num_patches, context_dim)`.
     /// Returns `(num_patches / merge_size², out_dim)`.
-    pub fn forward(&self, x: &Tensor) -> Result<Tensor, OCRError> {
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
         let num_patches = x
             .dim(0)
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "abstractor dim", e))?;
@@ -68,7 +68,7 @@ impl VisionAbstractor {
             * x.dim(1)
                 .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "abstractor dim1", e))?;
         if !total.is_multiple_of(self.merged_dim) {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "MinerU-Diffusion: abstractor element count {total} not divisible by merged_dim {}",
                     self.merged_dim
@@ -78,7 +78,7 @@ impl VisionAbstractor {
         let rows = total / self.merged_dim;
         let x = x.reshape((rows, self.merged_dim)).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU-Diffusion: abstractor reshape failed",
                 e,
             )
@@ -89,7 +89,7 @@ impl VisionAbstractor {
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "abstractor mlp.0", e))?;
         let x = x.gelu_erf().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MinerU-Diffusion: abstractor gelu failed",
                 e,
             )

--- a/oar-ocr-vl/src/mineru_diffusion/text.rs
+++ b/oar-ocr-vl/src/mineru_diffusion/text.rs
@@ -19,20 +19,16 @@ use crate::attention::{
     RotaryEmbedding, flash_attention, scaled_dot_product_attention_gqa,
     segmented_scaled_dot_product_attention_gqa,
 };
+use crate::error::Error;
 use crate::kv_trim::TrimmableKvCache;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing, rotate_half};
 use candle_core::{DType, Device, Tensor};
 use candle_nn::{
     Embedding, Linear, Module, RmsNorm, VarBuilder, embedding, linear, linear_no_bias, rms_norm,
 };
-use oar_ocr_core::core::OCRError;
 
-fn proc_err(msg: &'static str, e: candle_core::Error) -> OCRError {
-    candle_to_ocr_processing(
-        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
-        msg,
-        e,
-    )
+fn proc_err(msg: &'static str, e: candle_core::Error) -> Error {
+    candle_to_ocr_processing(crate::error::ProcessingStage::TensorOperation, msg, e)
 }
 
 /// Per-layer committed KV (rope already applied to keys).
@@ -225,7 +221,7 @@ impl SdarKvCache {
     /// appending to either branch cannot corrupt the other. Recursively forking
     /// past an inherited prefix materializes that prefix plus the selected
     /// private tail because this cache currently stores only one shared segment.
-    pub(crate) fn fork_at(&self, len: usize) -> Result<Self, OCRError> {
+    pub(crate) fn fork_at(&self, len: usize) -> Result<Self, Error> {
         let layers = self
             .layers
             .iter()
@@ -244,7 +240,7 @@ impl SdarKvCache {
     /// Roll every layer back to a shared prefix. This is used by models with
     /// speculative or forked decoding to discard unaccepted/tail tokens while
     /// retaining the already-computed prefix KV.
-    pub(crate) fn trim_to(&mut self, len: usize) -> Result<(), OCRError> {
+    pub(crate) fn trim_to(&mut self, len: usize) -> Result<(), Error> {
         for layer in &mut self.layers {
             layer
                 .trim_to(len)
@@ -254,7 +250,7 @@ impl SdarKvCache {
     }
 }
 
-fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, OCRError> {
+fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
     let a = x
         .broadcast_mul(cos)
         .map_err(|e| proc_err("SDAR rope x*cos", e))?;
@@ -279,12 +275,12 @@ struct SdarAttention {
 }
 
 impl SdarAttention {
-    fn load(cfg: &SdarConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &SdarConfig, vb: VarBuilder) -> Result<Self, Error> {
         if !cfg
             .num_attention_heads
             .is_multiple_of(cfg.num_key_value_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MinerU-Diffusion: num_attention_heads ({}) must be divisible by num_key_value_heads ({})",
                     cfg.num_attention_heads, cfg.num_key_value_heads
@@ -294,7 +290,7 @@ impl SdarAttention {
         let head_dim = cfg.head_dim()?;
         let q_dim = cfg.num_attention_heads * head_dim;
         let kv_dim = cfg.num_key_value_heads * head_dim;
-        let mk = |i: usize, o: usize, name: &str, vb: VarBuilder| -> Result<Linear, OCRError> {
+        let mk = |i: usize, o: usize, name: &str, vb: VarBuilder| -> Result<Linear, Error> {
             if cfg.attention_bias {
                 linear(i, o, vb)
             } else {
@@ -332,13 +328,13 @@ impl SdarAttention {
         mask: Option<&Tensor>,
         cache: &mut LayerKvCache,
         mode: AttentionMode,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (b, s, _) = hidden
             .dims3()
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "attn dims", e))?;
 
         let project =
-            |proj: &Linear, heads: usize, norm: Option<&RmsNorm>| -> Result<Tensor, OCRError> {
+            |proj: &Linear, heads: usize, norm: Option<&RmsNorm>| -> Result<Tensor, Error> {
                 let x = proj
                     .forward(hidden)
                     .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "attn proj", e))?;
@@ -428,12 +424,12 @@ impl SdarAttention {
         sin: &Tensor,
         caches: &mut [&mut LayerKvCache],
         mode: AttentionMode,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (b, s, _) = hidden
             .dims3()
             .map_err(|e| candle_to_ocr_inference("Qwen3", "batched attn dims", e))?;
         if b != caches.len() {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "Qwen3 batched attention has {b} rows but {} caches",
                     caches.len()
@@ -441,7 +437,7 @@ impl SdarAttention {
             });
         }
         let project =
-            |proj: &Linear, heads: usize, norm: Option<&RmsNorm>| -> Result<Tensor, OCRError> {
+            |proj: &Linear, heads: usize, norm: Option<&RmsNorm>| -> Result<Tensor, Error> {
                 let x = proj
                     .forward(hidden)
                     .map_err(|e| candle_to_ocr_inference("Qwen3", "batched attn proj", e))?;
@@ -523,7 +519,7 @@ struct SdarMlp {
 }
 
 impl SdarMlp {
-    fn load(cfg: &SdarConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &SdarConfig, vb: VarBuilder) -> Result<Self, Error> {
         let gate = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "load gate_proj", e))?;
         let up = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))
@@ -533,7 +529,7 @@ impl SdarMlp {
         Ok(Self { gate, up, down })
     }
 
-    fn forward(&self, x: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
         let gate = self
             .gate
             .forward(x)
@@ -559,7 +555,7 @@ struct SdarLayer {
 }
 
 impl SdarLayer {
-    fn load(cfg: &SdarConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &SdarConfig, vb: VarBuilder) -> Result<Self, Error> {
         let input_layernorm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "load input_layernorm", e))?;
         let post_attention_layernorm = rms_norm(
@@ -586,7 +582,7 @@ impl SdarLayer {
         mask: Option<&Tensor>,
         cache: &mut LayerKvCache,
         mode: AttentionMode,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let normed = self
             .input_layernorm
             .forward(hidden)
@@ -610,7 +606,7 @@ impl SdarLayer {
         sin: &Tensor,
         caches: &mut [&mut LayerKvCache],
         mode: AttentionMode,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let normed = self
             .input_layernorm
             .forward(hidden)
@@ -642,7 +638,7 @@ pub struct SdarModel {
 impl SdarModel {
     /// `vb` should point at `language_model` (so `vb.pp("model")` is the
     /// decoder and `vb.pp("lm_head")` the output projection).
-    pub fn load(cfg: &SdarConfig, vb: VarBuilder, dtype: DType) -> Result<Self, OCRError> {
+    pub fn load(cfg: &SdarConfig, vb: VarBuilder, dtype: DType) -> Result<Self, Error> {
         let model_vb = vb.pp("model");
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, model_vb.pp("embed_tokens"))
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "load embed_tokens", e))?;
@@ -676,24 +672,24 @@ impl SdarModel {
     }
 
     /// Embed token ids `(1, S)` into `(1, S, hidden)`.
-    pub fn embed(&self, input_ids: &Tensor) -> Result<Tensor, OCRError> {
+    pub fn embed(&self, input_ids: &Tensor) -> Result<Tensor, Error> {
         self.embed_tokens
             .forward(input_ids)
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "embed", e))
     }
 
-    fn rope_for(&self, positions: &[i64]) -> Result<(Tensor, Tensor), OCRError> {
+    fn rope_for(&self, positions: &[i64]) -> Result<(Tensor, Tensor), Error> {
         let s = positions.len();
         let pos = Tensor::from_vec(positions.to_vec(), (1, 1, s), &self.device)
             .map_err(|e| proc_err("SDAR position_ids tensor", e))?;
         self.rotary.forward_multi_axis(&pos, self.dtype)
     }
 
-    fn rope_for_batch(&self, positions: &[Vec<i64>]) -> Result<(Tensor, Tensor), OCRError> {
+    fn rope_for_batch(&self, positions: &[Vec<i64>]) -> Result<(Tensor, Tensor), Error> {
         let batch = positions.len();
         let seq = positions.first().map_or(0, Vec::len);
         if batch == 0 || seq == 0 || positions.iter().any(|row| row.len() != seq) {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "Qwen3 batched positions must be a non-empty rectangle".to_string(),
             });
         }
@@ -716,7 +712,7 @@ impl SdarModel {
         mask: Option<&Tensor>,
         cache: &mut SdarKvCache,
         store_kv: bool,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         self.forward_inner(inputs_embeds, positions, mask, cache, store_kv, false)
     }
 
@@ -732,7 +728,7 @@ impl SdarModel {
         positions: &[i64],
         cache: &mut SdarKvCache,
         store_kv: bool,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         self.forward_inner(inputs_embeds, positions, None, cache, store_kv, true)
     }
 
@@ -745,7 +741,7 @@ impl SdarModel {
         inputs_embeds: &Tensor,
         positions: &[Vec<i64>],
         caches: &mut [&mut SdarKvCache],
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (batch, seq, _) = inputs_embeds
             .dims3()
             .map_err(|e| candle_to_ocr_inference("Qwen3", "batched input shape", e))?;
@@ -753,7 +749,7 @@ impl SdarModel {
             || batch != caches.len()
             || positions.iter().any(|p| p.len() != seq)
         {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "Qwen3 batch mismatch: embeddings={batch}x{seq}, positions={}, caches={}",
                     positions.len(),
@@ -787,7 +783,7 @@ impl SdarModel {
         cache: &mut SdarKvCache,
         store_kv: bool,
         is_causal: bool,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (cos, sin) = self.rope_for(positions)?;
         let mut hidden = inputs_embeds.clone();
         let mode = AttentionMode {
@@ -803,7 +799,7 @@ impl SdarModel {
     }
 
     /// Project hidden states `(1, S, hidden)` to logits `(1, S, vocab)`.
-    pub fn lm_logits(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    pub fn lm_logits(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         self.lm_head
             .forward(hidden)
             .map_err(|e| candle_to_ocr_inference("MinerU-Diffusion", "lm_head", e))
@@ -841,7 +837,7 @@ mod tests {
     }
 
     #[test]
-    fn forked_cache_shares_prefix_and_owns_its_tail() -> Result<(), OCRError> {
+    fn forked_cache_shares_prefix_and_owns_its_tail() -> Result<(), Error> {
         let device = Device::Cpu;
         let mut parent = SdarKvCache::with_capacity(2, 8);
         for layer in &mut parent.layers {

--- a/oar-ocr-vl/src/monkeyocrv2/config.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/config.rs
@@ -1,5 +1,5 @@
+use crate::error::Error;
 use crate::mineru_diffusion::SdarConfig;
-use oar_ocr_core::core::OCRError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -27,10 +27,10 @@ fn default_num_channels() -> usize {
 }
 
 impl MonkeyOcrV2VisionConfig {
-    pub fn head_dim(&self) -> Result<usize, OCRError> {
+    pub fn head_dim(&self) -> Result<usize, Error> {
         if self.num_attention_heads == 0 || !self.embed_dim.is_multiple_of(self.num_attention_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MonkeyOCRv2 vision embed_dim {} must be divisible by num_attention_heads {}",
                     self.embed_dim, self.num_attention_heads
@@ -40,7 +40,7 @@ impl MonkeyOcrV2VisionConfig {
         Ok(self.embed_dim / self.num_attention_heads)
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         if self.embed_dim == 0
             || self.hidden_size == 0
             || self.intermediate_size == 0
@@ -49,12 +49,12 @@ impl MonkeyOcrV2VisionConfig {
             || self.spatial_merge_size == 0
             || self.temporal_patch_size == 0
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "MonkeyOCRv2 vision dimensions must be non-zero".to_string(),
             });
         }
         if self.num_channels != 3 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MonkeyOCRv2 currently supports RGB checkpoints, got num_channels={}",
                     self.num_channels
@@ -62,7 +62,7 @@ impl MonkeyOcrV2VisionConfig {
             });
         }
         if self.temporal_patch_size != 1 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MonkeyOCRv2 image checkpoints require temporal_patch_size=1, got {}",
                     self.temporal_patch_size
@@ -70,20 +70,20 @@ impl MonkeyOcrV2VisionConfig {
             });
         }
         if self.use_bias {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "MonkeyOCRv2 vision transformer use_bias=true is unsupported".to_string(),
             });
         }
         let head_dim = self.head_dim()?;
         if !head_dim.is_multiple_of(4) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MonkeyOCRv2 vision head_dim {head_dim} must be divisible by 4 for 2D RoPE"
                 ),
             });
         }
         if !self.rms_norm_eps.is_finite() || self.rms_norm_eps <= 0.0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MonkeyOCRv2 vision rms_norm_eps must be positive, got {}",
                     self.rms_norm_eps
@@ -105,15 +105,15 @@ pub struct MonkeyOcrV2Config {
 }
 
 impl MonkeyOcrV2Config {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         let config: Self = crate::utils::load_json_config(path, "MonkeyOCRv2", "config.json")?;
         config.validate()?;
         Ok(config)
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         if self.model_type != "monkeyocrv2" {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MonkeyOCRv2 expected model_type 'monkeyocrv2', got '{}'",
                     self.model_type
@@ -121,7 +121,7 @@ impl MonkeyOcrV2Config {
             });
         }
         if self.text_config.hidden_act != "silu" {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MonkeyOCRv2 supports Qwen3 hidden_act 'silu', got '{}'",
                     self.text_config.hidden_act
@@ -129,7 +129,7 @@ impl MonkeyOcrV2Config {
             });
         }
         if self.text_config.attention_bias {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "MonkeyOCRv2 attention_bias=true is unsupported".to_string(),
             });
         }
@@ -140,12 +140,12 @@ impl MonkeyOcrV2Config {
             || self.text_config.num_key_value_heads == 0
             || self.text_config.max_position_embeddings == 0
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "MonkeyOCRv2 text dimensions must be non-zero".to_string(),
             });
         }
         if self.text_config.head_dim()? == 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "MonkeyOCRv2 text head_dim must be non-zero".to_string(),
             });
         }
@@ -154,12 +154,12 @@ impl MonkeyOcrV2Config {
             .num_attention_heads
             .is_multiple_of(self.text_config.num_key_value_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "MonkeyOCRv2 attention heads must be divisible by KV heads".to_string(),
             });
         }
         if self.text_config.hidden_size != self.vision_config.hidden_size {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MonkeyOCRv2 vision merger output {} != text hidden size {}",
                     self.vision_config.hidden_size, self.text_config.hidden_size
@@ -192,14 +192,14 @@ pub struct MonkeyOcrV2ImageProcessorConfig {
 }
 
 impl MonkeyOcrV2ImageProcessorConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         let config: Self =
             crate::utils::load_json_config(path, "MonkeyOCRv2", "preprocessor_config.json")?;
         config.validate()?;
         Ok(config)
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         crate::utils::validate_patch_merge_temporal(
             "MonkeyOCRv2",
             self.patch_size,
@@ -207,7 +207,7 @@ impl MonkeyOcrV2ImageProcessorConfig {
             self.temporal_patch_size,
         )?;
         if self.min_pixels == 0 || self.max_pixels == 0 || self.min_pixels > self.max_pixels {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MonkeyOCRv2 invalid pixel bounds: {}..{}",
                     self.min_pixels, self.max_pixels
@@ -221,7 +221,7 @@ impl MonkeyOcrV2ImageProcessorConfig {
                 &self.image_std,
             )?;
             if self.image_std.contains(&0.0) {
-                return Err(OCRError::ConfigError {
+                return Err(Error::Config {
                     message: "MonkeyOCRv2 image_std values must be non-zero".to_string(),
                 });
             }
@@ -229,12 +229,12 @@ impl MonkeyOcrV2ImageProcessorConfig {
         Ok(())
     }
 
-    pub fn validate_vision(&self, vision: &MonkeyOcrV2VisionConfig) -> Result<(), OCRError> {
+    pub fn validate_vision(&self, vision: &MonkeyOcrV2VisionConfig) -> Result<(), Error> {
         if self.patch_size != vision.patch_size
             || self.temporal_patch_size != vision.temporal_patch_size
             || self.merge_size != vision.spatial_merge_size
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "MonkeyOCRv2 processor/vision mismatch: patch {}/{}, temporal {}/{}, merge {}/{}",
                     self.patch_size,

--- a/oar-ocr-vl/src/monkeyocrv2/model.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/model.rs
@@ -4,11 +4,11 @@ use super::vision::MonkeyOcrV2VisionModel;
 #[cfg(feature = "cuda")]
 use crate::cuda_kernels::{ArgmaxFirstBf16, ArgmaxFirstF32};
 use crate::doc_parser::{RecognitionBackend, RecognitionTask};
+use crate::error::Error;
 use crate::mineru_diffusion::text::{SdarKvCache, SdarModel};
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{DType, Device, IndexOp, Tensor};
 use image::RgbImage;
-use oar_ocr_core::core::OCRError;
 use std::path::Path;
 use tokenizers::Tokenizer;
 
@@ -66,17 +66,16 @@ pub struct MonkeyOcrV2 {
 }
 
 impl MonkeyOcrV2 {
-    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, OCRError> {
+    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, Error> {
         let model_dir = model_dir.as_ref();
         let cfg = MonkeyOcrV2Config::from_path(model_dir.join("config.json"))?;
         let image_cfg =
             MonkeyOcrV2ImageProcessorConfig::from_path(model_dir.join("preprocessor_config.json"))?;
         image_cfg.validate_vision(&cfg.vision_config)?;
-        let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| {
-            OCRError::ConfigError {
+        let tokenizer =
+            Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| Error::Config {
                 message: format!("MonkeyOCRv2 failed to load tokenizer.json: {e}"),
-            }
-        })?;
+            })?;
         require_token(&tokenizer, "<|image_pad|>", Some(cfg.image_token_id))?;
         require_token(&tokenizer, "<|vision_start|>", None)?;
         require_token(&tokenizer, "<|vision_end|>", None)?;
@@ -122,7 +121,7 @@ impl MonkeyOcrV2 {
         images: &[RgbImage],
         tasks: &[MonkeyOcrV2Task],
         max_new_tokens: usize,
-    ) -> Vec<Result<String, OCRError>> {
+    ) -> Vec<Result<String, Error>> {
         self.generate_tokens(images, tasks, max_new_tokens)
             .into_iter()
             .map(|result| result.and_then(|tokens| self.decode_tokens(&tokens)))
@@ -135,7 +134,7 @@ impl MonkeyOcrV2 {
         images: &[RgbImage],
         prompts: &[impl AsRef<str>],
         max_new_tokens: usize,
-    ) -> Vec<Result<String, OCRError>> {
+    ) -> Vec<Result<String, Error>> {
         if images.len() != prompts.len() {
             return vec![Err(length_mismatch(images.len(), prompts.len()))];
         }
@@ -155,7 +154,7 @@ impl MonkeyOcrV2 {
         images: &[RgbImage],
         tasks: &[MonkeyOcrV2Task],
         max_new_tokens: usize,
-    ) -> Vec<Result<Vec<u32>, OCRError>> {
+    ) -> Vec<Result<Vec<u32>, Error>> {
         if images.len() != tasks.len() {
             return vec![Err(length_mismatch(images.len(), tasks.len()))];
         }
@@ -175,7 +174,7 @@ impl MonkeyOcrV2 {
         instruction: &str,
         max_new_tokens: usize,
         min_pixels_override: Option<u32>,
-    ) -> Result<Vec<u32>, OCRError> {
+    ) -> Result<Vec<u32>, Error> {
         if max_new_tokens == 0 {
             return Ok(Vec::new());
         }
@@ -186,15 +185,15 @@ impl MonkeyOcrV2 {
         }
         let image_inputs = preprocess_image(image, &image_cfg, &self.device, self.dtype)?;
         let prompt = build_prompt(instruction, image_inputs.num_image_tokens);
-        let encoding =
-            self.tokenizer
-                .encode(prompt, false)
-                .map_err(|e| OCRError::InvalidInput {
-                    message: format!("MonkeyOCRv2 tokenizer encode failed: {e}"),
-                })?;
+        let encoding = self
+            .tokenizer
+            .encode(prompt, false)
+            .map_err(|e| Error::InvalidInput {
+                message: format!("MonkeyOCRv2 tokenizer encode failed: {e}"),
+            })?;
         let input_ids = encoding.get_ids();
         if input_ids.is_empty() {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "MonkeyOCRv2 prompt tokenization produced no tokens".to_string(),
             });
         }
@@ -223,7 +222,7 @@ impl MonkeyOcrV2 {
         let mut generated = Vec::new();
         generated
             .try_reserve_exact(max_new_tokens)
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!(
                     "MonkeyOCRv2 cannot reserve output for {max_new_tokens} tokens: {e}"
                 ),
@@ -259,7 +258,7 @@ impl MonkeyOcrV2 {
         &self,
         input_ids: &[u32],
         image_inputs: &MonkeyOcrV2ImageInputs,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let seq_len = input_ids.len();
         let token_ids = Tensor::new(input_ids, &self.device)
             .and_then(|tensor| tensor.unsqueeze(0))
@@ -279,7 +278,7 @@ impl MonkeyOcrV2 {
             .dim(0)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read image embedding count", e))?;
         if positions.len() != image_len || positions.is_empty() {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "MonkeyOCRv2 image placeholder count {} != image embedding count {image_len}",
                     positions.len()
@@ -292,7 +291,7 @@ impl MonkeyOcrV2 {
             .enumerate()
             .any(|(offset, &position)| position != start + offset)
         {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "MonkeyOCRv2 image placeholders must be contiguous".to_string(),
             });
         }
@@ -310,11 +309,11 @@ impl MonkeyOcrV2 {
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "merge multimodal embeddings", e))
     }
 
-    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, Error> {
         self.tokenizer
             .decode(tokens, true)
             .map(|text| text.trim().to_string())
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("MonkeyOCRv2 tokenizer decode failed: {e}"),
             })
     }
@@ -338,7 +337,7 @@ impl RecognitionBackend for MonkeyOcrV2 {
         image: RgbImage,
         task: RecognitionTask,
         max_tokens: usize,
-    ) -> Result<String, OCRError> {
+    ) -> Result<String, Error> {
         let monkey_task = match task {
             RecognitionTask::Ocr | RecognitionTask::Chart => MonkeyOcrV2Task::Text,
             RecognitionTask::Table => MonkeyOcrV2Task::Table,
@@ -371,20 +370,14 @@ fn build_prompt(instruction: &str, num_image_tokens: usize) -> String {
     prompt
 }
 
-fn require_token(
-    tokenizer: &Tokenizer,
-    token: &str,
-    expected: Option<u32>,
-) -> Result<u32, OCRError> {
-    let id = tokenizer
-        .token_to_id(token)
-        .ok_or_else(|| OCRError::ConfigError {
-            message: format!("MonkeyOCRv2 tokenizer is missing {token:?}"),
-        })?;
+fn require_token(tokenizer: &Tokenizer, token: &str, expected: Option<u32>) -> Result<u32, Error> {
+    let id = tokenizer.token_to_id(token).ok_or_else(|| Error::Config {
+        message: format!("MonkeyOCRv2 tokenizer is missing {token:?}"),
+    })?;
     if let Some(expected) = expected
         && id != expected
     {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "MonkeyOCRv2 token {token:?} id mismatch: tokenizer {id} != config {expected}"
             ),
@@ -393,8 +386,8 @@ fn require_token(
     Ok(id)
 }
 
-fn length_mismatch(images: usize, tasks: usize) -> OCRError {
-    OCRError::InvalidInput {
+fn length_mismatch(images: usize, tasks: usize) -> Error {
+    Error::InvalidInput {
         message: format!("MonkeyOCRv2 image count {images} != task/prompt count {tasks}"),
     }
 }
@@ -403,15 +396,14 @@ fn validate_generation_length(
     prompt_len: usize,
     max_new_tokens: usize,
     context_limit: usize,
-) -> Result<(), OCRError> {
-    let requested =
-        prompt_len
-            .checked_add(max_new_tokens)
-            .ok_or_else(|| OCRError::InvalidInput {
-                message: "MonkeyOCRv2 requested sequence length overflows usize".to_string(),
-            })?;
+) -> Result<(), Error> {
+    let requested = prompt_len
+        .checked_add(max_new_tokens)
+        .ok_or_else(|| Error::InvalidInput {
+            message: "MonkeyOCRv2 requested sequence length overflows usize".to_string(),
+        })?;
     if requested > context_limit {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "MonkeyOCRv2 prompt ({prompt_len}) plus max_new_tokens ({max_new_tokens}) exceeds context limit {context_limit}"
             ),
@@ -420,7 +412,7 @@ fn validate_generation_length(
     Ok(())
 }
 
-fn select_greedy_token(logits: &Tensor) -> Result<u32, OCRError> {
+fn select_greedy_token(logits: &Tensor) -> Result<u32, Error> {
     #[cfg(feature = "cuda")]
     if logits.device().is_cuda() && matches!(logits.dtype(), DType::BF16 | DType::F32) {
         let vocab_size = logits.elem_count();
@@ -445,7 +437,7 @@ fn select_greedy_token(logits: &Tensor) -> Result<u32, OCRError> {
         .and_then(|token| token.to_scalar::<u32>())
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MonkeyOCRv2 greedy argmax",
                 e,
             )

--- a/oar-ocr-vl/src/monkeyocrv2/processing.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/processing.rs
@@ -1,10 +1,10 @@
 use super::config::MonkeyOcrV2ImageProcessorConfig;
+use crate::error::Error;
 use crate::utils::image::{
     image_to_chw, patchify_merge_grouped, pil_resample_to_filter_type, smart_resize,
 };
 use candle_core::{DType, Device, Tensor};
 use image::{RgbImage, imageops::FilterType};
-use oar_ocr_core::core::OCRError;
 
 #[derive(Debug, Clone)]
 pub struct MonkeyOcrV2ImageInputs {
@@ -18,10 +18,10 @@ pub fn preprocess_image(
     cfg: &MonkeyOcrV2ImageProcessorConfig,
     device: &Device,
     dtype: DType,
-) -> Result<MonkeyOcrV2ImageInputs, OCRError> {
+) -> Result<MonkeyOcrV2ImageInputs, Error> {
     cfg.validate()?;
     if image.width() == 0 || image.height() == 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "MonkeyOCRv2 cannot process an empty image".to_string(),
         });
     }
@@ -29,14 +29,14 @@ pub fn preprocess_image(
     let factor = (cfg.patch_size * cfg.merge_size) as u32;
     let (height, width) = (image.height(), image.width());
     if !cfg.do_resize && (height < factor || width < factor) {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "MonkeyOCRv2 image dimensions must be at least {factor}x{factor}, got {width}x{height}"
             ),
         });
     }
     if !cfg.do_resize && (!height.is_multiple_of(factor) || !width.is_multiple_of(factor)) {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "MonkeyOCRv2 image dimensions must be divisible by {factor} when resizing is disabled, got {width}x{height}"
             ),
@@ -80,7 +80,7 @@ pub fn preprocess_image(
     let grid_h = resized_height as usize / cfg.patch_size;
     let grid_w = resized_width as usize / cfg.patch_size;
     if !grid_h.is_multiple_of(cfg.merge_size) || !grid_w.is_multiple_of(cfg.merge_size) {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "MonkeyOCRv2 resized grid {grid_h}x{grid_w} is not divisible by merge_size {}",
                 cfg.merge_size
@@ -103,7 +103,7 @@ pub fn preprocess_image(
     let patch_dim = 3 * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size;
     let num_patches = grid_t * grid_h * grid_w;
     if patches.len() != num_patches * patch_dim {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "MonkeyOCRv2 patch extraction produced {} values, expected {}",
                 patches.len(),
@@ -172,7 +172,7 @@ mod tests {
         let error = preprocess_image(&image, &cfg, &Device::Cpu, DType::F32).unwrap_err();
         assert!(matches!(
             error,
-            OCRError::InvalidInput { message }
+            Error::InvalidInput { message }
                 if message.contains("at least 28x28, got 27x28")
         ));
     }
@@ -186,7 +186,7 @@ mod tests {
         let error = preprocess_image(&image, &cfg, &Device::Cpu, DType::F32).unwrap_err();
         assert!(matches!(
             error,
-            OCRError::InvalidInput { message }
+            Error::InvalidInput { message }
                 if message.contains("divisible by 28") && message.contains("85x56")
         ));
     }

--- a/oar-ocr-vl/src/monkeyocrv2/vision.rs
+++ b/oar-ocr-vl/src/monkeyocrv2/vision.rs
@@ -3,13 +3,13 @@ use crate::attention::{
     VISION_CHUNKED_ATTN_CHUNK_SIZE, VISION_CHUNKED_ATTN_SEQ_THRESHOLD, chunked_vision_attention,
     flash_attention, scaled_dot_product_attention,
 };
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{DType, IndexOp, Tensor};
 use candle_nn::{
     LayerNorm, LayerNormConfig, Linear, Module, RmsNorm, VarBuilder, layer_norm, linear,
     linear_no_bias, rms_norm,
 };
-use oar_ocr_core::core::OCRError;
 
 const MODEL_NAME: &str = "MonkeyOCRv2";
 
@@ -21,7 +21,7 @@ struct PatchEmbed {
 }
 
 impl PatchEmbed {
-    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let patch_dim = cfg.num_channels * cfg.patch_size * cfg.patch_size;
         let vb = vb.pp("patch_embed").pp("patchifier");
         let weight = vb
@@ -44,7 +44,7 @@ impl PatchEmbed {
         Ok(Self { weight, bias, norm })
     }
 
-    fn forward(&self, patches: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, patches: &Tensor) -> Result<Tensor, Error> {
         let patches = patches
             .to_dtype(self.weight.dtype())
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "cast image patches", e))?;
@@ -71,7 +71,7 @@ struct VisionAttention {
 }
 
 impl VisionAttention {
-    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let qkv = linear_no_bias(cfg.embed_dim, cfg.embed_dim * 3, vb.pp("attn").pp("qkv"))
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision QKV", e))?;
         let proj = linear_no_bias(cfg.embed_dim, cfg.embed_dim, vb.pp("attn").pp("proj"))
@@ -86,7 +86,7 @@ impl VisionAttention {
         })
     }
 
-    fn forward(&self, hidden: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let seq_len = hidden
             .dim(0)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read vision sequence length", e))?;
@@ -149,7 +149,7 @@ fn apply_vision_rope(
     k: &Tensor,
     cos: &Tensor,
     sin: &Tensor,
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     let q_dtype = q.dtype();
     let k_dtype = k.dtype();
     let q = q
@@ -187,7 +187,7 @@ struct VisionMlp {
 }
 
 impl VisionMlp {
-    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let vb = vb.pp("mlp");
         let fc1 = linear_no_bias(cfg.embed_dim, cfg.intermediate_size, vb.pp("fc1"))
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision MLP fc1", e))?;
@@ -198,7 +198,7 @@ impl VisionMlp {
         Ok(Self { fc1, fc2, fc3 })
     }
 
-    fn forward(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         let gate = self
             .fc1
             .forward(hidden)
@@ -225,7 +225,7 @@ struct VisionBlock {
 }
 
 impl VisionBlock {
-    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let norm1 = rms_norm(cfg.embed_dim, cfg.rms_norm_eps, vb.pp("norm1"))
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load vision norm1", e))?;
         let norm2 = rms_norm(cfg.embed_dim, cfg.rms_norm_eps, vb.pp("norm2"))
@@ -240,7 +240,7 @@ impl VisionBlock {
         })
     }
 
-    fn forward(&self, hidden: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let normed = self
             .norm1
             .forward(hidden)
@@ -248,7 +248,7 @@ impl VisionBlock {
         let attention = self.attention.forward(&normed, cos, sin)?;
         let hidden = (hidden + attention).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MonkeyOCRv2 vision attention residual",
                 e,
             )
@@ -260,7 +260,7 @@ impl VisionBlock {
         let mlp = self.mlp.forward(&normed)?;
         (hidden + mlp).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "MonkeyOCRv2 vision MLP residual",
                 e,
             )
@@ -278,7 +278,7 @@ struct PatchMerger {
 }
 
 impl PatchMerger {
-    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let vb = vb.pp("merger");
         let norm = layer_norm(
             cfg.embed_dim,
@@ -304,12 +304,12 @@ impl PatchMerger {
         })
     }
 
-    fn forward(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         let num_patches = hidden
             .dim(0)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read merger patch count", e))?;
         if !num_patches.is_multiple_of(self.merge_group) {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "MonkeyOCRv2 merger patch count {num_patches} is not divisible by {}",
                     self.merge_group
@@ -342,7 +342,7 @@ pub struct MonkeyOcrV2VisionModel {
 }
 
 impl MonkeyOcrV2VisionModel {
-    pub fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    pub fn load(cfg: &MonkeyOcrV2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         cfg.validate()?;
         let patch_embed = PatchEmbed::load(cfg, vb.clone())?;
         let mut blocks = Vec::with_capacity(cfg.num_hidden_layers);
@@ -369,7 +369,7 @@ impl MonkeyOcrV2VisionModel {
         &self,
         pixel_values: &Tensor,
         grid_thw: (usize, usize, usize),
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (grid_t, grid_h, grid_w) = grid_thw;
         if grid_t != 1
             || grid_h == 0
@@ -377,7 +377,7 @@ impl MonkeyOcrV2VisionModel {
             || !grid_h.is_multiple_of(self.merge_size)
             || !grid_w.is_multiple_of(self.merge_size)
         {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "MonkeyOCRv2 invalid image grid {grid_thw:?} for merge_size {}",
                     self.merge_size
@@ -389,7 +389,7 @@ impl MonkeyOcrV2VisionModel {
             .dim(0)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "read pixel patch count", e))?;
         if actual != expected {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "MonkeyOCRv2 pixel patch count {actual} does not match grid {grid_thw:?} ({expected})"
                 ),
@@ -414,7 +414,7 @@ fn build_vision_rope(
     merge_size: usize,
     head_dim: usize,
     like: &Tensor,
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     let (grid_t, grid_h, grid_w) = grid_thw;
     let mut frequencies = Vec::with_capacity(grid_t * grid_h * grid_w * head_dim);
     for _ in 0..grid_t {

--- a/oar-ocr-vl/src/ovisocr2/config.rs
+++ b/oar-ocr-vl/src/ovisocr2/config.rs
@@ -1,5 +1,5 @@
+use crate::error::Error;
 use candle_nn::Activation;
-use oar_ocr_core::core::OCRError;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -84,7 +84,7 @@ pub struct OvisOcr2TextConfig {
 }
 
 impl OvisOcr2TextConfig {
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         if self.hidden_size == 0
             || self.intermediate_size == 0
             || self.vocab_size == 0
@@ -94,12 +94,12 @@ impl OvisOcr2TextConfig {
             || self.head_dim == 0
             || self.max_position_embeddings == 0
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 text dimensions must be non-zero".to_string(),
             });
         }
         if self.model_type != "qwen3_5_text" {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 expected text model_type 'qwen3_5_text', got '{}'",
                     self.model_type
@@ -107,7 +107,7 @@ impl OvisOcr2TextConfig {
             });
         }
         if self.hidden_act != Activation::Silu {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 text decoder supports hidden_act 'silu', got {:?}",
                     self.hidden_act
@@ -115,17 +115,17 @@ impl OvisOcr2TextConfig {
             });
         }
         if self.attention_bias {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 attention_bias=true is not supported".to_string(),
             });
         }
         if !self.attn_output_gate {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 requires attn_output_gate=true".to_string(),
             });
         }
         if !self.rms_norm_eps.is_finite() || self.rms_norm_eps <= 0.0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 rms_norm_eps must be finite and positive, got {}",
                     self.rms_norm_eps
@@ -133,7 +133,7 @@ impl OvisOcr2TextConfig {
             });
         }
         if self.eos_token_id as usize >= self.vocab_size {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 eos_token_id {} is outside vocab_size {}",
                     self.eos_token_id, self.vocab_size
@@ -144,7 +144,7 @@ impl OvisOcr2TextConfig {
             .num_attention_heads
             .is_multiple_of(self.num_key_value_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 num_attention_heads ({}) must be divisible by num_key_value_heads ({})",
                     self.num_attention_heads, self.num_key_value_heads
@@ -152,7 +152,7 @@ impl OvisOcr2TextConfig {
             });
         }
         if self.layer_types.len() != self.num_hidden_layers {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 layer_types length ({}) must equal num_hidden_layers ({})",
                     self.layer_types.len(),
@@ -165,7 +165,7 @@ impl OvisOcr2TextConfig {
             .iter()
             .any(|kind| kind != "linear_attention" && kind != "full_attention")
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 layer_types contains an unsupported layer type".to_string(),
             });
         }
@@ -175,12 +175,12 @@ impl OvisOcr2TextConfig {
             || self.linear_num_key_heads == 0
             || self.linear_num_value_heads == 0
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 linear-attention dimensions must be non-zero".to_string(),
             });
         }
         if self.linear_key_head_dim != self.linear_value_head_dim {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 requires equal linear key/value head dims, got {}/{}",
                     self.linear_key_head_dim, self.linear_value_head_dim
@@ -191,7 +191,7 @@ impl OvisOcr2TextConfig {
             .linear_num_value_heads
             .is_multiple_of(self.linear_num_key_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 linear_num_value_heads ({}) must be divisible by linear_num_key_heads ({})",
                     self.linear_num_value_heads, self.linear_num_key_heads
@@ -199,7 +199,7 @@ impl OvisOcr2TextConfig {
             });
         }
         if self.rope_parameters.rope_type != "default" {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 unsupported rope_type '{}'",
                     self.rope_parameters.rope_type
@@ -207,19 +207,19 @@ impl OvisOcr2TextConfig {
             });
         }
         if !self.rope_parameters.mrope_interleaved {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 requires interleaved MRoPE".to_string(),
             });
         }
         if self.rope_parameters.mrope_section.len() != 3
             || self.rope_parameters.mrope_section.contains(&0)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 mrope_section must contain three non-zero entries".to_string(),
             });
         }
         if !self.rope_parameters.rope_theta.is_finite() || self.rope_parameters.rope_theta <= 0.0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 rope_theta must be finite and positive, got {}",
                     self.rope_parameters.rope_theta
@@ -228,7 +228,7 @@ impl OvisOcr2TextConfig {
         }
         let partial = self.rope_parameters.partial_rotary_factor;
         if !partial.is_finite() || !(0.0..=1.0).contains(&partial) || partial == 0.0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!("OvisOCR2 partial_rotary_factor must be in (0, 1], got {partial}"),
             });
         }
@@ -238,11 +238,11 @@ impl OvisOcr2TextConfig {
             .mrope_section
             .iter()
             .try_fold(0usize, |sum, &value| sum.checked_add(value))
-            .ok_or_else(|| OCRError::ConfigError {
+            .ok_or_else(|| Error::Config {
                 message: "OvisOCR2 mrope_section sum overflow".to_string(),
             })?;
         if rotary_dim == 0 || !rotary_dim.is_multiple_of(2) || section_sum != rotary_dim / 2 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 mrope_section {:?} must sum to rotary_dim/2 ({})",
                     self.rope_parameters.mrope_section,
@@ -275,9 +275,9 @@ pub struct OvisOcr2VisionConfig {
 }
 
 impl OvisOcr2VisionConfig {
-    pub fn head_dim(&self) -> Result<usize, OCRError> {
+    pub fn head_dim(&self) -> Result<usize, Error> {
         if self.num_heads == 0 || !self.hidden_size.is_multiple_of(self.num_heads) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 vision hidden_size {} must be divisible by num_heads {}",
                     self.hidden_size, self.num_heads
@@ -287,10 +287,10 @@ impl OvisOcr2VisionConfig {
         Ok(self.hidden_size / self.num_heads)
     }
 
-    pub fn position_grid_size(&self) -> Result<usize, OCRError> {
+    pub fn position_grid_size(&self) -> Result<usize, Error> {
         let side = (self.num_position_embeddings as f64).sqrt() as usize;
         if side == 0 || side * side != self.num_position_embeddings {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 num_position_embeddings must be a non-zero square, got {}",
                     self.num_position_embeddings
@@ -300,9 +300,9 @@ impl OvisOcr2VisionConfig {
         Ok(side)
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         if self.model_type != "qwen3_5" {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 expected vision model_type 'qwen3_5', got '{}'",
                     self.model_type
@@ -317,13 +317,13 @@ impl OvisOcr2VisionConfig {
             || self.temporal_patch_size == 0
             || self.out_hidden_size == 0
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 vision dimensions must be non-zero".to_string(),
             });
         }
         let head_dim = self.head_dim()?;
         if !head_dim.is_multiple_of(4) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 vision head_dim must be divisible by 4 for 2D RoPE, got {head_dim}"
                 ),
@@ -331,7 +331,7 @@ impl OvisOcr2VisionConfig {
         }
         self.position_grid_size()?;
         if !self.deepstack_visual_indexes.is_empty() {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 deepstack vision features are not supported".to_string(),
             });
         }
@@ -356,7 +356,7 @@ pub struct OvisOcr2Config {
 }
 
 impl OvisOcr2Config {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         let cfg: Self = crate::utils::load_json_config(path, "OvisOCR2", "config.json")?;
         cfg.validate()?;
         Ok(cfg)
@@ -366,9 +366,9 @@ impl OvisOcr2Config {
         self.tie_word_embeddings || self.text_config.tie_word_embeddings
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         if self.model_type != "qwen3_5" {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 expected model_type 'qwen3_5', got '{}'",
                     self.model_type
@@ -378,7 +378,7 @@ impl OvisOcr2Config {
         self.text_config.validate()?;
         self.vision_config.validate()?;
         if !self.tie_word_embeddings() {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 requires tied token embeddings".to_string(),
             });
         }
@@ -389,7 +389,7 @@ impl OvisOcr2Config {
             ("vision_end_token_id", self.vision_end_token_id),
         ] {
             if token_id as usize >= self.text_config.vocab_size {
-                return Err(OCRError::ConfigError {
+                return Err(Error::Config {
                     message: format!(
                         "OvisOCR2 {name} {token_id} is outside vocab_size {}",
                         self.text_config.vocab_size
@@ -398,7 +398,7 @@ impl OvisOcr2Config {
             }
         }
         if self.vision_config.out_hidden_size != self.text_config.hidden_size {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 vision out_hidden_size ({}) must equal text hidden_size ({})",
                     self.vision_config.out_hidden_size, self.text_config.hidden_size
@@ -442,7 +442,7 @@ pub struct OvisOcr2ImageProcessorConfig {
 }
 
 impl OvisOcr2ImageProcessorConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         let cfg: Self =
             crate::utils::load_json_config(path, "OvisOCR2", "preprocessor_config.json")?;
         cfg.validate()?;
@@ -458,7 +458,7 @@ impl OvisOcr2ImageProcessorConfig {
         (OVIS_OCR2_MIN_PIXELS, OVIS_OCR2_MAX_PIXELS)
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         crate::utils::validate_image_mean_std("OvisOCR2", &self.image_mean, &self.image_std)?;
         if self
             .image_mean
@@ -466,17 +466,17 @@ impl OvisOcr2ImageProcessorConfig {
             .chain(&self.image_std)
             .any(|value| !value.is_finite())
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 image_mean/std values must be finite".to_string(),
             });
         }
         if self.do_normalize && self.image_std.iter().any(|&value| value <= 0.0) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 image_std values must be positive".to_string(),
             });
         }
         if self.do_rescale && !self.rescale_factor.is_finite() {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 rescale_factor must be finite, got {}",
                     self.rescale_factor
@@ -490,12 +490,12 @@ impl OvisOcr2ImageProcessorConfig {
             self.temporal_patch_size,
         )?;
         if self.size.shortest_edge == 0 || self.size.longest_edge == 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "OvisOCR2 processor size bounds must be non-zero".to_string(),
             });
         }
         if self.size.shortest_edge > self.size.longest_edge {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 shortest_edge {} exceeds longest_edge {}",
                     self.size.shortest_edge, self.size.longest_edge
@@ -505,7 +505,7 @@ impl OvisOcr2ImageProcessorConfig {
         if let Some(resample) = self.resample
             && resample > 5
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!("OvisOCR2 unsupported PIL resample value {resample}"),
             });
         }

--- a/oar-ocr-vl/src/ovisocr2/model.rs
+++ b/oar-ocr-vl/src/ovisocr2/model.rs
@@ -6,11 +6,11 @@ use super::text::OvisOcr2TextModel;
 use super::vision::OvisOcr2VisionModel;
 #[cfg(feature = "cuda")]
 use crate::cuda_kernels::{ArgmaxFirstBf16, ArgmaxFirstF32};
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::{Linear, Module, VarBuilder};
 use image::RgbImage;
-use oar_ocr_core::core::OCRError;
 use std::path::Path;
 use tokenizers::Tokenizer;
 
@@ -46,17 +46,16 @@ impl Drop for TextCacheGuard<'_> {
 
 impl OvisOcr2 {
     /// Load an OvisOCR2 Hugging Face model directory.
-    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, OCRError> {
+    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, Error> {
         let model_dir = model_dir.as_ref();
         let cfg = OvisOcr2Config::from_path(model_dir.join("config.json"))?;
         let image_cfg =
             OvisOcr2ImageProcessorConfig::from_path(model_dir.join("preprocessor_config.json"))?;
         validate_processor_vision_compatibility(&image_cfg, &cfg.vision_config)?;
-        let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| {
-            OCRError::ConfigError {
+        let tokenizer =
+            Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| Error::Config {
                 message: format!("failed to load OvisOCR2 tokenizer.json: {e}"),
-            }
-        })?;
+            })?;
         require_token_id(&tokenizer, "<|image_pad|>", Some(cfg.image_token_id))?;
         require_token_id(
             &tokenizer,
@@ -102,7 +101,7 @@ impl OvisOcr2 {
         &self,
         images: &[RgbImage],
         max_new_tokens: usize,
-    ) -> Vec<Result<String, OCRError>> {
+    ) -> Vec<Result<String, Error>> {
         self.generate_tokens(images, max_new_tokens)
             .into_iter()
             .map(|result| result.and_then(|tokens| self.decode_tokens(&tokens)))
@@ -111,11 +110,7 @@ impl OvisOcr2 {
 
     /// Parse pages using the official post-processing, which removes visual
     /// region `<img ...>` blocks by default.
-    pub fn parse(
-        &self,
-        images: &[RgbImage],
-        max_new_tokens: usize,
-    ) -> Vec<Result<String, OCRError>> {
+    pub fn parse(&self, images: &[RgbImage], max_new_tokens: usize) -> Vec<Result<String, Error>> {
         self.parse_with_image_tags(images, max_new_tokens, false)
     }
 
@@ -125,7 +120,7 @@ impl OvisOcr2 {
         images: &[RgbImage],
         max_new_tokens: usize,
         keep_image_tags: bool,
-    ) -> Vec<Result<String, OCRError>> {
+    ) -> Vec<Result<String, Error>> {
         self.generate_tokens(images, max_new_tokens)
             .into_iter()
             .map(|result| {
@@ -147,21 +142,21 @@ impl OvisOcr2 {
         &self,
         images: &[RgbImage],
         max_new_tokens: usize,
-    ) -> Vec<Result<Vec<u32>, OCRError>> {
+    ) -> Vec<Result<Vec<u32>, Error>> {
         images
             .iter()
             .map(|image| self.generate_one(image, max_new_tokens))
             .collect()
     }
 
-    fn generate_one(&self, image: &RgbImage, max_new_tokens: usize) -> Result<Vec<u32>, OCRError> {
+    fn generate_one(&self, image: &RgbImage, max_new_tokens: usize) -> Result<Vec<u32>, Error> {
         self.text.clear_cache();
         let _cache_guard = TextCacheGuard(&self.text);
         if max_new_tokens == 0 {
             return Ok(Vec::new());
         }
         if max_new_tokens > self.cfg.text_config.max_position_embeddings {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "OvisOCR2 max_new_tokens {max_new_tokens} exceeds context limit {}",
                     self.cfg.text_config.max_position_embeddings
@@ -176,15 +171,15 @@ impl OvisOcr2 {
             self.dtype,
         )?;
         let prompt = build_prompt(image_inputs.num_image_tokens);
-        let encoding =
-            self.tokenizer
-                .encode(prompt, false)
-                .map_err(|e| OCRError::InvalidInput {
-                    message: format!("OvisOCR2: tokenizer encode failed: {e}"),
-                })?;
+        let encoding = self
+            .tokenizer
+            .encode(prompt, false)
+            .map_err(|e| Error::InvalidInput {
+                message: format!("OvisOCR2: tokenizer encode failed: {e}"),
+            })?;
         let input_ids = encoding.get_ids().to_vec();
         if input_ids.is_empty() {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "OvisOCR2: prompt tokenization produced no tokens".to_string(),
             });
         }
@@ -211,7 +206,7 @@ impl OvisOcr2 {
         let mut generated = Vec::new();
         generated
             .try_reserve_exact(max_new_tokens)
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("OvisOCR2 cannot reserve output for {max_new_tokens} tokens: {e}"),
             })?;
 
@@ -227,7 +222,7 @@ impl OvisOcr2 {
 
             let token_ids = Tensor::from_vec(vec![token], (1, 1), &self.device).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "OvisOCR2: create decode token",
                     e,
                 )
@@ -248,7 +243,7 @@ impl OvisOcr2 {
         &self,
         input_ids: &[u32],
         image_inputs: &OvisOcr2ImageInputs,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let seq_len = input_ids.len();
         let token_ids = Tensor::from_vec(input_ids.to_vec(), (1, seq_len), &self.device)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "create prompt token ids", e))?;
@@ -268,7 +263,7 @@ impl OvisOcr2 {
             .dim(0)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "image embedding length", e))?;
         if image_positions.len() != image_len || image_positions.is_empty() {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "OvisOCR2: image placeholder count ({}) != image embedding count ({image_len})",
                     image_positions.len()
@@ -281,7 +276,7 @@ impl OvisOcr2 {
             .enumerate()
             .any(|(offset, &position)| position != start + offset)
         {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "OvisOCR2: image placeholder tokens must be contiguous".to_string(),
             });
         }
@@ -308,7 +303,7 @@ impl OvisOcr2 {
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "merge multimodal embeddings", e))
     }
 
-    fn logits_from_hidden(&self, hidden: &Tensor) -> Result<Tensor, OCRError> {
+    fn logits_from_hidden(&self, hidden: &Tensor) -> Result<Tensor, Error> {
         self.lm_head
             .forward(
                 &hidden
@@ -320,16 +315,16 @@ impl OvisOcr2 {
     }
 
     /// Decode generated token ids and apply the official truncated-repeat cleanup.
-    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens(&self, tokens: &[u32]) -> Result<String, Error> {
         Ok(clean_truncated_repeats(&self.decode_tokens_raw(tokens)?))
     }
 
     /// Decode token ids without OvisOCR2 post-processing.
-    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, Error> {
         self.tokenizer
             .decode(tokens, true)
             .map(|text| text.trim().to_string())
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("OvisOCR2: tokenizer decode failed: {e}"),
             })
     }
@@ -351,16 +346,14 @@ fn require_token_id(
     tokenizer: &Tokenizer,
     token: &str,
     expected: Option<u32>,
-) -> Result<u32, OCRError> {
-    let token_id = tokenizer
-        .token_to_id(token)
-        .ok_or_else(|| OCRError::ConfigError {
-            message: format!("OvisOCR2 tokenizer is missing required token {token:?}"),
-        })?;
+) -> Result<u32, Error> {
+    let token_id = tokenizer.token_to_id(token).ok_or_else(|| Error::Config {
+        message: format!("OvisOCR2 tokenizer is missing required token {token:?}"),
+    })?;
     if let Some(expected) = expected
         && token_id != expected
     {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "OvisOCR2 token {token:?} id mismatch: tokenizer {token_id} != config {expected}"
             ),
@@ -380,15 +373,14 @@ fn validate_generation_length(
     prompt_len: usize,
     max_new_tokens: usize,
     context_limit: usize,
-) -> Result<(), OCRError> {
-    let requested =
-        prompt_len
-            .checked_add(max_new_tokens)
-            .ok_or_else(|| OCRError::InvalidInput {
-                message: "OvisOCR2 requested sequence length overflows usize".to_string(),
-            })?;
+) -> Result<(), Error> {
+    let requested = prompt_len
+        .checked_add(max_new_tokens)
+        .ok_or_else(|| Error::InvalidInput {
+            message: "OvisOCR2 requested sequence length overflows usize".to_string(),
+        })?;
     if requested > context_limit {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "OvisOCR2 prompt ({prompt_len}) plus max_new_tokens ({max_new_tokens}) exceeds context limit {context_limit}"
             ),
@@ -415,11 +407,11 @@ fn build_position_ids(
     spatial_merge_size: usize,
     image_token_id: u32,
     device: &Device,
-) -> Result<(Tensor, i64), OCRError> {
+) -> Result<(Tensor, i64), Error> {
     let image_start = input_ids
         .iter()
         .position(|&token| token == image_token_id)
-        .ok_or_else(|| OCRError::InvalidInput {
+        .ok_or_else(|| Error::InvalidInput {
             message: "OvisOCR2: image token missing from prompt".to_string(),
         })?;
     let image_len = input_ids
@@ -428,7 +420,7 @@ fn build_position_ids(
         .take_while(|&&token| token == image_token_id)
         .count();
     if input_ids[image_start + image_len..].contains(&image_token_id) {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "OvisOCR2: non-contiguous image token span".to_string(),
         });
     }
@@ -437,7 +429,7 @@ fn build_position_ids(
         || !grid_h.is_multiple_of(spatial_merge_size)
         || !grid_w.is_multiple_of(spatial_merge_size)
     {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "OvisOCR2: invalid image grid {grid_thw:?} for merge size {spatial_merge_size}"
             ),
@@ -446,7 +438,7 @@ fn build_position_ids(
     let llm_h = grid_h / spatial_merge_size;
     let llm_w = grid_w / spatial_merge_size;
     if image_len != grid_t * llm_h * llm_w {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "OvisOCR2: image token count {image_len} != merged grid token count {}",
                 grid_t * llm_h * llm_w
@@ -492,7 +484,7 @@ fn build_position_ids(
     let data: Vec<i64> = axes.into_iter().flatten().collect();
     let tensor = Tensor::from_vec(data, (3, 1, seq_len), device).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "OvisOCR2: create multimodal position ids",
             e,
         )
@@ -500,17 +492,17 @@ fn build_position_ids(
     Ok((tensor, rope_delta))
 }
 
-fn text_position_ids(position: i64, device: &Device) -> Result<Tensor, OCRError> {
+fn text_position_ids(position: i64, device: &Device) -> Result<Tensor, Error> {
     Tensor::from_vec(vec![position; 3], (3, 1, 1), device).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "OvisOCR2: create decode position ids",
             e,
         )
     })
 }
 
-fn select_greedy_token(logits: &Tensor) -> Result<u32, OCRError> {
+fn select_greedy_token(logits: &Tensor) -> Result<u32, Error> {
     #[cfg(feature = "cuda")]
     if logits.device().is_cuda() && matches!(logits.dtype(), DType::BF16 | DType::F32) {
         let vocab_size = logits.elem_count();
@@ -535,7 +527,7 @@ fn select_greedy_token(logits: &Tensor) -> Result<u32, OCRError> {
         .and_then(|token| token.to_scalar::<u32>())
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "OvisOCR2: greedy argmax",
                 e,
             )

--- a/oar-ocr-vl/src/ovisocr2/processing.rs
+++ b/oar-ocr-vl/src/ovisocr2/processing.rs
@@ -1,11 +1,11 @@
 use super::config::{OvisOcr2ImageProcessorConfig, OvisOcr2VisionConfig};
+use crate::error::Error;
 use crate::utils::{
     candle_to_ocr_processing,
     image::{image_to_chw, patchify_merge_grouped, pil_resample_to_filter_type, smart_resize},
 };
 use candle_core::{DType, Device, Tensor};
 use image::{RgbImage, imageops::FilterType};
-use oar_ocr_core::core::OCRError;
 
 #[derive(Debug, Clone)]
 pub struct OvisOcr2ImageInputs {
@@ -17,9 +17,9 @@ pub struct OvisOcr2ImageInputs {
 pub(crate) fn validate_processor_vision_compatibility(
     cfg: &OvisOcr2ImageProcessorConfig,
     vision_cfg: &OvisOcr2VisionConfig,
-) -> Result<(), OCRError> {
+) -> Result<(), Error> {
     if cfg.patch_size != vision_cfg.patch_size {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "OvisOCR2 patch_size mismatch: processor {} != vision {}",
                 cfg.patch_size, vision_cfg.patch_size
@@ -27,7 +27,7 @@ pub(crate) fn validate_processor_vision_compatibility(
         });
     }
     if cfg.temporal_patch_size != vision_cfg.temporal_patch_size {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "OvisOCR2 temporal_patch_size mismatch: processor {} != vision {}",
                 cfg.temporal_patch_size, vision_cfg.temporal_patch_size
@@ -35,7 +35,7 @@ pub(crate) fn validate_processor_vision_compatibility(
         });
     }
     if cfg.merge_size != vision_cfg.spatial_merge_size {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "OvisOCR2 merge_size mismatch: processor {} != vision {}",
                 cfg.merge_size, vision_cfg.spatial_merge_size
@@ -43,7 +43,7 @@ pub(crate) fn validate_processor_vision_compatibility(
         });
     }
     if vision_cfg.in_channels != 3 {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "OvisOCR2 image preprocessing supports three RGB channels, got {}",
                 vision_cfg.in_channels
@@ -59,7 +59,7 @@ pub fn preprocess_image(
     vision_cfg: &OvisOcr2VisionConfig,
     device: &Device,
     dtype: DType,
-) -> Result<OvisOcr2ImageInputs, OCRError> {
+) -> Result<OvisOcr2ImageInputs, Error> {
     cfg.validate()?;
     vision_cfg.validate()?;
     validate_processor_vision_compatibility(cfg, vision_cfg)?;
@@ -68,13 +68,13 @@ pub fn preprocess_image(
         .patch_size
         .checked_mul(cfg.merge_size)
         .and_then(|factor| u32::try_from(factor).ok())
-        .ok_or_else(|| OCRError::ConfigError {
+        .ok_or_else(|| Error::Config {
             message: "OvisOCR2 patch/merge factor overflow".to_string(),
         })?;
     let (min_pixels, max_pixels) = cfg.runtime_pixel_bounds();
     let (height, width) = (image.height(), image.width());
     if height == 0 || width == 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!("OvisOCR2 input image must be non-empty, got {width}x{height}"),
         });
     }
@@ -85,7 +85,7 @@ pub fn preprocess_image(
     };
 
     if resized_height % factor != 0 || resized_width % factor != 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "OvisOCR2 preprocessed dimensions {resized_height}x{resized_width} must be divisible by {factor}"
             ),
@@ -127,7 +127,7 @@ pub fn preprocess_image(
     let grid_h = resized_height as usize / cfg.patch_size;
     let grid_w = resized_width as usize / cfg.patch_size;
     if !grid_h.is_multiple_of(cfg.merge_size) || !grid_w.is_multiple_of(cfg.merge_size) {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "OvisOCR2 patch grid {grid_h}x{grid_w} must be divisible by merge_size {}",
                 cfg.merge_size
@@ -151,7 +151,7 @@ pub fn preprocess_image(
         vision_cfg.in_channels * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size;
     let num_patches = grid_t * grid_h * grid_w;
     if flat.len() != num_patches * patch_dim {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "OvisOCR2 patch extraction produced {} values, expected {}",
                 flat.len(),
@@ -163,7 +163,7 @@ pub fn preprocess_image(
     let pixel_values = Tensor::from_vec(flat, (num_patches, patch_dim), device)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "OvisOCR2: create pixel_values",
                 e,
             )
@@ -171,7 +171,7 @@ pub fn preprocess_image(
         .to_dtype(dtype)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "OvisOCR2: cast pixel_values",
                 e,
             )

--- a/oar-ocr-vl/src/ovisocr2/text.rs
+++ b/oar-ocr-vl/src/ovisocr2/text.rs
@@ -8,6 +8,7 @@
 use super::config::OvisOcr2TextConfig;
 use super::gated_delta::gated_delta_rule;
 use crate::attention::{RotaryEmbedding, flash_attention, scaled_dot_product_attention_gqa};
+use crate::error::Error;
 use crate::kv_trim::TrimmableKvCache;
 use crate::utils::{candle_to_ocr_inference, rotate_half};
 use candle_core::{D, DType, Device, Tensor};
@@ -15,7 +16,6 @@ use candle_nn::{
     Conv1d, Conv1dConfig, Embedding, Linear, Module, RmsNorm, VarBuilder, embedding,
     linear_no_bias, rms_norm,
 };
-use oar_ocr_core::core::OCRError;
 use std::cell::RefCell;
 
 const MODEL_NAME: &str = "OvisOCR2";
@@ -27,7 +27,7 @@ struct AdditiveRmsNorm {
 }
 
 impl AdditiveRmsNorm {
-    fn load(dim: usize, eps: f64, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(dim: usize, eps: f64, vb: VarBuilder) -> Result<Self, Error> {
         let weight = vb
             .get(dim, "weight")
             .and_then(|weight| weight.to_dtype(DType::F32))
@@ -35,7 +35,7 @@ impl AdditiveRmsNorm {
         Ok(Self { weight, eps })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, Error> {
         let dtype = xs.dtype();
         let xs = xs
             .to_dtype(DType::F32)
@@ -68,7 +68,7 @@ struct OvisMlp {
 }
 
 impl OvisMlp {
-    fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, Error> {
         let gate_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "load MLP gate_proj", e))?;
         let up_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))
@@ -82,7 +82,7 @@ impl OvisMlp {
         })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, Error> {
         let gate = self
             .gate_proj
             .forward(xs)
@@ -142,7 +142,7 @@ fn cached_depthwise_conv_step(
 }
 
 impl GatedDeltaNet {
-    fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, Error> {
         let key_dim = cfg.linear_num_key_heads * cfg.linear_key_head_dim;
         let value_dim = cfg.linear_num_value_heads * cfg.linear_value_head_dim;
         let conv_dim = key_dim * 2 + value_dim;
@@ -150,7 +150,7 @@ impl GatedDeltaNet {
             .linear_num_value_heads
             .is_multiple_of(cfg.linear_num_key_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2: linear_num_value_heads ({}) must be divisible by linear_num_key_heads ({})",
                     cfg.linear_num_value_heads, cfg.linear_num_key_heads
@@ -158,7 +158,7 @@ impl GatedDeltaNet {
             });
         }
         if cfg.linear_key_head_dim != cfg.linear_value_head_dim {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2 currently requires equal Gated DeltaNet key/value head dims, got {}/{}",
                     cfg.linear_key_head_dim, cfg.linear_value_head_dim
@@ -238,7 +238,7 @@ impl GatedDeltaNet {
         })
     }
 
-    fn causal_conv(&self, mixed: &Tensor) -> Result<Tensor, OCRError> {
+    fn causal_conv(&self, mixed: &Tensor) -> Result<Tensor, Error> {
         let (batch, channels, seq_len) = mixed
             .dims3()
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN convolution input", e))?;
@@ -316,7 +316,7 @@ impl GatedDeltaNet {
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN convolution SiLU", e))
     }
 
-    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, Error> {
         let (batch, seq_len, _) = hidden_states
             .dims3()
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "GDN input shape", e))?;
@@ -464,12 +464,12 @@ struct FullAttention {
 }
 
 impl FullAttention {
-    fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, Error> {
         if !cfg
             .num_attention_heads
             .is_multiple_of(cfg.num_key_value_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2: num_attention_heads ({}) must be divisible by num_key_value_heads ({})",
                     cfg.num_attention_heads, cfg.num_key_value_heads
@@ -518,7 +518,7 @@ impl FullAttention {
         })
     }
 
-    fn apply_rope(&self, tensor: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, OCRError> {
+    fn apply_rope(&self, tensor: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let rotary_dim = cos
             .dim(D::Minus1)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention rotary dimension", e))?;
@@ -543,12 +543,7 @@ impl FullAttention {
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention RoPE output", e))
     }
 
-    fn forward(
-        &self,
-        hidden_states: &Tensor,
-        cos: &Tensor,
-        sin: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let (batch, seq_len, _) = hidden_states
             .dims3()
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "attention input", e))?;
@@ -652,14 +647,14 @@ struct DecoderLayer {
 }
 
 impl DecoderLayer {
-    fn load(cfg: &OvisOcr2TextConfig, layer_type: &str, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &OvisOcr2TextConfig, layer_type: &str, vb: VarBuilder) -> Result<Self, Error> {
         let mixer = match layer_type {
             "linear_attention" => {
                 TokenMixer::Linear(GatedDeltaNet::load(cfg, vb.pp("linear_attn"))?)
             }
             "full_attention" => TokenMixer::Full(FullAttention::load(cfg, vb.pp("self_attn"))?),
             other => {
-                return Err(OCRError::ConfigError {
+                return Err(Error::Config {
                     message: format!("OvisOCR2: unsupported decoder layer type '{other}'"),
                 });
             }
@@ -680,12 +675,7 @@ impl DecoderLayer {
         })
     }
 
-    fn forward(
-        &self,
-        hidden_states: &Tensor,
-        cos: &Tensor,
-        sin: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let residual = hidden_states.clone();
         let normalized = self.input_layernorm.forward(hidden_states)?;
         let mixed = match &self.mixer {
@@ -716,16 +706,16 @@ struct TextRotaryEmbedding {
 }
 
 impl TextRotaryEmbedding {
-    fn new(cfg: &OvisOcr2TextConfig, device: &Device) -> Result<Self, OCRError> {
+    fn new(cfg: &OvisOcr2TextConfig, device: &Device) -> Result<Self, Error> {
         let rotary_dim = (cfg.head_dim as f64 * cfg.rope_parameters.partial_rotary_factor) as usize;
         if rotary_dim == 0 || !rotary_dim.is_multiple_of(2) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!("OvisOCR2: invalid rotary dimension {rotary_dim}"),
             });
         }
         let half = rotary_dim / 2;
         if cfg.rope_parameters.mrope_section.iter().sum::<usize>() != half {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2: mrope_section {:?} must sum to rotary_dim/2 ({half})",
                     cfg.rope_parameters.mrope_section
@@ -743,12 +733,12 @@ impl TextRotaryEmbedding {
         Ok(Self { rotary, axis_ids })
     }
 
-    fn forward(&self, position_ids: &Tensor, dtype: DType) -> Result<(Tensor, Tensor), OCRError> {
+    fn forward(&self, position_ids: &Tensor, dtype: DType) -> Result<(Tensor, Tensor), Error> {
         let (cos, sin) = self.rotary.forward_multi_axis(position_ids, dtype)?;
         Ok((self.select_axes(&cos)?, self.select_axes(&sin)?))
     }
 
-    fn select_axes(&self, values: &Tensor) -> Result<Tensor, OCRError> {
+    fn select_axes(&self, values: &Tensor) -> Result<Tensor, Error> {
         let (_, batch, seq_len, rotary_dim) = values
             .dims4()
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "mRoPE tensor shape", e))?;
@@ -794,9 +784,9 @@ pub(crate) struct OvisOcr2TextModel {
 }
 
 impl OvisOcr2TextModel {
-    pub(crate) fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    pub(crate) fn load(cfg: &OvisOcr2TextConfig, vb: VarBuilder) -> Result<Self, Error> {
         if cfg.layer_types.len() != cfg.num_hidden_layers {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "OvisOCR2: layer_types has {} entries, expected {}",
                     cfg.layer_types.len(),
@@ -824,7 +814,7 @@ impl OvisOcr2TextModel {
         })
     }
 
-    pub(crate) fn embed(&self, input_ids: &Tensor) -> Result<Tensor, OCRError> {
+    pub(crate) fn embed(&self, input_ids: &Tensor) -> Result<Tensor, Error> {
         self.embed_tokens
             .forward(input_ids)
             .map_err(|e| candle_to_ocr_inference(MODEL_NAME, "token embedding", e))
@@ -838,7 +828,7 @@ impl OvisOcr2TextModel {
         &self,
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (cos, sin) = self
             .rotary_emb
             .forward(position_ids, inputs_embeds.dtype())?;

--- a/oar-ocr-vl/src/ovisocr2/vision.rs
+++ b/oar-ocr-vl/src/ovisocr2/vision.rs
@@ -3,12 +3,12 @@ use crate::attention::{
     VISION_CHUNKED_ATTN_CHUNK_SIZE, VISION_CHUNKED_ATTN_SEQ_THRESHOLD, chunked_vision_attention,
     flash_attention, on_compute_device, scaled_dot_product_attention,
 };
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::{
     Activation, LayerNorm, LayerNormConfig, Linear, Module, VarBuilder, layer_norm, linear,
 };
-use oar_ocr_core::core::OCRError;
 
 #[derive(Debug, Clone)]
 struct VisionPatchEmbed {
@@ -17,7 +17,7 @@ struct VisionPatchEmbed {
 }
 
 impl VisionPatchEmbed {
-    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let vb = vb.pp("patch_embed").pp("proj");
         let patch_dim = cfg.in_channels * cfg.temporal_patch_size * cfg.patch_size * cfg.patch_size;
         let weight = vb
@@ -40,7 +40,7 @@ impl VisionPatchEmbed {
         Ok(Self { weight, bias })
     }
 
-    fn forward(&self, patches: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, patches: &Tensor) -> Result<Tensor, Error> {
         let patches = patches
             .to_dtype(self.weight.dtype())
             .map_err(|e| candle_to_ocr_inference("OvisOCR2", "cast vision patches", e))?;
@@ -61,12 +61,12 @@ struct VisionRotaryEmbedding {
 }
 
 impl VisionRotaryEmbedding {
-    fn new(dim: usize, device: &Device) -> Result<Self, OCRError> {
+    fn new(dim: usize, device: &Device) -> Result<Self, Error> {
         let inv_freq = crate::utils::vision_inv_freq(dim, 10_000.0, "OvisOCR2", device)?;
         Ok(Self { inv_freq })
     }
 
-    fn forward(&self, sequence_length: usize) -> Result<Tensor, OCRError> {
+    fn forward(&self, sequence_length: usize) -> Result<Tensor, Error> {
         let device = self.inv_freq.device();
         on_compute_device(device, |compute_device| {
             let positions = Tensor::arange(0u32, sequence_length as u32, compute_device)?
@@ -79,7 +79,7 @@ impl VisionRotaryEmbedding {
         })
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "OvisOCR2: build vision rotary frequency table",
                 e,
             )
@@ -92,7 +92,7 @@ fn apply_rotary_pos_emb_vision(
     k: &Tensor,
     cos: &Tensor,
     sin: &Tensor,
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     let q_dtype = q.dtype();
     let k_dtype = k.dtype();
     let q = q
@@ -135,7 +135,7 @@ struct VisionAttention {
 }
 
 impl VisionAttention {
-    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let head_dim = cfg.head_dim()?;
         let qkv = linear(
             cfg.hidden_size,
@@ -154,12 +154,7 @@ impl VisionAttention {
         })
     }
 
-    fn forward(
-        &self,
-        hidden_states: &Tensor,
-        cos: &Tensor,
-        sin: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let sequence_length = hidden_states
             .dim(0)
             .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision sequence length", e))?;
@@ -226,7 +221,7 @@ struct VisionMlp {
 }
 
 impl VisionMlp {
-    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let linear_fc1 = linear(
             cfg.hidden_size,
             cfg.intermediate_size,
@@ -246,7 +241,7 @@ impl VisionMlp {
         })
     }
 
-    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, Error> {
         let hidden_states = self
             .linear_fc1
             .forward(hidden_states)
@@ -267,7 +262,7 @@ struct VisionBlock {
 }
 
 impl VisionBlock {
-    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let norm_cfg = LayerNormConfig {
             eps: 1e-6,
             ..Default::default()
@@ -286,12 +281,7 @@ impl VisionBlock {
         })
     }
 
-    fn forward(
-        &self,
-        hidden_states: &Tensor,
-        cos: &Tensor,
-        sin: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor, Error> {
         let normed = self
             .norm1
             .forward(hidden_states)
@@ -299,7 +289,7 @@ impl VisionBlock {
         let attention = self.attention.forward(&normed, cos, sin)?;
         let hidden_states = (hidden_states + attention).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "OvisOCR2: vision attention residual",
                 e,
             )
@@ -311,7 +301,7 @@ impl VisionBlock {
         let mlp = self.mlp.forward(&normed)?;
         (hidden_states + mlp).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "OvisOCR2: vision MLP residual",
                 e,
             )
@@ -329,7 +319,7 @@ struct VisionPatchMerger {
 }
 
 impl VisionPatchMerger {
-    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         let vb = vb.pp("merger");
         let norm_cfg = LayerNormConfig {
             eps: 1e-6,
@@ -352,12 +342,12 @@ impl VisionPatchMerger {
         })
     }
 
-    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor, Error> {
         let num_patches = hidden_states
             .dim(0)
             .map_err(|e| candle_to_ocr_inference("OvisOCR2", "vision merger patch count", e))?;
         if !num_patches.is_multiple_of(self.merge_group) {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "OvisOCR2 vision merger expected patch count divisible by {}, got {num_patches}",
                     self.merge_group
@@ -393,7 +383,7 @@ pub struct OvisOcr2VisionModel {
 }
 
 impl OvisOcr2VisionModel {
-    pub fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, OCRError> {
+    pub fn load(cfg: &OvisOcr2VisionConfig, vb: VarBuilder) -> Result<Self, Error> {
         cfg.validate()?;
         let patch_embed = VisionPatchEmbed::load(cfg, vb.clone())?;
         let position_embedding = vb
@@ -426,17 +416,17 @@ impl OvisOcr2VisionModel {
         &self,
         pixel_values: &Tensor,
         grid_thw: (usize, usize, usize),
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (grid_t, grid_h, grid_w) = grid_thw;
         if grid_t == 0 || grid_h == 0 || grid_w == 0 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!("OvisOCR2 vision grid must be non-zero, got {grid_thw:?}"),
             });
         }
         if !grid_h.is_multiple_of(self.spatial_merge_size)
             || !grid_w.is_multiple_of(self.spatial_merge_size)
         {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "OvisOCR2 vision grid {grid_h}x{grid_w} must be divisible by merge_size {}",
                     self.spatial_merge_size
@@ -446,14 +436,14 @@ impl OvisOcr2VisionModel {
         let num_patches = grid_t
             .checked_mul(grid_h)
             .and_then(|value| value.checked_mul(grid_w))
-            .ok_or_else(|| OCRError::InvalidInput {
+            .ok_or_else(|| Error::InvalidInput {
                 message: "OvisOCR2 vision patch count overflow".to_string(),
             })?;
         if pixel_values.dim(0).map_err(|e| {
             candle_to_ocr_inference("OvisOCR2", "read vision pixel_values length", e)
         })? != num_patches
         {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "OvisOCR2 pixel_values patch count ({}) does not match grid {grid_thw:?} ({num_patches})",
                     pixel_values.dims().first().copied().unwrap_or(0)
@@ -488,7 +478,7 @@ impl OvisOcr2VisionModel {
 fn merge_grouped_spatial_coordinates(
     grid_thw: (usize, usize, usize),
     merge_size: usize,
-) -> Result<Vec<(usize, usize)>, OCRError> {
+) -> Result<Vec<(usize, usize)>, Error> {
     let (grid_t, grid_h, grid_w) = grid_thw;
     if grid_t == 0
         || grid_h == 0
@@ -497,7 +487,7 @@ fn merge_grouped_spatial_coordinates(
         || !grid_h.is_multiple_of(merge_size)
         || !grid_w.is_multiple_of(merge_size)
     {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "OvisOCR2 invalid merge-grouped grid: grid={grid_thw:?}, merge={merge_size}"
             ),
@@ -506,7 +496,7 @@ fn merge_grouped_spatial_coordinates(
     let num_patches = grid_t
         .checked_mul(grid_h)
         .and_then(|value| value.checked_mul(grid_w))
-        .ok_or_else(|| OCRError::InvalidInput {
+        .ok_or_else(|| Error::InvalidInput {
             message: "OvisOCR2 merge-grouped patch count overflow".to_string(),
         })?;
     let mut coordinates = Vec::with_capacity(num_patches);
@@ -532,10 +522,10 @@ fn interpolate_position_embedding(
     base_grid_size: usize,
     grid_thw: (usize, usize, usize),
     merge_size: usize,
-) -> Result<Tensor, OCRError> {
+) -> Result<Tensor, Error> {
     let (_, grid_h, grid_w) = grid_thw;
     if base_grid_size == 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "OvisOCR2 invalid learned-position grid: base={base_grid_size}, grid={grid_thw:?}, merge={merge_size}"
             ),
@@ -545,7 +535,7 @@ fn interpolate_position_embedding(
         .dims2()
         .map_err(|e| candle_to_ocr_inference("OvisOCR2", "position embedding shape", e))?;
     if num_positions != base_grid_size * base_grid_size {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "OvisOCR2 position embedding rows ({num_positions}) do not match base grid {base_grid_size}x{base_grid_size}"
             ),
@@ -591,7 +581,7 @@ fn interpolate_position_embedding(
         weight11.push(dh * dw);
     }
 
-    let weighted = |indices: Vec<u32>, weights: Vec<f32>| -> Result<Tensor, OCRError> {
+    let weighted = |indices: Vec<u32>, weights: Vec<f32>| -> Result<Tensor, Error> {
         let indices =
             Tensor::from_vec(indices, num_patches, position_embedding.device()).map_err(|e| {
                 candle_to_ocr_inference("OvisOCR2", "position interpolation indices", e)
@@ -623,7 +613,7 @@ fn build_vision_rotary_embeddings(
     grid_thw: (usize, usize, usize),
     merge_size: usize,
     device: &Device,
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     let (_, grid_h, grid_w) = grid_thw;
     let coordinates = merge_grouped_spatial_coordinates(grid_thw, merge_size)?;
     let max_grid = grid_h.max(grid_w);
@@ -662,7 +652,7 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    fn learned_position_interpolation_matches_bilinear_reference() -> Result<(), OCRError> {
+    fn learned_position_interpolation_matches_bilinear_reference() -> Result<(), Error> {
         let weights = Tensor::from_vec(vec![0.0f32, 1.0, 2.0, 3.0], (4, 1), &Device::Cpu)
             .map_err(|e| candle_to_ocr_inference("OvisOCR2", "test position tensor", e))?;
         let output = interpolate_position_embedding(&weights, 2, (1, 3, 3), 1)?;
@@ -678,7 +668,7 @@ mod tests {
     }
 
     #[test]
-    fn learned_positions_follow_spatial_merge_group_order() -> Result<(), OCRError> {
+    fn learned_positions_follow_spatial_merge_group_order() -> Result<(), Error> {
         let weights = Tensor::from_vec(
             (0..16).map(|value| value as f32).collect::<Vec<_>>(),
             (16, 1),
@@ -701,7 +691,7 @@ mod tests {
     }
 
     #[test]
-    fn loads_qwen35_weight_names_and_forwards_tiny_tower() -> Result<(), OCRError> {
+    fn loads_qwen35_weight_names_and_forwards_tiny_tower() -> Result<(), Error> {
         let cfg = OvisOcr2VisionConfig {
             model_type: "qwen3_5".to_string(),
             depth: 0,

--- a/oar-ocr-vl/src/paddleocr_vl/config.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/config.rs
@@ -1,4 +1,4 @@
-use oar_ocr_core::core::OCRError;
+use crate::error::Error;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -21,11 +21,11 @@ pub struct PaddleOcrVlImageProcessorConfig {
 }
 
 impl PaddleOcrVlImageProcessorConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         crate::utils::load_json_config(path, "PaddleOCR-VL", "preprocessor_config.json")
     }
 
-    pub fn validate(&self) -> Result<(), OCRError> {
+    pub fn validate(&self) -> Result<(), Error> {
         crate::utils::validate_image_mean_std("PaddleOCR-VL", &self.image_mean, &self.image_std)?;
         crate::utils::validate_patch_merge_temporal(
             "PaddleOCR-VL",
@@ -79,7 +79,7 @@ pub struct PaddleOcrVlConfig {
 }
 
 impl PaddleOcrVlConfig {
-    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, OCRError> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         crate::utils::load_json_config(path, "PaddleOCR-VL", "config.json")
     }
 }

--- a/oar-ocr-vl/src/paddleocr_vl/ernie.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/ernie.rs
@@ -9,6 +9,7 @@ use crate::decoder_graph::{
     CudaGraphKvLengths, SingleTokenDecoderCudaGraph, cuda_graph_error, decoder_attention_is_causal,
     sync_graph_tensor,
 };
+use crate::error::Error;
 #[cfg(feature = "cuda")]
 use crate::hunyuanocr::dynamic_kv::DynamicKvAppend;
 use crate::kv_trim::TrimmableKvCache;
@@ -17,7 +18,6 @@ use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing, rotate_hal
 use candle_core::{DType, Device};
 use candle_core::{IndexOp, Tensor};
 use candle_nn::{Linear, Module};
-use oar_ocr_core::core::OCRError;
 use std::cell::RefCell;
 
 #[cfg(feature = "cuda")]
@@ -29,13 +29,13 @@ fn apply_multimodal_rotary_pos_emb(
     cos: &Tensor,
     sin: &Tensor,
     mrope_section: &[usize],
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     // MRoPE uses 3 position dimensions
     let cos = select_rope_sections(cos, mrope_section, 3)?;
     let sin = select_rope_sections(sin, mrope_section, 3)?;
     let q_mul = q.broadcast_mul(&cos).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "PaddleOCR-VL: mrope q*cos failed",
             e,
         )
@@ -43,14 +43,14 @@ fn apply_multimodal_rotary_pos_emb(
     let q_half = rotate_half(q)?;
     let q_half_mul = q_half.broadcast_mul(&sin).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "PaddleOCR-VL: mrope rotate_half(q)*sin failed",
             e,
         )
     })?;
     let q_rot = (&q_mul + &q_half_mul).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "PaddleOCR-VL: mrope apply on q failed",
             e,
         )
@@ -58,7 +58,7 @@ fn apply_multimodal_rotary_pos_emb(
 
     let k_mul = k.broadcast_mul(&cos).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "PaddleOCR-VL: mrope k*cos failed",
             e,
         )
@@ -66,14 +66,14 @@ fn apply_multimodal_rotary_pos_emb(
     let k_half = rotate_half(k)?;
     let k_half_mul = k_half.broadcast_mul(&sin).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "PaddleOCR-VL: mrope rotate_half(k)*sin failed",
             e,
         )
     })?;
     let k_rot = (&k_mul + &k_half_mul).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "PaddleOCR-VL: mrope apply on k failed",
             e,
         )
@@ -89,7 +89,7 @@ struct Ernie4_5Mlp {
 }
 
 impl Ernie4_5Mlp {
-    fn load(cfg: &PaddleOcrVlConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &PaddleOcrVlConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let gate_proj = candle_nn::linear_b(
             cfg.hidden_size,
             cfg.intermediate_size,
@@ -118,7 +118,7 @@ impl Ernie4_5Mlp {
         })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, Error> {
         let gate = self
             .gate_proj
             .forward(xs)
@@ -153,7 +153,7 @@ struct Ernie4_5Attention {
 }
 
 impl Ernie4_5Attention {
-    fn load(cfg: &PaddleOcrVlConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &PaddleOcrVlConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let q_proj = candle_nn::linear_b(
             cfg.hidden_size,
             cfg.num_attention_heads * cfg.head_dim,
@@ -187,7 +187,7 @@ impl Ernie4_5Attention {
             .num_attention_heads
             .is_multiple_of(cfg.num_key_value_heads)
         {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "PaddleOCR-VL: num_attention_heads ({}) must be divisible by num_key_value_heads ({})",
                     cfg.num_attention_heads, cfg.num_key_value_heads
@@ -220,7 +220,7 @@ impl Ernie4_5Attention {
         hidden_states: &Tensor,
         cos: &Tensor,
         sin: &Tensor,
-    ) -> Result<(Tensor, Tensor, Tensor), OCRError> {
+    ) -> Result<(Tensor, Tensor, Tensor), Error> {
         let (b, seq_len, _) = hidden_states
             .dims3()
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "attn hidden_states dims3", e))?;
@@ -273,7 +273,7 @@ impl Ernie4_5Attention {
         cos: &Tensor,
         sin: &Tensor,
         causal_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (b, seq_len, _) = hidden_states
             .dims3()
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "attn hidden_states dims3", e))?;
@@ -314,7 +314,7 @@ impl Ernie4_5Attention {
         attn_output: &Tensor,
         batch: usize,
         seq_len: usize,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let attn_output = attn_output
             .transpose(1, 2)
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "attn out transpose", e))?
@@ -327,7 +327,7 @@ impl Ernie4_5Attention {
     }
 
     #[cfg(feature = "cuda")]
-    fn prepare_dynamic_cache(&self, query_len: usize, cache_len: usize) -> Result<(), OCRError> {
+    fn prepare_dynamic_cache(&self, query_len: usize, cache_len: usize) -> Result<(), Error> {
         let template = Tensor::zeros(
             (1, self.num_kv_heads, query_len, self.head_dim),
             self.k_proj.weight().dtype(),
@@ -348,19 +348,19 @@ impl Ernie4_5Attention {
         sin: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (batch, query_len, _) = hidden_states.dims3().map_err(|e| {
             candle_to_ocr_inference("PaddleOCR-VL", "dynamic attention hidden shape", e)
         })?;
         if batch != 1 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: "PaddleOCR-VL CUDA-graph attention requires batch size 1".to_string(),
             });
         }
         let (q, k, v) = self.project_qkv(hidden_states, cos, sin)?;
         let cache = self.kv_cache.borrow();
         let cache_len = cache.storage_capacity();
-        let (cache_k, cache_v) = cache.storage().ok_or_else(|| OCRError::ConfigError {
+        let (cache_k, cache_v) = cache.storage().ok_or_else(|| Error::Config {
             message: "PaddleOCR-VL dynamic KV storage is not initialized".to_string(),
         })?;
         drop(cache);
@@ -415,7 +415,7 @@ impl Ernie4_5Attention {
     }
 
     #[cfg(feature = "cuda")]
-    fn set_kv_cache_len(&self, len: usize) -> Result<(), OCRError> {
+    fn set_kv_cache_len(&self, len: usize) -> Result<(), Error> {
         self.kv_cache
             .borrow_mut()
             .set_current_len(len)
@@ -432,7 +432,7 @@ struct Ernie4_5DecoderLayer {
 }
 
 impl Ernie4_5DecoderLayer {
-    fn load(cfg: &PaddleOcrVlConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &PaddleOcrVlConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let self_attn = Ernie4_5Attention::load(cfg, vb.pp("self_attn"))?;
         let mlp = Ernie4_5Mlp::load(cfg, vb.pp("mlp"))?;
         let input_layernorm =
@@ -458,7 +458,7 @@ impl Ernie4_5DecoderLayer {
         cos: &Tensor,
         sin: &Tensor,
         causal_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let residual = hidden_states.clone();
         let hidden_states = self
             .input_layernorm
@@ -490,7 +490,7 @@ impl Ernie4_5DecoderLayer {
         sin: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let residual = hidden_states.clone();
         let hidden_states = self
             .input_layernorm
@@ -524,7 +524,7 @@ impl Ernie4_5DecoderLayer {
     }
 
     #[cfg(feature = "cuda")]
-    fn set_kv_cache_len(&self, len: usize) -> Result<(), OCRError> {
+    fn set_kv_cache_len(&self, len: usize) -> Result<(), Error> {
         self.self_attn.set_kv_cache_len(len)
     }
 }
@@ -540,7 +540,7 @@ pub struct Ernie4_5Model {
 }
 
 impl Ernie4_5Model {
-    pub fn load(cfg: &PaddleOcrVlConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    pub fn load(cfg: &PaddleOcrVlConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let embed_tokens =
             candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("embed_tokens"))
                 .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "load embed_tokens", e))?;
@@ -564,7 +564,7 @@ impl Ernie4_5Model {
         })
     }
 
-    pub fn embed(&self, input_ids: &Tensor) -> Result<Tensor, OCRError> {
+    pub fn embed(&self, input_ids: &Tensor) -> Result<Tensor, Error> {
         self.embed_tokens
             .forward(input_ids)
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "embed tokens", e))
@@ -575,7 +575,7 @@ impl Ernie4_5Model {
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
         causal_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (cos, sin) = self
             .rotary
             .forward_multi_axis(position_ids, inputs_embeds.dtype())?;
@@ -589,7 +589,7 @@ impl Ernie4_5Model {
         cos: &Tensor,
         sin: &Tensor,
         causal_mask: Option<&Tensor>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let mut hidden_states = inputs_embeds.clone();
         for layer in &self.layers {
             hidden_states = layer.forward(&hidden_states, cos, sin, causal_mask)?;
@@ -599,7 +599,7 @@ impl Ernie4_5Model {
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "llm final norm", e))
     }
 
-    fn project_logits(&self, hidden_states: &Tensor, lm_head: &Linear) -> Result<Tensor, OCRError> {
+    fn project_logits(&self, hidden_states: &Tensor, lm_head: &Linear) -> Result<Tensor, Error> {
         lm_head
             .forward(hidden_states)
             .and_then(|logits| logits.i((0, 0, ..)))
@@ -612,7 +612,7 @@ impl Ernie4_5Model {
         position_ids: &Tensor,
         causal_mask: Option<&Tensor>,
         lm_head: &Linear,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         #[cfg(feature = "cuda")]
         {
             let kv_len = self.kv_cache_len().saturating_add(1);
@@ -631,7 +631,7 @@ impl Ernie4_5Model {
         position_ids: &Tensor,
         query_lengths: &Tensor,
         kv_lengths: &Tensor,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (cos, sin) = self
             .rotary
             .forward_multi_axis(position_ids, inputs_embeds.dtype())?;
@@ -650,7 +650,7 @@ impl Ernie4_5Model {
         prompt_len: usize,
         max_new_tokens: usize,
         lm_head: &Linear,
-    ) -> Result<(), OCRError> {
+    ) -> Result<(), Error> {
         if std::env::var_os("OAR_VL_DISABLE_CUDA_GRAPH").is_some()
             || std::env::var_os("OAR_PADDLEOCR_VL_DISABLE_CUDA_GRAPH").is_some()
         {
@@ -692,7 +692,7 @@ impl Ernie4_5Model {
     }
 
     #[cfg(feature = "cuda")]
-    fn capture_cuda_graph(&self, cache_len: usize, lm_head: &Linear) -> Result<(), OCRError> {
+    fn capture_cuda_graph(&self, cache_len: usize, lm_head: &Linear) -> Result<(), Error> {
         use candle_core::cuda_backend::cudarc::driver::sys::{
             CUgraphInstantiate_flags_enum, CUstreamCaptureMode_enum,
         };
@@ -765,7 +765,7 @@ impl Ernie4_5Model {
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
             )
             .map_err(|e| cuda_graph_error("PaddleOCR-VL", "end decoder CUDA graph capture", e))?
-            .ok_or_else(|| OCRError::ConfigError {
+            .ok_or_else(|| Error::Config {
                 message: "PaddleOCR-VL decoder capture returned no graph".to_string(),
             })?;
         graph
@@ -791,7 +791,7 @@ impl Ernie4_5Model {
         inputs_embeds: &Tensor,
         position_ids: &Tensor,
         kv_len: usize,
-    ) -> Result<Option<Tensor>, OCRError> {
+    ) -> Result<Option<Tensor>, Error> {
         let captured_ref = self.decode_graph.borrow();
         let Some(captured) = captured_ref.as_ref() else {
             return Ok(None);

--- a/oar-ocr-vl/src/paddleocr_vl/model.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/model.rs
@@ -8,11 +8,11 @@ use super::vision::VisionModel;
 use crate::attention::{
     combine_masks, create_causal_mask, create_generation_mask, create_left_padding_mask,
 };
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{D, DType, Device, IndexOp, Tensor};
 use candle_nn::Module;
 use image::{RgbImage, imageops::FilterType};
-use oar_ocr_core::core::OCRError;
 use std::path::Path;
 use tokenizers::Tokenizer;
 
@@ -74,23 +74,20 @@ pub struct PaddleOcrVl {
 }
 
 impl PaddleOcrVl {
-    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, OCRError> {
+    pub fn from_dir(model_dir: impl AsRef<Path>, device: Device) -> Result<Self, Error> {
         let model_dir = model_dir.as_ref();
         let cfg = PaddleOcrVlConfig::from_path(model_dir.join("config.json"))?;
         let image_cfg =
             PaddleOcrVlImageProcessorConfig::from_path(model_dir.join("preprocessor_config.json"))?;
 
-        let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| {
-            OCRError::ConfigError {
+        let tokenizer =
+            Tokenizer::from_file(model_dir.join("tokenizer.json")).map_err(|e| Error::Config {
                 message: format!("failed to load PaddleOCR-VL tokenizer.json: {e}"),
-            }
-        })?;
-
-        let eos_token_id = tokenizer
-            .token_to_id("</s>")
-            .ok_or_else(|| OCRError::ConfigError {
-                message: "PaddleOCR-VL: tokenizer is missing </s> token".to_string(),
             })?;
+
+        let eos_token_id = tokenizer.token_to_id("</s>").ok_or_else(|| Error::Config {
+            message: "PaddleOCR-VL: tokenizer is missing </s> token".to_string(),
+        })?;
         let sep_token_id = tokenizer.token_to_id("<|end_of_sentence|>");
 
         let assistant_prefix = if std::fs::read_to_string(model_dir.join("chat_template.jinja"))
@@ -105,7 +102,7 @@ impl PaddleOcrVl {
         // Pre-tokenize image placeholder to avoid repeated string allocation
         let image_placeholder_token_id = tokenizer
             .token_to_id("<|IMAGE_PLACEHOLDER|>")
-            .ok_or_else(|| OCRError::ConfigError {
+            .ok_or_else(|| Error::Config {
                 message: "PaddleOCR-VL: tokenizer is missing <|IMAGE_PLACEHOLDER|> token"
                     .to_string(),
             })?;
@@ -159,7 +156,7 @@ impl PaddleOcrVl {
         images: &[RgbImage],
         tasks: &[PaddleOcrVlTask],
         max_new_tokens: usize,
-    ) -> Vec<Result<String, OCRError>> {
+    ) -> Vec<Result<String, Error>> {
         self.generate_with_raw(images, tasks, max_new_tokens)
             .into_iter()
             .map(|r| r.map(|(_, processed)| processed))
@@ -172,12 +169,12 @@ impl PaddleOcrVl {
         images: &[RgbImage],
         tasks: &[PaddleOcrVlTask],
         max_new_tokens: usize,
-    ) -> Vec<Result<(String, String), OCRError>> {
+    ) -> Vec<Result<(String, String), Error>> {
         if images.is_empty() {
             return Vec::new();
         }
         if images.len() != tasks.len() {
-            return vec![Err(OCRError::InvalidInput {
+            return vec![Err(Error::InvalidInput {
                 message: format!(
                     "PaddleOCR-VL: images count ({}) != tasks count ({})",
                     images.len(),
@@ -196,7 +193,7 @@ impl PaddleOcrVl {
                 let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
-                        Err(OCRError::InvalidInput {
+                        Err(Error::InvalidInput {
                             message: msg.clone(),
                         })
                     })
@@ -214,12 +211,12 @@ impl PaddleOcrVl {
         images: &[RgbImage],
         tasks: &[PaddleOcrVlTask],
         max_new_tokens: usize,
-    ) -> Vec<Result<Vec<u32>, OCRError>> {
+    ) -> Vec<Result<Vec<u32>, Error>> {
         if images.is_empty() {
             return Vec::new();
         }
         if images.len() != tasks.len() {
-            return vec![Err(OCRError::InvalidInput {
+            return vec![Err(Error::InvalidInput {
                 message: format!(
                     "PaddleOCR-VL: images count ({}) != tasks count ({})",
                     images.len(),
@@ -234,7 +231,7 @@ impl PaddleOcrVl {
                 let msg = crate::utils::error_chain_message("generation failed", &e);
                 (0..images.len())
                     .map(|_| {
-                        Err(OCRError::InvalidInput {
+                        Err(Error::InvalidInput {
                             message: msg.clone(),
                         })
                     })
@@ -249,7 +246,7 @@ impl PaddleOcrVl {
         images: &[RgbImage],
         tasks: &[PaddleOcrVlTask],
         max_new_tokens: usize,
-    ) -> Result<Vec<Vec<u32>>, OCRError> {
+    ) -> Result<Vec<Vec<u32>>, Error> {
         let batch_size = images.len();
 
         // 1. Preprocess all images
@@ -315,14 +312,15 @@ impl PaddleOcrVl {
             let prefix_enc =
                 self.tokenizer
                     .encode(prefix, false)
-                    .map_err(|e| OCRError::InvalidInput {
+                    .map_err(|e| Error::InvalidInput {
                         message: format!("tokenizer encode failed: {e}"),
                     })?;
-            let suffix_enc = self.tokenizer.encode(suffix.as_str(), false).map_err(|e| {
-                OCRError::InvalidInput {
-                    message: format!("tokenizer encode failed: {e}"),
-                }
-            })?;
+            let suffix_enc =
+                self.tokenizer
+                    .encode(suffix.as_str(), false)
+                    .map_err(|e| Error::InvalidInput {
+                        message: format!("tokenizer encode failed: {e}"),
+                    })?;
 
             let mut input_ids =
                 Vec::with_capacity(prefix_enc.len() + image_token_count + suffix_enc.len());
@@ -346,7 +344,7 @@ impl PaddleOcrVl {
         // 4. Build embeddings per sample
         let seq_lens: Vec<usize> = all_input_ids.iter().map(|ids| ids.len()).collect();
         let Some(&max_seq_len) = seq_lens.iter().max() else {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "PaddleOCR-VL: empty batch is not supported".to_string(),
             });
         };
@@ -600,7 +598,7 @@ impl PaddleOcrVl {
         &self,
         tokens: &[u32],
         task: PaddleOcrVlTask,
-    ) -> Result<(String, String), OCRError> {
+    ) -> Result<(String, String), Error> {
         self.decode_generated_tokens(tokens, task)
     }
 
@@ -610,10 +608,10 @@ impl PaddleOcrVl {
     /// use this when feeding PaddleOCR-VL output as a draft for another
     /// target VLM. DSV matches at token granularity, so any post-process on
     /// the source side will byte-mismatch the target's natural output.
-    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, OCRError> {
+    pub fn decode_tokens_raw(&self, tokens: &[u32]) -> Result<String, Error> {
         self.tokenizer
             .decode(tokens, true)
-            .map_err(|e| OCRError::InvalidInput {
+            .map_err(|e| Error::InvalidInput {
                 message: format!("decode failed: {e}"),
             })
     }
@@ -626,7 +624,7 @@ impl PaddleOcrVl {
         &self,
         tokens: &[u32],
         task: PaddleOcrVlTask,
-    ) -> Result<(String, String), OCRError> {
+    ) -> Result<(String, String), Error> {
         let decoded = self.decode_tokens_raw(tokens)?;
         let processed = task.postprocess(decoded.clone());
         Ok((decoded, processed))
@@ -638,10 +636,10 @@ fn get_rope_index(
     input_ids: &[u32],
     image_grid_thw: &[(usize, usize, usize)],
     device: &Device,
-) -> Result<(Tensor, i64), OCRError> {
+) -> Result<(Tensor, i64), Error> {
     let spatial_merge_size = cfg.vision_config.spatial_merge_size;
     if spatial_merge_size == 0 {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: "PaddleOCR-VL: vision_config.spatial_merge_size must be > 0".to_string(),
         });
     }
@@ -652,13 +650,13 @@ fn get_rope_index(
             image_count += 1;
         }
         if input_ids[i] == cfg.vision_start_token_id && input_ids[i + 1] == cfg.video_token_id {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: "PaddleOCR-VL: video inputs are not supported".to_string(),
             });
         }
     }
     if image_count != image_grid_thw.len() {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "PaddleOCR-VL: image count mismatch between prompt ({image_count}) and image_grid_thw ({})",
                 image_grid_thw.len()
@@ -675,7 +673,7 @@ fn get_rope_index(
             .iter()
             .position(|&id| id == cfg.image_token_id)
             .map(|p| st + p)
-            .ok_or_else(|| OCRError::InvalidInput {
+            .ok_or_else(|| Error::InvalidInput {
                 message: format!(
                     "PaddleOCR-VL: expected image token for image[{image_idx}] but none found"
                 ),
@@ -717,7 +715,7 @@ fn get_rope_index(
     }
 
     if positions.len() != input_ids.len() {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "PaddleOCR-VL: rope position ids length mismatch: got {}, expected {}",
                 positions.len(),
@@ -739,7 +737,7 @@ fn get_rope_index(
     let position_ids = Tensor::from_vec(pos_ids, (3usize, 1usize, input_ids.len()), device)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: build position_ids tensor failed",
                 e,
             )

--- a/oar-ocr-vl/src/paddleocr_vl/processing.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/processing.rs
@@ -1,11 +1,11 @@
 use super::config::PaddleOcrVlImageProcessorConfig;
+use crate::error::Error;
 use crate::utils::image::pil_resample_to_filter_type;
 pub use crate::utils::image::smart_resize;
 use crate::utils::table::{convert_otsl_to_html, looks_like_table_tokens};
 pub use crate::utils::text::strip_math_wrappers;
 use candle_core::{DType, Device, Tensor};
 use image::{RgbImage, imageops::FilterType};
-use oar_ocr_core::core::OCRError;
 use rayon::prelude::*;
 
 #[derive(Debug, Clone)]
@@ -27,7 +27,7 @@ pub fn preprocess_images(
     cfg: &PaddleOcrVlImageProcessorConfig,
     device: &Device,
     dtype: DType,
-) -> Result<PaddleOcrVlImageInputs, OCRError> {
+) -> Result<PaddleOcrVlImageInputs, Error> {
     preprocess_images_with_max_pixels(images, cfg, device, dtype, cfg.max_pixels)
 }
 
@@ -37,10 +37,10 @@ pub(crate) fn preprocess_images_with_max_pixels(
     device: &Device,
     dtype: DType,
     max_pixels: u32,
-) -> Result<PaddleOcrVlImageInputs, OCRError> {
+) -> Result<PaddleOcrVlImageInputs, Error> {
     cfg.validate()?;
     if images.is_empty() {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "PaddleOCR-VL: no images provided".to_string(),
         });
     }
@@ -70,7 +70,7 @@ pub(crate) fn preprocess_images_with_max_pixels(
         };
 
         if rh % patch != 0 || rw % patch != 0 {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "PaddleOCR-VL preprocess produced non-divisible dims: {rh}x{rw} not divisible by patch_size={patch}"
                 ),
@@ -127,8 +127,8 @@ pub(crate) fn preprocess_images_with_max_pixels(
             (num_patches, 3usize, cfg.patch_size, cfg.patch_size),
             device,
         )
-        .map_err(|e| OCRError::Processing {
-            kind: oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+        .map_err(|e| Error::Processing {
+            kind: crate::error::ProcessingStage::TensorOperation,
             context: "PaddleOCR-VL: failed to create pixel_values tensor".to_string(),
             source: Box::new(e),
         })?;
@@ -137,8 +137,8 @@ pub(crate) fn preprocess_images_with_max_pixels(
         grids.push((grid_t, grid_h, grid_w));
     }
 
-    let pixel_values = Tensor::cat(&all_patches, 0).map_err(|e| OCRError::Processing {
-        kind: oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+    let pixel_values = Tensor::cat(&all_patches, 0).map_err(|e| Error::Processing {
+        kind: crate::error::ProcessingStage::TensorOperation,
         context: "PaddleOCR-VL: failed to concatenate pixel_values tensors".to_string(),
         source: Box::new(e),
     })?;
@@ -146,8 +146,8 @@ pub(crate) fn preprocess_images_with_max_pixels(
     // Convert to the target dtype (e.g., BF16 for model inference)
     let pixel_values = pixel_values
         .to_dtype(dtype)
-        .map_err(|e| OCRError::Processing {
-            kind: oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+        .map_err(|e| Error::Processing {
+            kind: crate::error::ProcessingStage::TensorOperation,
             context: "PaddleOCR-VL: failed to convert pixel_values to target dtype".to_string(),
             source: Box::new(e),
         })?;
@@ -165,7 +165,7 @@ mod tests {
     use image::{Rgb, RgbImage};
 
     #[test]
-    fn test_preprocess_outputs_expected_shapes() -> Result<(), OCRError> {
+    fn test_preprocess_outputs_expected_shapes() -> Result<(), Error> {
         let cfg = PaddleOcrVlImageProcessorConfig {
             do_resize: true,
             do_rescale: true,

--- a/oar-ocr-vl/src/paddleocr_vl/projector.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/projector.rs
@@ -1,8 +1,8 @@
 use super::config::{PaddleOcrVlConfig, PaddleOcrVlVisionConfig};
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{D, Tensor};
 use candle_nn::Module;
-use oar_ocr_core::core::OCRError;
 
 #[derive(Debug, Clone)]
 pub struct Projector {
@@ -17,7 +17,7 @@ impl Projector {
         text_cfg: &PaddleOcrVlConfig,
         vision_cfg: &PaddleOcrVlVisionConfig,
         vb: candle_nn::VarBuilder,
-    ) -> Result<Self, OCRError> {
+    ) -> Result<Self, Error> {
         let ln_cfg = candle_nn::LayerNormConfig {
             eps: 1e-5,
             remove_mean: true,
@@ -43,9 +43,9 @@ impl Projector {
         &self,
         image_features: &[Tensor],
         image_grid_thw: &[(usize, usize, usize)],
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         if image_features.len() != image_grid_thw.len() {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "PaddleOCR-VL: image_features len {} does not match image_grid_thw len {}",
                     image_features.len(),
@@ -62,7 +62,7 @@ impl Projector {
             })?;
 
             if h % m != 0 || w % m != 0 {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: format!(
                         "PaddleOCR-VL: image grid {t}x{h}x{w} not divisible by merge_size={m}"
                     ),
@@ -71,7 +71,7 @@ impl Projector {
 
             let d = feat.dim(D::Minus1).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: projector dim failed",
                     e,
                 )
@@ -83,7 +83,7 @@ impl Projector {
                 .reshape((t, h, w, d))
                 .map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "PaddleOCR-VL: projector reshape thwd failed",
                         e,
                     )
@@ -91,7 +91,7 @@ impl Projector {
                 .reshape((t, hb, m, wb, m, d))
                 .map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "PaddleOCR-VL: projector reshape blocks failed",
                         e,
                     )
@@ -99,7 +99,7 @@ impl Projector {
                 .permute((0, 1, 3, 2, 4, 5))
                 .map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "PaddleOCR-VL: projector permute failed",
                         e,
                     )
@@ -107,7 +107,7 @@ impl Projector {
                 .reshape((t * hb * wb, m * m * d))
                 .map_err(|e| {
                     candle_to_ocr_processing(
-                        oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                        crate::error::ProcessingStage::TensorOperation,
                         "PaddleOCR-VL: projector merge reshape failed",
                         e,
                     )
@@ -129,7 +129,7 @@ impl Projector {
         let refs: Vec<&Tensor> = projected.iter().collect();
         Tensor::cat(&refs, 0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: projector concat failed",
                 e,
             )

--- a/oar-ocr-vl/src/paddleocr_vl/vision.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/vision.rs
@@ -1,8 +1,8 @@
 use super::config::PaddleOcrVlVisionConfig;
+use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing, rotate_half};
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_nn::Module;
-use oar_ocr_core::core::OCRError;
 use rayon::prelude::*;
 
 /// Above this seq length vision attention runs chunked along the query dim
@@ -83,17 +83,17 @@ struct SigLIPRotaryEmbedding {
 }
 
 impl SigLIPRotaryEmbedding {
-    fn new(dim: usize, theta: f64, device: &Device) -> Result<Self, OCRError> {
+    fn new(dim: usize, theta: f64, device: &Device) -> Result<Self, Error> {
         let inv_freq = crate::utils::vision_inv_freq(dim, theta, "PaddleOCR-VL", device)?;
         Ok(Self { inv_freq })
     }
 
     /// Compute freqs for positions 0..seqlen
-    fn forward(&self, seqlen: usize, device: &Device) -> Result<Tensor, OCRError> {
+    fn forward(&self, seqlen: usize, device: &Device) -> Result<Tensor, Error> {
         let seq: Vec<f32> = (0..seqlen).map(|i| i as f32).collect();
         let seq = Tensor::from_vec(seq, (seqlen,), device).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision rope seq tensor failed",
                 e,
             )
@@ -101,7 +101,7 @@ impl SigLIPRotaryEmbedding {
         // outer product: (seqlen, dim/2)
         let inv_freq = self.inv_freq.to_dtype(DType::F32).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision inv_freq cast failed",
                 e,
             )
@@ -111,21 +111,21 @@ impl SigLIPRotaryEmbedding {
             .unsqueeze(1)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision seq unsqueeze failed",
                     e,
                 )
             })?
             .broadcast_mul(&inv_freq.unsqueeze(0).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision inv_freq unsqueeze failed",
                     e,
                 )
             })?)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision rope outer product failed",
                     e,
                 )
@@ -134,7 +134,7 @@ impl SigLIPRotaryEmbedding {
     }
 }
 
-fn rotate_half_vision(x: &Tensor) -> Result<Tensor, OCRError> {
+fn rotate_half_vision(x: &Tensor) -> Result<Tensor, Error> {
     rotate_half(x)
 }
 
@@ -144,21 +144,21 @@ fn apply_rotary_pos_emb_vision(
     k: &Tensor,
     cos: &Tensor,
     sin: &Tensor,
-) -> Result<(Tensor, Tensor), OCRError> {
+) -> Result<(Tensor, Tensor), Error> {
     // q, k: (batch, seq, num_heads, head_dim)
     // cos, sin: (seq, head_dim) -> need to unsqueeze for broadcasting
     let orig_dtype = q.dtype();
 
     let q = q.to_dtype(DType::F32).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "PaddleOCR-VL: vision rope q cast failed",
             e,
         )
     })?;
     let k = k.to_dtype(DType::F32).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "PaddleOCR-VL: vision rope k cast failed",
             e,
         )
@@ -169,7 +169,7 @@ fn apply_rotary_pos_emb_vision(
         .unsqueeze(0)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision cos unsqueeze0 failed",
                 e,
             )
@@ -177,7 +177,7 @@ fn apply_rotary_pos_emb_vision(
         .unsqueeze(2)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision cos unsqueeze2 failed",
                 e,
             )
@@ -185,7 +185,7 @@ fn apply_rotary_pos_emb_vision(
         .to_dtype(DType::F32)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision cos cast failed",
                 e,
             )
@@ -195,7 +195,7 @@ fn apply_rotary_pos_emb_vision(
         .unsqueeze(0)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision sin unsqueeze0 failed",
                 e,
             )
@@ -203,7 +203,7 @@ fn apply_rotary_pos_emb_vision(
         .unsqueeze(2)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision sin unsqueeze2 failed",
                 e,
             )
@@ -211,7 +211,7 @@ fn apply_rotary_pos_emb_vision(
         .to_dtype(DType::F32)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision sin cast failed",
                 e,
             )
@@ -223,21 +223,21 @@ fn apply_rotary_pos_emb_vision(
         .broadcast_mul(&cos)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision q*cos failed",
                 e,
             )
         })?
         .broadcast_add(&q_rot.broadcast_mul(&sin).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision rotate_half(q)*sin failed",
                 e,
             )
         })?)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision q rope add failed",
                 e,
             )
@@ -248,21 +248,21 @@ fn apply_rotary_pos_emb_vision(
         .broadcast_mul(&cos)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision k*cos failed",
                 e,
             )
         })?
         .broadcast_add(&k_rot.broadcast_mul(&sin).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision rotate_half(k)*sin failed",
                 e,
             )
         })?)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision k rope add failed",
                 e,
             )
@@ -270,14 +270,14 @@ fn apply_rotary_pos_emb_vision(
 
     let q_embed = q_embed.to_dtype(orig_dtype).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "PaddleOCR-VL: vision q_embed cast back failed",
             e,
         )
     })?;
     let k_embed = k_embed.to_dtype(orig_dtype).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "PaddleOCR-VL: vision k_embed cast back failed",
             e,
         )
@@ -298,7 +298,7 @@ struct VisionAttention {
 }
 
 impl VisionAttention {
-    fn load(cfg: &PaddleOcrVlVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &PaddleOcrVlVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let q_proj = candle_nn::linear(cfg.hidden_size, cfg.hidden_size, vb.pp("q_proj"))
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "load vision q_proj", e))?;
         let k_proj = candle_nn::linear(cfg.hidden_size, cfg.hidden_size, vb.pp("k_proj"))
@@ -308,7 +308,7 @@ impl VisionAttention {
         let out_proj = candle_nn::linear(cfg.hidden_size, cfg.hidden_size, vb.pp("out_proj"))
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "load vision out_proj", e))?;
         if !cfg.hidden_size.is_multiple_of(cfg.num_attention_heads) {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "PaddleOCR-VL vision: hidden_size ({}) must be divisible by num_attention_heads ({})",
                     cfg.hidden_size, cfg.num_attention_heads
@@ -331,7 +331,7 @@ impl VisionAttention {
         &self,
         hidden_states: &Tensor,
         rope_emb: Option<(&Tensor, &Tensor)>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let (b, seq, embed_dim) = hidden_states
             .dims3()
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "vision attn dims3", e))?;
@@ -497,7 +497,7 @@ struct VisionMlp {
 }
 
 impl VisionMlp {
-    fn load(cfg: &PaddleOcrVlVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &PaddleOcrVlVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let fc1 = candle_nn::linear(cfg.hidden_size, cfg.intermediate_size, vb.pp("fc1"))
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "load vision fc1", e))?;
         let fc2 = candle_nn::linear(cfg.intermediate_size, cfg.hidden_size, vb.pp("fc2"))
@@ -507,7 +507,7 @@ impl VisionMlp {
         Ok(Self { fc1, fc2, act })
     }
 
-    fn forward(&self, xs: &Tensor) -> Result<Tensor, OCRError> {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, Error> {
         let xs = self
             .fc1
             .forward(xs)
@@ -531,7 +531,7 @@ struct VisionEncoderLayer {
 }
 
 impl VisionEncoderLayer {
-    fn load(cfg: &PaddleOcrVlVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &PaddleOcrVlVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let ln_cfg = candle_nn::LayerNormConfig {
             eps: cfg.layer_norm_eps,
             remove_mean: true,
@@ -555,7 +555,7 @@ impl VisionEncoderLayer {
         &self,
         hidden_states: &Tensor,
         rope_emb: Option<(&Tensor, &Tensor)>,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         let residual = hidden_states.clone();
         let hidden_states = self
             .layer_norm1
@@ -583,7 +583,7 @@ struct VisionEmbeddings {
 }
 
 impl VisionEmbeddings {
-    fn load(cfg: &PaddleOcrVlVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, OCRError> {
+    fn load(cfg: &PaddleOcrVlVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let conv_cfg = candle_nn::Conv2dConfig {
             padding: 0,
             stride: cfg.patch_size,
@@ -618,9 +618,9 @@ impl VisionEmbeddings {
         width: usize,
         device: &Device,
         dtype: DType,
-    ) -> Result<Tensor, OCRError> {
+    ) -> Result<Tensor, Error> {
         if height == 0 || width == 0 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "PaddleOCR-VL: vision interpolate_pos_encoding requires height/width > 0, got {height}x{width}"
                 ),
@@ -630,7 +630,7 @@ impl VisionEmbeddings {
         let pos_w = self.position_embedding.embeddings();
         let (num_positions, dim) = pos_w.dims2().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision position_embedding dims2 failed",
                 e,
             )
@@ -638,7 +638,7 @@ impl VisionEmbeddings {
 
         let grid = (num_positions as f64).sqrt() as usize;
         if grid * grid != num_positions {
-            return Err(OCRError::ConfigError {
+            return Err(Error::Config {
                 message: format!(
                     "PaddleOCR-VL: vision position_embedding weight is not a square grid, \
                      got num_positions={num_positions} (nearest square is {grid}×{grid}={})",
@@ -657,7 +657,7 @@ impl VisionEmbeddings {
             .to_dtype(DType::F32)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision position_embedding cast to f32 failed",
                     e,
                 )
@@ -665,7 +665,7 @@ impl VisionEmbeddings {
             .flatten_all()
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision position_embedding flatten failed",
                     e,
                 )
@@ -673,7 +673,7 @@ impl VisionEmbeddings {
             .to_vec1::<f32>()
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision position_embedding to_vec failed",
                     e,
                 )
@@ -683,7 +683,7 @@ impl VisionEmbeddings {
         Tensor::from_vec(out, (height * width, dim), device)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision interpolated pos embedding tensor failed",
                     e,
                 )
@@ -691,7 +691,7 @@ impl VisionEmbeddings {
             .to_dtype(dtype)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision interpolated pos embedding cast failed",
                     e,
                 )
@@ -708,10 +708,7 @@ pub struct VisionModel {
 }
 
 impl VisionModel {
-    pub fn load(
-        cfg: &PaddleOcrVlVisionConfig,
-        vb: candle_nn::VarBuilder,
-    ) -> Result<Self, OCRError> {
+    pub fn load(cfg: &PaddleOcrVlVisionConfig, vb: candle_nn::VarBuilder) -> Result<Self, Error> {
         let embeddings = VisionEmbeddings::load(cfg, vb.pp("embeddings"))?;
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         for i in 0..cfg.num_hidden_layers {
@@ -747,7 +744,7 @@ impl VisionModel {
         &self,
         pixel_values: &Tensor,
         image_grid_thw: &[(usize, usize, usize)],
-    ) -> Result<Vec<Tensor>, OCRError> {
+    ) -> Result<Vec<Tensor>, Error> {
         let device = pixel_values.device();
 
         // Compute height/width position IDs for 2D rope
@@ -780,7 +777,7 @@ impl VisionModel {
         let h_ids = Tensor::new(height_position_ids.clone(), device)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision height_ids tensor failed",
                     e,
                 )
@@ -788,7 +785,7 @@ impl VisionModel {
             .to_dtype(DType::U32)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision height_ids cast failed",
                     e,
                 )
@@ -797,7 +794,7 @@ impl VisionModel {
         let w_ids = Tensor::new(width_position_ids, device)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision width_ids tensor failed",
                     e,
                 )
@@ -805,7 +802,7 @@ impl VisionModel {
             .to_dtype(DType::U32)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision width_ids cast failed",
                     e,
                 )
@@ -814,14 +811,14 @@ impl VisionModel {
         // freqs_h = freqs[height_ids], freqs_w = freqs[width_ids]
         let freqs_h = freqs.index_select(&h_ids, 0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision freqs_h gather failed",
                 e,
             )
         })?;
         let freqs_w = freqs.index_select(&w_ids, 0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision freqs_w gather failed",
                 e,
             )
@@ -830,7 +827,7 @@ impl VisionModel {
         // Concatenate to get (num_patches, head_dim/2) then repeat to get (num_patches, head_dim)
         let rope_emb = Tensor::cat(&[&freqs_h, &freqs_w], 1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision rope_emb cat failed",
                 e,
             )
@@ -838,7 +835,7 @@ impl VisionModel {
         // Repeat to double the dimension for full head_dim
         let rope_emb = Tensor::cat(&[&rope_emb, &rope_emb], 1).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision rope_emb repeat failed",
                 e,
             )
@@ -846,14 +843,14 @@ impl VisionModel {
 
         let cos = rope_emb.cos().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision rope cos failed",
                 e,
             )
         })?;
         let sin = rope_emb.sin().map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision rope sin failed",
                 e,
             )
@@ -871,7 +868,7 @@ impl VisionModel {
             .flatten_from(2)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision patch flatten failed",
                     e,
                 )
@@ -879,7 +876,7 @@ impl VisionModel {
             .squeeze(2)
             .map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision patch squeeze failed",
                     e,
                 )
@@ -891,7 +888,7 @@ impl VisionModel {
         let mut start = 0usize;
         for &(t, h, w) in image_grid_thw {
             if t != 1 {
-                return Err(OCRError::InvalidInput {
+                return Err(Error::InvalidInput {
                     message: "PaddleOCR-VL: vision temporal inputs are not supported (t != 1)"
                         .to_string(),
                 });
@@ -900,7 +897,7 @@ impl VisionModel {
             let end = start + len;
             let seg = patch.i((start..end, ..)).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision slice patch embeddings failed",
                     e,
                 )
@@ -918,7 +915,7 @@ impl VisionModel {
         let refs: Vec<&Tensor> = segments.iter().collect();
         let patch = Tensor::cat(&refs, 0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision concat pos-added patches failed",
                 e,
             )
@@ -926,7 +923,7 @@ impl VisionModel {
 
         let mut hidden = patch.unsqueeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision add batch dim failed",
                 e,
             )
@@ -944,7 +941,7 @@ impl VisionModel {
 
         let hidden = hidden.squeeze(0).map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "PaddleOCR-VL: vision squeeze batch failed",
                 e,
             )
@@ -957,7 +954,7 @@ impl VisionModel {
             let end = start + len;
             let slice = hidden.i((start..end, ..)).map_err(|e| {
                 candle_to_ocr_processing(
-                    oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                    crate::error::ProcessingStage::TensorOperation,
                     "PaddleOCR-VL: vision slice failed",
                     e,
                 )

--- a/oar-ocr-vl/src/pp_doclayout/config.rs
+++ b/oar-ocr-vl/src/pp_doclayout/config.rs
@@ -1,0 +1,565 @@
+//! Configuration for PP-DocLayoutV2 and PP-DocLayoutV3.
+//!
+//! Mirrors `config.json` of the `PaddlePaddle/PP-DocLayoutV{2,3}_safetensors`
+//! checkpoints. Defaults follow
+//! `transformers/models/pp_doclayout_v{2,3}/configuration_pp_doclayout_v{2,3}.py`,
+//! so fields the checkpoints omit still resolve to the upstream values.
+
+use crate::error::Error;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Which PP-DocLayout generation a checkpoint belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PpDocLayoutVersion {
+    /// PP-DocLayoutV2: RT-DETR detector plus a LayoutLM-style pointer network.
+    V2,
+    /// PP-DocLayoutV3: RT-DETR detector with an in-decoder order head.
+    V3,
+}
+
+impl PpDocLayoutVersion {
+    /// Resolves the version from the `model_type` field of `config.json`.
+    pub fn from_model_type(model_type: &str) -> Result<Self, Error> {
+        match model_type {
+            "pp_doclayout_v2" => Ok(Self::V2),
+            "pp_doclayout_v3" => Ok(Self::V3),
+            other => Err(Error::Config {
+                message: format!(
+                    "PP-DocLayout: unsupported model_type '{other}', expected \
+                     'pp_doclayout_v2' or 'pp_doclayout_v3'"
+                ),
+            }),
+        }
+    }
+}
+
+/// Backbone selection. Only the fields that vary between the two checkpoints
+/// are read; the `L` stage geometry is baked into the backbone module.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BackboneConfig {
+    /// HGNetV2 architecture preset. Both checkpoints use `L`.
+    #[serde(default = "default_arch")]
+    pub arch: String,
+    /// Stage indices to return, e.g. `[1, 2, 3]` for stage2/3/4.
+    #[serde(default = "default_return_idx")]
+    pub return_idx: Vec<usize>,
+}
+
+fn default_arch() -> String {
+    "L".to_string()
+}
+
+fn default_return_idx() -> Vec<usize> {
+    vec![1, 2, 3]
+}
+
+/// Reading-order pointer network configuration (PP-DocLayoutV2 only).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReadingOrderConfig {
+    #[serde(default = "default_ro_hidden_size")]
+    pub hidden_size: usize,
+    #[serde(default = "default_ro_heads")]
+    pub num_attention_heads: usize,
+    #[serde(default = "default_ro_layers")]
+    pub num_hidden_layers: usize,
+    #[serde(default = "default_ro_intermediate")]
+    pub intermediate_size: usize,
+    #[serde(default = "default_layer_norm_eps")]
+    pub layer_norm_eps: f64,
+    #[serde(default = "default_ro_max_positions")]
+    pub max_position_embeddings: usize,
+    #[serde(default = "default_ro_max_2d_positions")]
+    pub max_2d_position_embeddings: usize,
+    #[serde(default = "default_ro_type_vocab")]
+    pub type_vocab_size: usize,
+    #[serde(default = "default_ro_vocab")]
+    pub vocab_size: usize,
+    #[serde(default)]
+    pub start_token_id: u32,
+    #[serde(default = "default_ro_pad_token")]
+    pub pad_token_id: u32,
+    #[serde(default = "default_ro_end_token")]
+    pub end_token_id: u32,
+    #[serde(default = "default_ro_pred_token")]
+    pub pred_token_id: u32,
+    #[serde(default = "default_ro_coordinate_size")]
+    pub coordinate_size: usize,
+    #[serde(default = "default_ro_shape_size")]
+    pub shape_size: usize,
+    #[serde(default = "default_ro_num_classes")]
+    pub num_classes: usize,
+    #[serde(default = "default_ro_bias_embed_dim")]
+    pub relation_bias_embed_dim: usize,
+    #[serde(default = "default_ro_bias_theta")]
+    pub relation_bias_theta: f64,
+    #[serde(default = "default_ro_bias_scale")]
+    pub relation_bias_scale: f64,
+    #[serde(default = "default_global_pointer_head_size")]
+    pub global_pointer_head_size: usize,
+    #[serde(default = "crate::utils::default_true")]
+    pub tril_mask: bool,
+}
+
+impl Default for ReadingOrderConfig {
+    fn default() -> Self {
+        Self {
+            hidden_size: default_ro_hidden_size(),
+            num_attention_heads: default_ro_heads(),
+            num_hidden_layers: default_ro_layers(),
+            intermediate_size: default_ro_intermediate(),
+            layer_norm_eps: default_layer_norm_eps(),
+            max_position_embeddings: default_ro_max_positions(),
+            max_2d_position_embeddings: default_ro_max_2d_positions(),
+            type_vocab_size: default_ro_type_vocab(),
+            vocab_size: default_ro_vocab(),
+            start_token_id: 0,
+            pad_token_id: default_ro_pad_token(),
+            end_token_id: default_ro_end_token(),
+            pred_token_id: default_ro_pred_token(),
+            coordinate_size: default_ro_coordinate_size(),
+            shape_size: default_ro_shape_size(),
+            num_classes: default_ro_num_classes(),
+            relation_bias_embed_dim: default_ro_bias_embed_dim(),
+            relation_bias_theta: default_ro_bias_theta(),
+            relation_bias_scale: default_ro_bias_scale(),
+            global_pointer_head_size: default_global_pointer_head_size(),
+            tril_mask: true,
+        }
+    }
+}
+
+fn default_ro_hidden_size() -> usize {
+    512
+}
+fn default_ro_heads() -> usize {
+    8
+}
+fn default_ro_layers() -> usize {
+    6
+}
+fn default_ro_intermediate() -> usize {
+    2048
+}
+fn default_ro_max_positions() -> usize {
+    514
+}
+fn default_ro_max_2d_positions() -> usize {
+    1024
+}
+fn default_ro_type_vocab() -> usize {
+    1
+}
+fn default_ro_vocab() -> usize {
+    4
+}
+fn default_ro_pad_token() -> u32 {
+    1
+}
+fn default_ro_end_token() -> u32 {
+    2
+}
+fn default_ro_pred_token() -> u32 {
+    3
+}
+fn default_ro_coordinate_size() -> usize {
+    171
+}
+fn default_ro_shape_size() -> usize {
+    170
+}
+fn default_ro_num_classes() -> usize {
+    20
+}
+fn default_ro_bias_embed_dim() -> usize {
+    16
+}
+fn default_ro_bias_theta() -> f64 {
+    10000.0
+}
+fn default_ro_bias_scale() -> f64 {
+    100.0
+}
+fn default_global_pointer_head_size() -> usize {
+    64
+}
+
+/// Top-level PP-DocLayout configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PpDocLayoutConfig {
+    pub model_type: String,
+    #[serde(default)]
+    pub backbone_config: Option<BackboneConfig>,
+
+    #[serde(default = "default_d_model")]
+    pub d_model: usize,
+    #[serde(default = "default_encoder_hidden_dim")]
+    pub encoder_hidden_dim: usize,
+    #[serde(default = "default_encoder_in_channels")]
+    pub encoder_in_channels: Vec<usize>,
+    /// V2 spells this `feat_strides`, V3 `feature_strides`.
+    #[serde(default, alias = "feature_strides")]
+    pub feat_strides: Option<Vec<usize>>,
+    #[serde(default = "default_encoder_layers")]
+    pub encoder_layers: usize,
+    #[serde(default = "default_ffn_dim")]
+    pub encoder_ffn_dim: usize,
+    #[serde(default = "default_attention_heads")]
+    pub encoder_attention_heads: usize,
+    #[serde(default = "default_encode_proj_layers")]
+    pub encode_proj_layers: Vec<usize>,
+    #[serde(default = "default_positional_encoding_temperature")]
+    pub positional_encoding_temperature: f64,
+    #[serde(default = "default_encoder_activation")]
+    pub encoder_activation_function: String,
+    #[serde(default = "default_activation")]
+    pub activation_function: String,
+    /// Pre-LN encoder layers. Only `false` (post-LN) is implemented, which is
+    /// what both checkpoints ship; loading rejects `true` rather than quietly
+    /// running the wrong layer order.
+    #[serde(default)]
+    pub normalize_before: bool,
+    #[serde(default = "default_hidden_expansion")]
+    pub hidden_expansion: f64,
+
+    #[serde(default = "default_num_queries")]
+    pub num_queries: usize,
+    #[serde(default = "default_decoder_in_channels")]
+    pub decoder_in_channels: Vec<usize>,
+    #[serde(default = "default_ffn_dim")]
+    pub decoder_ffn_dim: usize,
+    #[serde(default = "default_num_feature_levels")]
+    pub num_feature_levels: usize,
+    #[serde(default = "default_decoder_n_points")]
+    pub decoder_n_points: usize,
+    #[serde(default = "default_decoder_layers")]
+    pub decoder_layers: usize,
+    #[serde(default = "default_attention_heads")]
+    pub decoder_attention_heads: usize,
+    #[serde(default = "default_decoder_activation")]
+    pub decoder_activation_function: String,
+
+    #[serde(default = "default_layer_norm_eps")]
+    pub layer_norm_eps: f64,
+    #[serde(default = "default_batch_norm_eps")]
+    pub batch_norm_eps: f64,
+
+    /// Class id to label name. The checkpoints map several ids to the same
+    /// name (for example both `footer` entries), which is intentional.
+    pub id2label: HashMap<String, String>,
+    /// Per-class score thresholds (V2). V3 uses a single threshold.
+    #[serde(default)]
+    pub class_thresholds: Option<Vec<f32>>,
+    /// Detection class id to reading-order category (V2).
+    #[serde(default)]
+    pub class_order: Option<Vec<usize>>,
+    /// Reading-order pointer network (V2).
+    #[serde(default)]
+    pub reading_order_config: Option<ReadingOrderConfig>,
+
+    /// Global pointer head size for the V3 order head.
+    #[serde(default = "default_global_pointer_head_size")]
+    pub global_pointer_head_size: usize,
+    /// Channel widths of the V3 mask feature head.
+    #[serde(default = "default_mask_feature_channels")]
+    pub mask_feature_channels: Vec<usize>,
+    /// Channel width of the V3 stage1 (stride 4) feature map.
+    #[serde(default = "default_x4_feat_dim")]
+    pub x4_feat_dim: usize,
+    /// Number of V3 mask prototypes.
+    #[serde(default = "default_num_prototypes")]
+    pub num_prototypes: usize,
+    /// Whether V3 derives the decoder's initial boxes from the predicted
+    /// masks. Upstream defaults to `true`.
+    #[serde(default = "crate::utils::default_true")]
+    pub mask_enhanced: bool,
+}
+
+fn default_d_model() -> usize {
+    256
+}
+fn default_encoder_hidden_dim() -> usize {
+    256
+}
+fn default_encoder_in_channels() -> Vec<usize> {
+    vec![512, 1024, 2048]
+}
+fn default_encoder_layers() -> usize {
+    1
+}
+fn default_ffn_dim() -> usize {
+    1024
+}
+fn default_attention_heads() -> usize {
+    8
+}
+fn default_encode_proj_layers() -> Vec<usize> {
+    vec![2]
+}
+fn default_positional_encoding_temperature() -> f64 {
+    10000.0
+}
+fn default_encoder_activation() -> String {
+    "gelu".to_string()
+}
+fn default_activation() -> String {
+    "silu".to_string()
+}
+fn default_hidden_expansion() -> f64 {
+    1.0
+}
+fn default_num_queries() -> usize {
+    300
+}
+fn default_decoder_in_channels() -> Vec<usize> {
+    vec![256, 256, 256]
+}
+fn default_num_feature_levels() -> usize {
+    3
+}
+fn default_decoder_n_points() -> usize {
+    4
+}
+fn default_decoder_layers() -> usize {
+    6
+}
+fn default_decoder_activation() -> String {
+    "relu".to_string()
+}
+fn default_layer_norm_eps() -> f64 {
+    1e-5
+}
+fn default_batch_norm_eps() -> f64 {
+    1e-5
+}
+fn default_mask_feature_channels() -> Vec<usize> {
+    vec![64, 64]
+}
+fn default_x4_feat_dim() -> usize {
+    128
+}
+fn default_num_prototypes() -> usize {
+    32
+}
+
+impl PpDocLayoutConfig {
+    /// Loads `config.json` from a checkpoint directory entry.
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
+        let cfg: Self = crate::utils::load_json_config(path, "PP-DocLayout", "config.json")?;
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    /// Which generation this configuration describes.
+    pub fn version(&self) -> Result<PpDocLayoutVersion, Error> {
+        PpDocLayoutVersion::from_model_type(&self.model_type)
+    }
+
+    /// Number of detection classes.
+    pub fn num_labels(&self) -> usize {
+        self.id2label.len()
+    }
+
+    /// Feature-map strides, defaulting to the RT-DETR `[8, 16, 32]`.
+    pub fn strides(&self) -> Vec<usize> {
+        self.feat_strides.clone().unwrap_or_else(|| vec![8, 16, 32])
+    }
+
+    /// Backbone stage indices to return.
+    pub fn backbone_return_idx(&self) -> Vec<usize> {
+        self.backbone_config
+            .as_ref()
+            .map(|b| b.return_idx.clone())
+            .unwrap_or_else(default_return_idx)
+    }
+
+    /// Label for a class id, or `unknown` when the id is not in `id2label`.
+    pub fn label(&self, class_id: usize) -> &str {
+        self.id2label
+            .get(&class_id.to_string())
+            .map(String::as_str)
+            .unwrap_or("unknown")
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        let version = self.version()?;
+
+        if let Some(backbone) = &self.backbone_config
+            && backbone.arch != "L"
+        {
+            return Err(Error::Config {
+                message: format!(
+                    "PP-DocLayout: unsupported backbone arch '{}', only 'L' is implemented",
+                    backbone.arch
+                ),
+            });
+        }
+
+        if self.normalize_before {
+            return Err(Error::Config {
+                message: "PP-DocLayout: normalize_before=true (pre-LN encoder) is not implemented"
+                    .to_string(),
+            });
+        }
+
+        if self.id2label.is_empty() {
+            return Err(Error::Config {
+                message: "PP-DocLayout: config.json has an empty id2label map".to_string(),
+            });
+        }
+
+        if let Some(thresholds) = &self.class_thresholds
+            && thresholds.len() != self.num_labels()
+        {
+            return Err(Error::Config {
+                message: format!(
+                    "PP-DocLayout: class_thresholds has {} entries but there are {} labels",
+                    thresholds.len(),
+                    self.num_labels()
+                ),
+            });
+        }
+
+        if version == PpDocLayoutVersion::V2 {
+            let Some(class_order) = &self.class_order else {
+                return Err(Error::Config {
+                    message: "PP-DocLayoutV2: config.json is missing class_order".to_string(),
+                });
+            };
+            if class_order.len() != self.num_labels() {
+                return Err(Error::Config {
+                    message: format!(
+                        "PP-DocLayoutV2: class_order has {} entries but there are {} labels",
+                        class_order.len(),
+                        self.num_labels()
+                    ),
+                });
+            }
+        }
+
+        if self.encoder_in_channels.len() != self.num_feature_levels {
+            return Err(Error::Config {
+                message: format!(
+                    "PP-DocLayout: encoder_in_channels has {} entries but num_feature_levels is {}",
+                    self.encoder_in_channels.len(),
+                    self.num_feature_levels
+                ),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Reading-order configuration, falling back to upstream defaults.
+    pub fn reading_order(&self) -> ReadingOrderConfig {
+        self.reading_order_config.clone().unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v2_json(extra: &str) -> String {
+        format!(
+            r#"{{
+                "model_type": "pp_doclayout_v2",
+                "backbone_config": {{"arch": "L", "return_idx": [1, 2, 3]}},
+                "feat_strides": [8, 16, 32],
+                "id2label": {{"0": "text", "1": "table"}},
+                "class_thresholds": [0.5, 0.4],
+                "class_order": [2, 12],
+                "reading_order_config": {{"hidden_size": 512, "num_classes": 20}}
+                {extra}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn parses_a_v2_configuration() {
+        let cfg: PpDocLayoutConfig = serde_json::from_str(&v2_json("")).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(cfg.version().unwrap(), PpDocLayoutVersion::V2);
+        assert_eq!(cfg.num_labels(), 2);
+        assert_eq!(cfg.strides(), vec![8, 16, 32]);
+        assert_eq!(cfg.backbone_return_idx(), vec![1, 2, 3]);
+        assert_eq!(cfg.label(1), "table");
+        assert_eq!(cfg.label(9), "unknown");
+        assert_eq!(cfg.num_queries, 300);
+        assert_eq!(cfg.decoder_layers, 6);
+        assert_eq!(cfg.reading_order().global_pointer_head_size, 64);
+    }
+
+    /// V3 spells the stride list `feature_strides` and returns four backbone
+    /// stages, the first of which feeds the mask branch.
+    #[test]
+    fn parses_a_v3_configuration() {
+        let json = r#"{
+            "model_type": "pp_doclayout_v3",
+            "backbone_config": {"arch": "L", "return_idx": [0, 1, 2, 3]},
+            "feature_strides": [8, 16, 32],
+            "id2label": {"0": "text"},
+            "mask_feature_channels": [64, 64],
+            "x4_feat_dim": 128
+        }"#;
+        let cfg: PpDocLayoutConfig = serde_json::from_str(json).unwrap();
+        cfg.validate().unwrap();
+        assert_eq!(cfg.version().unwrap(), PpDocLayoutVersion::V3);
+        assert_eq!(cfg.strides(), vec![8, 16, 32]);
+        assert_eq!(cfg.backbone_return_idx(), vec![0, 1, 2, 3]);
+        assert_eq!(cfg.num_prototypes, 32);
+        assert!(cfg.mask_enhanced);
+    }
+
+    #[test]
+    fn rejects_unknown_model_types() {
+        assert!(PpDocLayoutVersion::from_model_type("rt_detr").is_err());
+    }
+
+    #[test]
+    fn rejects_a_v2_configuration_without_class_order() {
+        let json = r#"{
+            "model_type": "pp_doclayout_v2",
+            "id2label": {"0": "text"},
+            "class_thresholds": [0.5]
+        }"#;
+        let cfg: PpDocLayoutConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_mismatched_threshold_counts() {
+        let json = r#"{
+            "model_type": "pp_doclayout_v3",
+            "id2label": {"0": "text", "1": "table"},
+            "class_thresholds": [0.5]
+        }"#;
+        let cfg: PpDocLayoutConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.validate().is_err());
+    }
+
+    /// Post-LN is baked into the encoder, so a pre-LN checkpoint must be
+    /// refused rather than silently mis-run.
+    #[test]
+    fn rejects_pre_layer_norm_encoders() {
+        let json = r#"{
+            "model_type": "pp_doclayout_v3",
+            "id2label": {"0": "text"},
+            "normalize_before": true
+        }"#;
+        let cfg: PpDocLayoutConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_backbone_architectures() {
+        let json = r#"{
+            "model_type": "pp_doclayout_v3",
+            "backbone_config": {"arch": "X"},
+            "id2label": {"0": "text"}
+        }"#;
+        let cfg: PpDocLayoutConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.validate().is_err());
+    }
+}

--- a/oar-ocr-vl/src/pp_doclayout/decoder.rs
+++ b/oar-ocr-vl/src/pp_doclayout/decoder.rs
@@ -1,0 +1,771 @@
+//! RT-DETR transformer decoder with multi-scale deformable cross-attention.
+//!
+//! Ported from `transformers/models/rt_detr/modeling_rt_detr.py`
+//! (`RTDetrDecoder`, `RTDetrDecoderLayer`, `RTDetrMultiscaleDeformableAttention`
+//! and the shared `MultiScaleDeformableAttention` sampler).
+
+use super::config::PpDocLayoutConfig;
+use super::err::infer_err;
+use super::layers::Activation;
+use crate::error::Error;
+use candle_core::{DType, Tensor};
+use candle_nn::{LayerNorm, Linear, Module, VarBuilder, layer_norm, linear};
+
+/// Spatial size of one feature level.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct LevelShape {
+    pub height: usize,
+    pub width: usize,
+}
+
+impl LevelShape {
+    fn len(&self) -> usize {
+        self.height * self.width
+    }
+}
+
+/// The plain MLP head RT-DETR uses for boxes and query positions: ReLU between
+/// every layer but the last.
+#[derive(Debug)]
+pub(super) struct MlpPredictionHead {
+    layers: Vec<Linear>,
+}
+
+impl MlpPredictionHead {
+    pub(super) fn load(
+        input_dim: usize,
+        hidden_dim: usize,
+        output_dim: usize,
+        num_layers: usize,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let layers_vb = vb.pp("layers");
+        let mut layers = Vec::with_capacity(num_layers);
+        for i in 0..num_layers {
+            let in_dim = if i == 0 { input_dim } else { hidden_dim };
+            let out_dim = if i + 1 == num_layers {
+                output_dim
+            } else {
+                hidden_dim
+            };
+            layers.push(
+                linear(in_dim, out_dim, layers_vb.pp(i))
+                    .map_err(|e| infer_err("load mlp head layer", e))?,
+            );
+        }
+        Ok(Self { layers })
+    }
+
+    pub(super) fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let mut hidden = x.clone();
+        let last = self.layers.len().saturating_sub(1);
+        for (i, layer) in self.layers.iter().enumerate() {
+            hidden = layer
+                .forward(&hidden)
+                .map_err(|e| infer_err("mlp head layer", e))?;
+            if i != last {
+                hidden = hidden.relu().map_err(|e| infer_err("mlp head relu", e))?;
+            }
+        }
+        Ok(hidden)
+    }
+}
+
+/// Self-attention over the object queries. Position embeddings are added to
+/// queries and keys but not to values.
+#[derive(Debug)]
+struct QuerySelfAttention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    out_proj: Linear,
+    num_heads: usize,
+    head_dim: usize,
+    scaling: f64,
+}
+
+impl QuerySelfAttention {
+    fn load(hidden_size: usize, num_heads: usize, vb: VarBuilder) -> Result<Self, Error> {
+        let head_dim = hidden_size / num_heads;
+        Ok(Self {
+            q_proj: linear(hidden_size, hidden_size, vb.pp("q_proj"))
+                .map_err(|e| infer_err("load decoder q_proj", e))?,
+            k_proj: linear(hidden_size, hidden_size, vb.pp("k_proj"))
+                .map_err(|e| infer_err("load decoder k_proj", e))?,
+            v_proj: linear(hidden_size, hidden_size, vb.pp("v_proj"))
+                .map_err(|e| infer_err("load decoder v_proj", e))?,
+            out_proj: linear(hidden_size, hidden_size, vb.pp("out_proj"))
+                .map_err(|e| infer_err("load decoder out_proj", e))?,
+            num_heads,
+            head_dim,
+            scaling: (head_dim as f64).powf(-0.5),
+        })
+    }
+
+    fn forward(&self, hidden: &Tensor, position: &Tensor) -> Result<Tensor, Error> {
+        let (batch, seq_len, _) = hidden
+            .dims3()
+            .map_err(|e| infer_err("decoder attention shape", e))?;
+        let query_key_input =
+            (hidden + position).map_err(|e| infer_err("decoder query position add", e))?;
+
+        let split = |t: Tensor| -> Result<Tensor, Error> {
+            t.reshape((batch, seq_len, self.num_heads, self.head_dim))
+                .and_then(|t| t.transpose(1, 2))
+                .and_then(|t| t.contiguous())
+                .map_err(|e| infer_err("decoder attention reshape", e))
+        };
+
+        let query = split(
+            self.q_proj
+                .forward(&query_key_input)
+                .map_err(|e| infer_err("decoder q projection", e))?,
+        )?;
+        let key = split(
+            self.k_proj
+                .forward(&query_key_input)
+                .map_err(|e| infer_err("decoder k projection", e))?,
+        )?;
+        let value = split(
+            self.v_proj
+                .forward(hidden)
+                .map_err(|e| infer_err("decoder v projection", e))?,
+        )?;
+
+        let scores = (query
+            .matmul(
+                &key.transpose(2, 3)
+                    .and_then(|t| t.contiguous())
+                    .map_err(|e| infer_err("decoder key transpose", e))?,
+            )
+            .map_err(|e| infer_err("decoder attention scores", e))?
+            * self.scaling)
+            .map_err(|e| infer_err("decoder attention scaling", e))?;
+        let probs = candle_nn::ops::softmax_last_dim(&scores)
+            .map_err(|e| infer_err("decoder attention softmax", e))?;
+        let context = probs
+            .matmul(&value)
+            .map_err(|e| infer_err("decoder attention context", e))?
+            .transpose(1, 2)
+            .map_err(|e| infer_err("decoder context transpose", e))?
+            .reshape((batch, seq_len, self.num_heads * self.head_dim))
+            .map_err(|e| infer_err("decoder context reshape", e))?;
+        self.out_proj
+            .forward(&context)
+            .map_err(|e| infer_err("decoder output projection", e))
+    }
+}
+
+/// Multi-scale deformable attention: each head samples `n_points` locations per
+/// feature level around the query's reference box and blends them with learned
+/// weights.
+#[derive(Debug)]
+struct DeformableAttention {
+    sampling_offsets: Linear,
+    attention_weights: Linear,
+    value_proj: Linear,
+    output_proj: Linear,
+    d_model: usize,
+    num_heads: usize,
+    num_levels: usize,
+    num_points: usize,
+}
+
+impl DeformableAttention {
+    fn load(cfg: &PpDocLayoutConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let num_heads = cfg.decoder_attention_heads;
+        if !cfg.d_model.is_multiple_of(num_heads) {
+            return Err(Error::Config {
+                message: format!(
+                    "PP-DocLayout: d_model {} is not divisible by decoder_attention_heads {}",
+                    cfg.d_model, num_heads
+                ),
+            });
+        }
+        let num_levels = cfg.num_feature_levels;
+        let num_points = cfg.decoder_n_points;
+        Ok(Self {
+            sampling_offsets: linear(
+                cfg.d_model,
+                num_heads * num_levels * num_points * 2,
+                vb.pp("sampling_offsets"),
+            )
+            .map_err(|e| infer_err("load sampling_offsets", e))?,
+            attention_weights: linear(
+                cfg.d_model,
+                num_heads * num_levels * num_points,
+                vb.pp("attention_weights"),
+            )
+            .map_err(|e| infer_err("load attention_weights", e))?,
+            value_proj: linear(cfg.d_model, cfg.d_model, vb.pp("value_proj"))
+                .map_err(|e| infer_err("load value_proj", e))?,
+            output_proj: linear(cfg.d_model, cfg.d_model, vb.pp("output_proj"))
+                .map_err(|e| infer_err("load output_proj", e))?,
+            d_model: cfg.d_model,
+            num_heads,
+            num_levels,
+            num_points,
+        })
+    }
+
+    /// `reference_points` is `(batch, num_queries, 4)` in cxcywh form.
+    fn forward(
+        &self,
+        hidden: &Tensor,
+        encoder_hidden: &Tensor,
+        position: &Tensor,
+        reference_points: &Tensor,
+        shapes: &[LevelShape],
+    ) -> Result<Tensor, Error> {
+        let hidden = (hidden + position).map_err(|e| infer_err("deformable position add", e))?;
+        let (batch, num_queries, _) = hidden
+            .dims3()
+            .map_err(|e| infer_err("deformable query shape", e))?;
+        let head_dim = self.d_model / self.num_heads;
+
+        let value = self
+            .value_proj
+            .forward(encoder_hidden)
+            .map_err(|e| infer_err("deformable value projection", e))?;
+
+        let offsets = self
+            .sampling_offsets
+            .forward(&hidden)
+            .and_then(|t| {
+                t.reshape((
+                    batch,
+                    num_queries,
+                    self.num_heads,
+                    self.num_levels,
+                    self.num_points,
+                    2,
+                ))
+            })
+            .map_err(|e| infer_err("deformable sampling offsets", e))?;
+
+        let weights = self
+            .attention_weights
+            .forward(&hidden)
+            .and_then(|t| {
+                t.reshape((
+                    batch,
+                    num_queries,
+                    self.num_heads,
+                    self.num_levels * self.num_points,
+                ))
+            })
+            .map_err(|e| infer_err("deformable attention weights", e))?;
+        let weights = candle_nn::ops::softmax_last_dim(&weights)
+            .and_then(|t| {
+                t.reshape((
+                    batch,
+                    num_queries,
+                    self.num_heads,
+                    self.num_levels,
+                    self.num_points,
+                ))
+            })
+            .map_err(|e| infer_err("deformable weight softmax", e))?;
+
+        let reference = reference_points
+            .reshape((batch, num_queries, 1, 1, 1, 4))
+            .map_err(|e| infer_err("deformable reference reshape", e))?;
+        let centers = reference
+            .narrow(5, 0, 2)
+            .map_err(|e| infer_err("deformable reference centers", e))?;
+        let sizes = reference
+            .narrow(5, 2, 2)
+            .map_err(|e| infer_err("deformable reference sizes", e))?;
+
+        let scaled_offsets = ((offsets / self.num_points as f64)
+            .map_err(|e| infer_err("deformable offset scale", e))?
+            .broadcast_mul(&sizes)
+            .map_err(|e| infer_err("deformable offset size", e))?
+            * 0.5)
+            .map_err(|e| infer_err("deformable offset half", e))?;
+        let locations = scaled_offsets
+            .broadcast_add(&centers)
+            .map_err(|e| infer_err("deformable sampling locations", e))?;
+
+        let sampled = self.sample(&value, &locations, shapes, batch, num_queries, head_dim)?;
+
+        let weights = weights
+            .permute((0, 2, 1, 3, 4))
+            .and_then(|t| t.contiguous())
+            .and_then(|t| {
+                t.reshape((
+                    batch,
+                    self.num_heads,
+                    num_queries,
+                    self.num_levels,
+                    self.num_points,
+                    1,
+                ))
+            })
+            .map_err(|e| infer_err("deformable weight permute", e))?;
+        let blended = sampled
+            .broadcast_mul(&weights)
+            .map_err(|e| infer_err("deformable blend", e))?
+            .sum(4)
+            .and_then(|t| t.sum(3))
+            .map_err(|e| infer_err("deformable reduce", e))?;
+
+        let output = blended
+            .permute((0, 2, 1, 3))
+            .and_then(|t| t.contiguous())
+            .and_then(|t| t.reshape((batch, num_queries, self.d_model)))
+            .map_err(|e| infer_err("deformable output reshape", e))?;
+        self.output_proj
+            .forward(&output)
+            .map_err(|e| infer_err("deformable output projection", e))
+    }
+
+    /// Bilinear sampling equivalent to `grid_sample(..., align_corners=False,
+    /// padding_mode="zeros")`, returning `(batch, heads, queries, levels,
+    /// points, head_dim)`.
+    fn sample(
+        &self,
+        value: &Tensor,
+        locations: &Tensor,
+        shapes: &[LevelShape],
+        batch: usize,
+        num_queries: usize,
+        head_dim: usize,
+    ) -> Result<Tensor, Error> {
+        let device = value.device();
+        let value = value
+            .reshape((batch, (), self.num_heads, head_dim))
+            .and_then(|t| t.permute((0, 2, 1, 3)))
+            .and_then(|t| t.contiguous())
+            .map_err(|e| infer_err("deformable value reshape", e))?;
+
+        let mut level_outputs = Vec::with_capacity(self.num_levels);
+        let mut offset = 0usize;
+        for (level, shape) in shapes.iter().enumerate() {
+            let (height, width) = (shape.height, shape.width);
+            let level_value = value
+                .narrow(2, offset, shape.len())
+                .and_then(|t| t.contiguous())
+                .and_then(|t| t.reshape((batch * self.num_heads * shape.len(), head_dim)))
+                .map_err(|e| infer_err("deformable level value", e))?;
+            offset += shape.len();
+
+            let level_loc = locations
+                .narrow(3, level, 1)
+                .and_then(|t| t.squeeze(3))
+                .and_then(|t| t.permute((0, 2, 1, 3, 4)))
+                .and_then(|t| t.contiguous())
+                .map_err(|e| infer_err("deformable level locations", e))?;
+            let x = level_loc
+                .narrow(4, 0, 1)
+                .and_then(|t| t.squeeze(4))
+                .map_err(|e| infer_err("deformable level x", e))?;
+            let y = level_loc
+                .narrow(4, 1, 1)
+                .and_then(|t| t.squeeze(4))
+                .map_err(|e| infer_err("deformable level y", e))?;
+
+            // align_corners=False maps a normalized coordinate to
+            // `coord * size - 0.5` in pixel space.
+            let gx = ((x * width as f64).map_err(|e| infer_err("deformable x scale", e))? - 0.5)
+                .map_err(|e| infer_err("deformable x shift", e))?;
+            let gy = ((y * height as f64).map_err(|e| infer_err("deformable y scale", e))? - 0.5)
+                .map_err(|e| infer_err("deformable y shift", e))?;
+            let x0 = gx.floor().map_err(|e| infer_err("deformable x floor", e))?;
+            let y0 = gy.floor().map_err(|e| infer_err("deformable y floor", e))?;
+            let wx = (&gx - &x0).map_err(|e| infer_err("deformable x frac", e))?;
+            let wy = (&gy - &y0).map_err(|e| infer_err("deformable y frac", e))?;
+
+            let plane = plane_offsets(
+                batch,
+                self.num_heads,
+                shape.len(),
+                num_queries,
+                self.num_points,
+                device,
+            )?;
+
+            let mut accumulated: Option<Tensor> = None;
+            for (dx, dy) in [(0f64, 0f64), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)] {
+                let xi = (&x0 + dx).map_err(|e| infer_err("deformable corner x", e))?;
+                let yi = (&y0 + dy).map_err(|e| infer_err("deformable corner y", e))?;
+
+                let valid = in_range(&xi, width)?
+                    .mul(&in_range(&yi, height)?)
+                    .map_err(|e| infer_err("deformable corner validity", e))?;
+
+                let xc = clamp_index(&xi, width)?;
+                let yc = clamp_index(&yi, height)?;
+                let flat =
+                    ((yc * width as f64).map_err(|e| infer_err("deformable row offset", e))? + xc)
+                        .and_then(|t| t + &plane)
+                        .map_err(|e| infer_err("deformable flat index", e))?;
+                let flat = flat
+                    .flatten_all()
+                    .and_then(|t| t.to_dtype(DType::U32))
+                    .map_err(|e| infer_err("deformable index cast", e))?;
+
+                let gathered = level_value
+                    .index_select(&flat, 0)
+                    .and_then(|t| {
+                        t.reshape((
+                            batch,
+                            self.num_heads,
+                            num_queries,
+                            self.num_points,
+                            head_dim,
+                        ))
+                    })
+                    .map_err(|e| infer_err("deformable gather", e))?;
+
+                let corner_x = if dx == 0.0 {
+                    (1.0 - &wx).map_err(|e| infer_err("deformable weight x", e))?
+                } else {
+                    wx.clone()
+                };
+                let corner_y = if dy == 0.0 {
+                    (1.0 - &wy).map_err(|e| infer_err("deformable weight y", e))?
+                } else {
+                    wy.clone()
+                };
+                let weight = (corner_x * corner_y)
+                    .and_then(|w| w * valid)
+                    .and_then(|w| w.unsqueeze(4))
+                    .map_err(|e| infer_err("deformable corner weight", e))?;
+
+                let contribution = gathered
+                    .broadcast_mul(&weight)
+                    .map_err(|e| infer_err("deformable corner blend", e))?;
+                accumulated = Some(match accumulated {
+                    Some(acc) => (acc + contribution)
+                        .map_err(|e| infer_err("deformable corner accumulate", e))?,
+                    None => contribution,
+                });
+            }
+
+            let level_output = accumulated
+                .ok_or_else(|| Error::Config {
+                    message: "PP-DocLayout: deformable sampling produced no corners".to_string(),
+                })?
+                .unsqueeze(3)
+                .map_err(|e| infer_err("deformable level unsqueeze", e))?;
+            level_outputs.push(level_output);
+        }
+
+        Tensor::cat(&level_outputs, 3).map_err(|e| infer_err("deformable level concat", e))
+    }
+}
+
+/// `1.0` where `coord` is a valid index into `[0, size)`, else `0.0`.
+fn in_range(coord: &Tensor, size: usize) -> Result<Tensor, Error> {
+    let low = coord
+        .ge(0f64)
+        .map_err(|e| infer_err("deformable range low", e))?;
+    let high = coord
+        .le((size - 1) as f64)
+        .map_err(|e| infer_err("deformable range high", e))?;
+    low.mul(&high)
+        .and_then(|t| t.to_dtype(coord.dtype()))
+        .map_err(|e| infer_err("deformable range mask", e))
+}
+
+/// Clamps a coordinate into `[0, size - 1]` so the gather stays in bounds; the
+/// validity mask zeroes out whatever the clamp pulled back in.
+fn clamp_index(coord: &Tensor, size: usize) -> Result<Tensor, Error> {
+    coord
+        .clamp(0f64, (size - 1) as f64)
+        .map_err(|e| infer_err("deformable clamp", e))
+}
+
+/// Per-(batch, head) base offsets into the flattened level buffer, broadcast to
+/// `(batch, heads, queries, points)`.
+fn plane_offsets(
+    batch: usize,
+    num_heads: usize,
+    level_len: usize,
+    num_queries: usize,
+    num_points: usize,
+    device: &candle_core::Device,
+) -> Result<Tensor, Error> {
+    let values: Vec<f32> = (0..batch * num_heads)
+        .map(|i| (i * level_len) as f32)
+        .collect();
+    Tensor::from_vec(values, (batch, num_heads, 1, 1), device)
+        .and_then(|t| t.broadcast_as((batch, num_heads, num_queries, num_points)))
+        .and_then(|t| t.contiguous())
+        .map_err(|e| infer_err("deformable plane offsets", e))
+}
+
+/// One decoder layer: query self-attention, deformable cross-attention, MLP.
+#[derive(Debug)]
+struct DecoderLayer {
+    self_attn: QuerySelfAttention,
+    self_attn_layer_norm: LayerNorm,
+    encoder_attn: DeformableAttention,
+    encoder_attn_layer_norm: LayerNorm,
+    fc1: Linear,
+    fc2: Linear,
+    final_layer_norm: LayerNorm,
+    activation: Activation,
+}
+
+impl DecoderLayer {
+    fn load(cfg: &PpDocLayoutConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let hidden = cfg.d_model;
+        Ok(Self {
+            self_attn: QuerySelfAttention::load(
+                hidden,
+                cfg.decoder_attention_heads,
+                vb.pp("self_attn"),
+            )?,
+            self_attn_layer_norm: layer_norm(
+                hidden,
+                cfg.layer_norm_eps,
+                vb.pp("self_attn_layer_norm"),
+            )
+            .map_err(|e| infer_err("load decoder self_attn_layer_norm", e))?,
+            encoder_attn: DeformableAttention::load(cfg, vb.pp("encoder_attn"))?,
+            encoder_attn_layer_norm: layer_norm(
+                hidden,
+                cfg.layer_norm_eps,
+                vb.pp("encoder_attn_layer_norm"),
+            )
+            .map_err(|e| infer_err("load decoder encoder_attn_layer_norm", e))?,
+            fc1: linear(hidden, cfg.decoder_ffn_dim, vb.pp("fc1"))
+                .map_err(|e| infer_err("load decoder fc1", e))?,
+            fc2: linear(cfg.decoder_ffn_dim, hidden, vb.pp("fc2"))
+                .map_err(|e| infer_err("load decoder fc2", e))?,
+            final_layer_norm: layer_norm(hidden, cfg.layer_norm_eps, vb.pp("final_layer_norm"))
+                .map_err(|e| infer_err("load decoder final_layer_norm", e))?,
+            activation: Activation::parse(&cfg.decoder_activation_function)?,
+        })
+    }
+
+    fn forward(
+        &self,
+        hidden: &Tensor,
+        position: &Tensor,
+        reference_points: &Tensor,
+        encoder_hidden: &Tensor,
+        shapes: &[LevelShape],
+    ) -> Result<Tensor, Error> {
+        let attn = self.self_attn.forward(hidden, position)?;
+        let hidden = (hidden + attn).map_err(|e| infer_err("decoder self residual", e))?;
+        let hidden = self
+            .self_attn_layer_norm
+            .forward(&hidden)
+            .map_err(|e| infer_err("decoder self norm", e))?;
+
+        let cross = self.encoder_attn.forward(
+            &hidden,
+            encoder_hidden,
+            position,
+            reference_points,
+            shapes,
+        )?;
+        let hidden = (hidden + cross).map_err(|e| infer_err("decoder cross residual", e))?;
+        let hidden = self
+            .encoder_attn_layer_norm
+            .forward(&hidden)
+            .map_err(|e| infer_err("decoder cross norm", e))?;
+
+        let ffn = self
+            .fc1
+            .forward(&hidden)
+            .map_err(|e| infer_err("decoder fc1", e))?;
+        let ffn = self.activation.apply(&ffn)?;
+        let ffn = self
+            .fc2
+            .forward(&ffn)
+            .map_err(|e| infer_err("decoder fc2", e))?;
+        let hidden = (hidden + ffn).map_err(|e| infer_err("decoder ffn residual", e))?;
+        self.final_layer_norm
+            .forward(&hidden)
+            .map_err(|e| infer_err("decoder ffn norm", e))
+    }
+}
+
+/// Decoder output kept by the detection heads.
+pub(super) struct DecoderOutput {
+    /// Hidden states of the last layer, `(batch, queries, d_model)`.
+    pub last_hidden_state: Tensor,
+    /// Class logits of the last layer, `(batch, queries, num_labels)`.
+    pub logits: Tensor,
+    /// Refined boxes of the last layer in cxcywh form, `(batch, queries, 4)`.
+    pub reference_points: Tensor,
+}
+
+/// Detection heads driving the per-layer box refinement.
+///
+/// V2 stores one class and box head per decoder layer. V3 shares a single pair
+/// with the encoder head and normalizes the hidden states before classifying,
+/// so those heads are supplied by the caller.
+#[derive(Debug)]
+pub(super) enum DecoderHeads {
+    /// One head pair per layer, loaded from `decoder.class_embed` /
+    /// `decoder.bbox_embed`.
+    PerLayer {
+        class_embed: Vec<Linear>,
+        bbox_embed: Vec<MlpPredictionHead>,
+    },
+    /// Heads tied to `enc_score_head` / `enc_bbox_head`, passed in per call.
+    Shared,
+}
+
+/// Heads and norm a shared-head decoder borrows for one forward pass.
+pub(super) struct SharedHeads<'a> {
+    pub class_embed: &'a Linear,
+    pub bbox_embed: &'a MlpPredictionHead,
+    pub norm: &'a LayerNorm,
+}
+
+/// The RT-DETR decoder stack with iterative box refinement.
+#[derive(Debug)]
+pub(super) struct Decoder {
+    layers: Vec<DecoderLayer>,
+    query_pos_head: MlpPredictionHead,
+    heads: DecoderHeads,
+}
+
+impl Decoder {
+    /// `shared_heads` selects the V3 layout, where the class and box heads are
+    /// tied to the encoder head instead of being stored per layer.
+    pub(super) fn load(
+        cfg: &PpDocLayoutConfig,
+        shared_heads: bool,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let layers_vb = vb.pp("layers");
+        let mut layers = Vec::with_capacity(cfg.decoder_layers);
+        for i in 0..cfg.decoder_layers {
+            layers.push(DecoderLayer::load(cfg, layers_vb.pp(i))?);
+        }
+
+        let heads = if shared_heads {
+            DecoderHeads::Shared
+        } else {
+            let class_vb = vb.pp("class_embed");
+            let bbox_vb = vb.pp("bbox_embed");
+            let mut class_embed = Vec::with_capacity(cfg.decoder_layers);
+            let mut bbox_embed = Vec::with_capacity(cfg.decoder_layers);
+            for i in 0..cfg.decoder_layers {
+                class_embed.push(
+                    linear(cfg.d_model, cfg.num_labels(), class_vb.pp(i))
+                        .map_err(|e| infer_err("load decoder class head", e))?,
+                );
+                bbox_embed.push(MlpPredictionHead::load(
+                    cfg.d_model,
+                    cfg.d_model,
+                    4,
+                    3,
+                    bbox_vb.pp(i),
+                )?);
+            }
+            DecoderHeads::PerLayer {
+                class_embed,
+                bbox_embed,
+            }
+        };
+
+        Ok(Self {
+            layers,
+            query_pos_head: MlpPredictionHead::load(
+                4,
+                2 * cfg.d_model,
+                cfg.d_model,
+                2,
+                vb.pp("query_pos_head"),
+            )?,
+            heads,
+        })
+    }
+
+    /// `reference_points` arrives unactivated (logit space), as produced by the
+    /// encoder head.
+    pub(super) fn forward(
+        &self,
+        queries: &Tensor,
+        encoder_hidden: &Tensor,
+        reference_points: &Tensor,
+        shapes: &[LevelShape],
+        shared: Option<SharedHeads<'_>>,
+    ) -> Result<DecoderOutput, Error> {
+        let mut hidden = queries.clone();
+        let mut reference = candle_nn::ops::sigmoid(reference_points)
+            .map_err(|e| infer_err("decoder reference sigmoid", e))?;
+        let mut logits = None;
+
+        for (idx, layer) in self.layers.iter().enumerate() {
+            let position = self.query_pos_head.forward(&reference)?;
+            hidden = layer.forward(&hidden, &position, &reference, encoder_hidden, shapes)?;
+
+            let (corners, class_logits) = match (&self.heads, &shared) {
+                (
+                    DecoderHeads::PerLayer {
+                        class_embed,
+                        bbox_embed,
+                    },
+                    _,
+                ) => (
+                    bbox_embed[idx].forward(&hidden)?,
+                    class_embed[idx]
+                        .forward(&hidden)
+                        .map_err(|e| infer_err("decoder class head", e))?,
+                ),
+                (DecoderHeads::Shared, Some(shared)) => {
+                    // Boxes come off the raw states, classes off the normalized
+                    // ones, matching PP-DocLayoutV3.
+                    let normed = shared
+                        .norm
+                        .forward(&hidden)
+                        .map_err(|e| infer_err("decoder shared norm", e))?;
+                    (
+                        shared.bbox_embed.forward(&hidden)?,
+                        shared
+                            .class_embed
+                            .forward(&normed)
+                            .map_err(|e| infer_err("decoder shared class head", e))?,
+                    )
+                }
+                (DecoderHeads::Shared, None) => {
+                    return Err(Error::Config {
+                        message: "PP-DocLayout: shared decoder heads were not supplied".to_string(),
+                    });
+                }
+            };
+
+            let refined = (corners + inverse_sigmoid(&reference)?)
+                .map_err(|e| infer_err("decoder box refinement", e))?;
+            reference = candle_nn::ops::sigmoid(&refined)
+                .map_err(|e| infer_err("decoder box sigmoid", e))?;
+            logits = Some(class_logits);
+        }
+
+        let logits = logits.ok_or_else(|| Error::Config {
+            message: "PP-DocLayout: decoder_layers must be at least 1".to_string(),
+        })?;
+
+        Ok(DecoderOutput {
+            last_hidden_state: hidden,
+            logits,
+            reference_points: reference,
+        })
+    }
+}
+
+/// `log(x / (1 - x))` with the upstream clamping.
+pub(super) fn inverse_sigmoid(x: &Tensor) -> Result<Tensor, Error> {
+    const EPS: f64 = 1e-5;
+    let x = x
+        .clamp(0f64, 1f64)
+        .map_err(|e| infer_err("inverse sigmoid clamp", e))?;
+    let numerator = x
+        .clamp(EPS, f64::INFINITY)
+        .map_err(|e| infer_err("inverse sigmoid numerator", e))?;
+    let denominator = (1.0 - &x)
+        .and_then(|t| t.clamp(EPS, f64::INFINITY))
+        .map_err(|e| infer_err("inverse sigmoid denominator", e))?;
+    (numerator / denominator)
+        .and_then(|t| t.log())
+        .map_err(|e| infer_err("inverse sigmoid log", e))
+}

--- a/oar-ocr-vl/src/pp_doclayout/encoder.rs
+++ b/oar-ocr-vl/src/pp_doclayout/encoder.rs
@@ -1,0 +1,516 @@
+//! RT-DETR hybrid encoder: AIFI on the coarsest level, then a top-down FPN and
+//! a bottom-up PAN over the projected backbone features.
+//!
+//! Ported from `transformers/models/rt_detr/modeling_rt_detr.py`
+//! (`RTDetrHybridEncoder` and friends). The checkpoints store the AIFI stack
+//! under `model.encoder.encoder.*`, which is the name used here.
+
+use super::config::PpDocLayoutConfig;
+use super::err::infer_err;
+use super::layers::{Activation, ConvNormLayer};
+use super::mask_head::MaskFeatureHead;
+use crate::error::Error;
+use candle_core::{DType, Device, Tensor};
+use candle_nn::{LayerNorm, Linear, Module, VarBuilder, layer_norm, linear};
+
+/// Multi-head self-attention where the position embedding is added to the
+/// query and key inputs but not to the values.
+#[derive(Debug)]
+struct SelfAttention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    out_proj: Linear,
+    num_heads: usize,
+    head_dim: usize,
+    scaling: f64,
+}
+
+impl SelfAttention {
+    fn load(hidden_size: usize, num_heads: usize, vb: VarBuilder) -> Result<Self, Error> {
+        let head_dim = hidden_size / num_heads;
+        Ok(Self {
+            q_proj: linear(hidden_size, hidden_size, vb.pp("q_proj"))
+                .map_err(|e| infer_err("load encoder q_proj", e))?,
+            k_proj: linear(hidden_size, hidden_size, vb.pp("k_proj"))
+                .map_err(|e| infer_err("load encoder k_proj", e))?,
+            v_proj: linear(hidden_size, hidden_size, vb.pp("v_proj"))
+                .map_err(|e| infer_err("load encoder v_proj", e))?,
+            out_proj: linear(hidden_size, hidden_size, vb.pp("out_proj"))
+                .map_err(|e| infer_err("load encoder out_proj", e))?,
+            num_heads,
+            head_dim,
+            scaling: (head_dim as f64).powf(-0.5),
+        })
+    }
+
+    fn forward(&self, hidden: &Tensor, position: Option<&Tensor>) -> Result<Tensor, Error> {
+        let (batch, seq_len, _) = hidden
+            .dims3()
+            .map_err(|e| infer_err("encoder attention shape", e))?;
+        let query_key_input = match position {
+            Some(pos) => hidden
+                .broadcast_add(pos)
+                .map_err(|e| infer_err("encoder position add", e))?,
+            None => hidden.clone(),
+        };
+
+        let split = |t: Tensor, what: &'static str| -> Result<Tensor, Error> {
+            t.reshape((batch, seq_len, self.num_heads, self.head_dim))
+                .and_then(|t| t.transpose(1, 2))
+                .and_then(|t| t.contiguous())
+                .map_err(|e| infer_err(what, e))
+        };
+
+        let query = split(
+            self.q_proj
+                .forward(&query_key_input)
+                .map_err(|e| infer_err("encoder q projection", e))?,
+            "encoder q reshape",
+        )?;
+        let key = split(
+            self.k_proj
+                .forward(&query_key_input)
+                .map_err(|e| infer_err("encoder k projection", e))?,
+            "encoder k reshape",
+        )?;
+        let value = split(
+            self.v_proj
+                .forward(hidden)
+                .map_err(|e| infer_err("encoder v projection", e))?,
+            "encoder v reshape",
+        )?;
+
+        let scores = (query
+            .matmul(
+                &key.transpose(2, 3)
+                    .and_then(|t| t.contiguous())
+                    .map_err(|e| infer_err("encoder key transpose", e))?,
+            )
+            .map_err(|e| infer_err("encoder attention scores", e))?
+            * self.scaling)
+            .map_err(|e| infer_err("encoder attention scaling", e))?;
+        let probs = candle_nn::ops::softmax_last_dim(&scores)
+            .map_err(|e| infer_err("encoder attention softmax", e))?;
+        let context = probs
+            .matmul(&value)
+            .map_err(|e| infer_err("encoder attention context", e))?
+            .transpose(1, 2)
+            .map_err(|e| infer_err("encoder context transpose", e))?
+            .reshape((batch, seq_len, self.num_heads * self.head_dim))
+            .map_err(|e| infer_err("encoder context reshape", e))?;
+        self.out_proj
+            .forward(&context)
+            .map_err(|e| infer_err("encoder output projection", e))
+    }
+}
+
+/// One post-norm transformer encoder layer.
+#[derive(Debug)]
+struct EncoderLayer {
+    self_attn: SelfAttention,
+    self_attn_layer_norm: LayerNorm,
+    fc1: Linear,
+    fc2: Linear,
+    final_layer_norm: LayerNorm,
+    activation: Activation,
+}
+
+impl EncoderLayer {
+    fn load(cfg: &PpDocLayoutConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let hidden = cfg.encoder_hidden_dim;
+        Ok(Self {
+            self_attn: SelfAttention::load(
+                hidden,
+                cfg.encoder_attention_heads,
+                vb.pp("self_attn"),
+            )?,
+            self_attn_layer_norm: layer_norm(
+                hidden,
+                cfg.layer_norm_eps,
+                vb.pp("self_attn_layer_norm"),
+            )
+            .map_err(|e| infer_err("load encoder self_attn_layer_norm", e))?,
+            fc1: linear(hidden, cfg.encoder_ffn_dim, vb.pp("fc1"))
+                .map_err(|e| infer_err("load encoder fc1", e))?,
+            fc2: linear(cfg.encoder_ffn_dim, hidden, vb.pp("fc2"))
+                .map_err(|e| infer_err("load encoder fc2", e))?,
+            final_layer_norm: layer_norm(hidden, cfg.layer_norm_eps, vb.pp("final_layer_norm"))
+                .map_err(|e| infer_err("load encoder final_layer_norm", e))?,
+            activation: Activation::parse(&cfg.encoder_activation_function)?,
+        })
+    }
+
+    fn forward(&self, hidden: &Tensor, position: Option<&Tensor>) -> Result<Tensor, Error> {
+        let attn = self.self_attn.forward(hidden, position)?;
+        let hidden = (hidden + attn).map_err(|e| infer_err("encoder attention residual", e))?;
+        let hidden = self
+            .self_attn_layer_norm
+            .forward(&hidden)
+            .map_err(|e| infer_err("encoder attention norm", e))?;
+
+        let ffn = self
+            .fc1
+            .forward(&hidden)
+            .map_err(|e| infer_err("encoder fc1", e))?;
+        let ffn = self.activation.apply(&ffn)?;
+        let ffn = self
+            .fc2
+            .forward(&ffn)
+            .map_err(|e| infer_err("encoder fc2", e))?;
+        let hidden = (hidden + ffn).map_err(|e| infer_err("encoder ffn residual", e))?;
+        self.final_layer_norm
+            .forward(&hidden)
+            .map_err(|e| infer_err("encoder ffn norm", e))
+    }
+}
+
+/// Attention-based intra-scale feature interaction over a single feature map.
+#[derive(Debug)]
+struct AifiLayer {
+    layers: Vec<EncoderLayer>,
+    embed_dim: usize,
+    temperature: f64,
+}
+
+impl AifiLayer {
+    fn load(cfg: &PpDocLayoutConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let layers_vb = vb.pp("layers");
+        let mut layers = Vec::with_capacity(cfg.encoder_layers);
+        for i in 0..cfg.encoder_layers {
+            layers.push(EncoderLayer::load(cfg, layers_vb.pp(i))?);
+        }
+        Ok(Self {
+            layers,
+            embed_dim: cfg.encoder_hidden_dim,
+            temperature: cfg.positional_encoding_temperature,
+        })
+    }
+
+    fn forward(&self, feature_map: &Tensor) -> Result<Tensor, Error> {
+        let (batch, channels, height, width) = feature_map
+            .dims4()
+            .map_err(|e| infer_err("aifi input shape", e))?;
+        let mut hidden = feature_map
+            .flatten_from(2)
+            .and_then(|t| t.permute((0, 2, 1)))
+            .and_then(|t| t.contiguous())
+            .map_err(|e| infer_err("aifi flatten", e))?;
+
+        let position = sine_position_embedding(
+            height,
+            width,
+            self.embed_dim,
+            self.temperature,
+            feature_map.device(),
+            feature_map.dtype(),
+        )?;
+
+        for layer in &self.layers {
+            hidden = layer.forward(&hidden, Some(&position))?;
+        }
+
+        hidden
+            .permute((0, 2, 1))
+            .and_then(|t| t.reshape((batch, channels, height, width)))
+            .and_then(|t| t.contiguous())
+            .map_err(|e| infer_err("aifi reshape", e))
+    }
+}
+
+/// 2D sinusoidal position embedding laid out as `[sin_h | cos_h | sin_w |
+/// cos_w]` in row-major (height-outer) order, shaped `(1, height*width, dim)`.
+fn sine_position_embedding(
+    height: usize,
+    width: usize,
+    embed_dim: usize,
+    temperature: f64,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor, Error> {
+    if !embed_dim.is_multiple_of(4) {
+        return Err(Error::Config {
+            message: format!("PP-DocLayout: encoder_hidden_dim {embed_dim} must be divisible by 4"),
+        });
+    }
+    let pos_dim = embed_dim / 4;
+    // Torch builds these in f64 before casting, so do the same to stay
+    // bit-comparable at the tail frequencies.
+    let omega: Vec<f64> = (0..pos_dim)
+        .map(|i| 1.0 / temperature.powf(i as f64 / pos_dim as f64))
+        .collect();
+
+    let mut data = vec![0f64; height * width * embed_dim];
+    for h in 0..height {
+        for w in 0..width {
+            let base = (h * width + w) * embed_dim;
+            for (k, &om) in omega.iter().enumerate() {
+                let ph = h as f64 * om;
+                let pw = w as f64 * om;
+                data[base + k] = ph.sin();
+                data[base + pos_dim + k] = ph.cos();
+                data[base + 2 * pos_dim + k] = pw.sin();
+                data[base + 3 * pos_dim + k] = pw.cos();
+            }
+        }
+    }
+
+    Tensor::from_vec(data, (1, height * width, embed_dim), device)
+        .and_then(|t| t.to_dtype(dtype))
+        .map_err(|e| infer_err("build position embedding", e))
+}
+
+/// RepVGG block: a 3x3 and a 1x1 branch summed, then activated.
+#[derive(Debug)]
+struct RepVggBlock {
+    conv1: ConvNormLayer,
+    conv2: ConvNormLayer,
+    activation: Activation,
+}
+
+impl RepVggBlock {
+    fn load(cfg: &PpDocLayoutConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let hidden = (cfg.encoder_hidden_dim as f64 * cfg.hidden_expansion) as usize;
+        Ok(Self {
+            conv1: ConvNormLayer::load(
+                hidden,
+                hidden,
+                3,
+                1,
+                Some(1),
+                Activation::Identity,
+                cfg.batch_norm_eps,
+                vb.pp("conv1"),
+            )?,
+            conv2: ConvNormLayer::load(
+                hidden,
+                hidden,
+                1,
+                1,
+                Some(0),
+                Activation::Identity,
+                cfg.batch_norm_eps,
+                vb.pp("conv2"),
+            )?,
+            activation: Activation::parse(&cfg.activation_function)?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let y = (self.conv1.forward(x)? + self.conv2.forward(x)?)
+            .map_err(|e| infer_err("repvgg branch sum", e))?;
+        self.activation.apply(&y)
+    }
+}
+
+/// Cross-stage-partial layer with three RepVGG bottlenecks.
+#[derive(Debug)]
+struct CspRepLayer {
+    conv1: ConvNormLayer,
+    conv2: ConvNormLayer,
+    bottlenecks: Vec<RepVggBlock>,
+}
+
+impl CspRepLayer {
+    const NUM_BLOCKS: usize = 3;
+
+    fn load(cfg: &PpDocLayoutConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let in_channels = cfg.encoder_hidden_dim * 2;
+        let out_channels = cfg.encoder_hidden_dim;
+        let hidden = (out_channels as f64 * cfg.hidden_expansion) as usize;
+        if hidden != out_channels {
+            return Err(Error::Config {
+                message: "PP-DocLayout: hidden_expansion != 1.0 is not supported".to_string(),
+            });
+        }
+        let activation = Activation::parse(&cfg.activation_function)?;
+        let bottlenecks_vb = vb.pp("bottlenecks");
+        let mut bottlenecks = Vec::with_capacity(Self::NUM_BLOCKS);
+        for i in 0..Self::NUM_BLOCKS {
+            bottlenecks.push(RepVggBlock::load(cfg, bottlenecks_vb.pp(i))?);
+        }
+        Ok(Self {
+            conv1: ConvNormLayer::load(
+                in_channels,
+                hidden,
+                1,
+                1,
+                None,
+                activation,
+                cfg.batch_norm_eps,
+                vb.pp("conv1"),
+            )?,
+            conv2: ConvNormLayer::load(
+                in_channels,
+                hidden,
+                1,
+                1,
+                None,
+                activation,
+                cfg.batch_norm_eps,
+                vb.pp("conv2"),
+            )?,
+            bottlenecks,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let mut branch = self.conv1.forward(x)?;
+        for block in &self.bottlenecks {
+            branch = block.forward(&branch)?;
+        }
+        let other = self.conv2.forward(x)?;
+        (branch + other).map_err(|e| infer_err("csp merge", e))
+    }
+}
+
+/// The full hybrid encoder.
+#[derive(Debug)]
+pub(super) struct HybridEncoder {
+    aifi: Vec<AifiLayer>,
+    encode_proj_layers: Vec<usize>,
+    lateral_convs: Vec<ConvNormLayer>,
+    fpn_blocks: Vec<CspRepLayer>,
+    downsample_convs: Vec<ConvNormLayer>,
+    pan_blocks: Vec<CspRepLayer>,
+    mask_head: Option<MaskFeatureHead>,
+}
+
+impl HybridEncoder {
+    /// `with_mask_head` loads the V3 mask branch.
+    pub(super) fn load(
+        cfg: &PpDocLayoutConfig,
+        with_mask_head: bool,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let num_stages = cfg.encoder_in_channels.len().saturating_sub(1);
+        let hidden = cfg.encoder_hidden_dim;
+        let activation = Activation::parse(&cfg.activation_function)?;
+
+        // Upstream calls this stack `aifi`; the checkpoints store it as
+        // `encoder`, which is the name we have to load from.
+        let aifi_vb = vb.pp("encoder");
+        let mut aifi = Vec::with_capacity(cfg.encode_proj_layers.len());
+        for i in 0..cfg.encode_proj_layers.len() {
+            aifi.push(AifiLayer::load(cfg, aifi_vb.pp(i))?);
+        }
+
+        let lateral_vb = vb.pp("lateral_convs");
+        let fpn_vb = vb.pp("fpn_blocks");
+        let mut lateral_convs = Vec::with_capacity(num_stages);
+        let mut fpn_blocks = Vec::with_capacity(num_stages);
+        for i in 0..num_stages {
+            lateral_convs.push(ConvNormLayer::load(
+                hidden,
+                hidden,
+                1,
+                1,
+                None,
+                activation,
+                cfg.batch_norm_eps,
+                lateral_vb.pp(i),
+            )?);
+            fpn_blocks.push(CspRepLayer::load(cfg, fpn_vb.pp(i))?);
+        }
+
+        let downsample_vb = vb.pp("downsample_convs");
+        let pan_vb = vb.pp("pan_blocks");
+        let mut downsample_convs = Vec::with_capacity(num_stages);
+        let mut pan_blocks = Vec::with_capacity(num_stages);
+        for i in 0..num_stages {
+            downsample_convs.push(ConvNormLayer::load(
+                hidden,
+                hidden,
+                3,
+                2,
+                None,
+                activation,
+                cfg.batch_norm_eps,
+                downsample_vb.pp(i),
+            )?);
+            pan_blocks.push(CspRepLayer::load(cfg, pan_vb.pp(i))?);
+        }
+
+        Ok(Self {
+            aifi,
+            encode_proj_layers: cfg.encode_proj_layers.clone(),
+            lateral_convs,
+            fpn_blocks,
+            downsample_convs,
+            pan_blocks,
+            mask_head: with_mask_head
+                .then(|| MaskFeatureHead::load(cfg, vb.clone()))
+                .transpose()?,
+        })
+    }
+
+    /// Runs the V3 mask branch over the fused levels, if this encoder has one.
+    pub(super) fn mask_features(
+        &self,
+        pan: &[Tensor],
+        x4: &Tensor,
+    ) -> Result<Option<Tensor>, Error> {
+        self.mask_head
+            .as_ref()
+            .map(|head| head.forward(pan, x4))
+            .transpose()
+    }
+
+    /// Fuses the projected backbone features, returning one map per level in
+    /// fine-to-coarse order.
+    pub(super) fn forward(&self, features: &[Tensor]) -> Result<Vec<Tensor>, Error> {
+        let mut features = features.to_vec();
+        for (i, &level) in self.encode_proj_layers.iter().enumerate() {
+            let Some(feature) = features.get(level) else {
+                return Err(Error::Config {
+                    message: format!(
+                        "PP-DocLayout: encode_proj_layers references level {level} but only \
+                         {} feature levels are available",
+                        features.len()
+                    ),
+                });
+            };
+            features[level] = self.aifi[i].forward(feature)?;
+        }
+
+        let num_stages = self.lateral_convs.len();
+        let mut fpn = vec![features[features.len() - 1].clone()];
+        for (idx, (lateral, block)) in self
+            .lateral_convs
+            .iter()
+            .zip(self.fpn_blocks.iter())
+            .enumerate()
+        {
+            let backbone_feature = &features[num_stages - idx - 1];
+            let top = lateral.forward(&fpn[fpn.len() - 1])?;
+            let last = fpn.len() - 1;
+            fpn[last] = top.clone();
+
+            let (_, _, height, width) = top
+                .dims4()
+                .map_err(|e| infer_err("fpn upsample shape", e))?;
+            let upsampled = top
+                .upsample_nearest2d(height * 2, width * 2)
+                .map_err(|e| infer_err("fpn upsample", e))?;
+            let fused = Tensor::cat(&[&upsampled, backbone_feature], 1)
+                .map_err(|e| infer_err("fpn concat", e))?;
+            fpn.push(block.forward(&fused)?);
+        }
+        fpn.reverse();
+
+        let mut pan = vec![fpn[0].clone()];
+        for (idx, (downsample, block)) in self
+            .downsample_convs
+            .iter()
+            .zip(self.pan_blocks.iter())
+            .enumerate()
+        {
+            let downsampled = downsample.forward(&pan[pan.len() - 1])?;
+            let fused = Tensor::cat(&[&downsampled, &fpn[idx + 1]], 1)
+                .map_err(|e| infer_err("pan concat", e))?;
+            pan.push(block.forward(&fused)?);
+        }
+
+        Ok(pan)
+    }
+}

--- a/oar-ocr-vl/src/pp_doclayout/err.rs
+++ b/oar-ocr-vl/src/pp_doclayout/err.rs
@@ -1,0 +1,17 @@
+//! Error helpers shared by the PP-DocLayout modules.
+
+use crate::error::Error;
+use crate::error::ProcessingStage;
+use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
+
+pub(super) const MODEL_NAME: &str = "PP-DocLayout";
+
+/// Wraps a Candle failure that happened while loading or running the model.
+pub(super) fn infer_err(context: &'static str, error: candle_core::Error) -> Error {
+    candle_to_ocr_inference(MODEL_NAME, context, error)
+}
+
+/// Wraps a Candle failure in tensor pre/post-processing.
+pub(super) fn proc_err(context: &'static str, error: candle_core::Error) -> Error {
+    candle_to_ocr_processing(ProcessingStage::TensorOperation, context, error)
+}

--- a/oar-ocr-vl/src/pp_doclayout/hgnetv2.rs
+++ b/oar-ocr-vl/src/pp_doclayout/hgnetv2.rs
@@ -1,0 +1,456 @@
+//! HGNetV2 backbone shared by PP-DocLayoutV2 and PP-DocLayoutV3.
+//!
+//! Ported from `transformers/models/hgnet_v2/modeling_hgnet_v2.py`. Both
+//! checkpoints use the `L` architecture with `use_learnable_affine_block =
+//! false`, so the learnable-affine path is intentionally absent here.
+
+use super::err::{MODEL_NAME, infer_err};
+use crate::error::Error;
+use candle_core::{D, Tensor};
+use candle_nn::{BatchNorm, BatchNormConfig, Conv2d, Conv2dConfig, Module, ModuleT, VarBuilder};
+
+/// Stage layout of the `L` architecture, the only one these checkpoints use.
+const STEM_CHANNELS: [usize; 3] = [3, 32, 48];
+const STEM_STRIDES: [usize; 5] = [2, 1, 1, 2, 1];
+const STAGE_IN_CHANNELS: [usize; 4] = [48, 128, 512, 1024];
+const STAGE_MID_CHANNELS: [usize; 4] = [48, 96, 192, 384];
+const STAGE_OUT_CHANNELS: [usize; 4] = [128, 512, 1024, 2048];
+const STAGE_NUM_BLOCKS: [usize; 4] = [1, 1, 3, 1];
+const STAGE_DOWNSAMPLE: [bool; 4] = [false, true, true, true];
+const STAGE_DOWNSAMPLE_STRIDES: [usize; 4] = [2, 2, 2, 2];
+const STAGE_LIGHT_BLOCK: [bool; 4] = [false, false, true, true];
+const STAGE_KERNEL_SIZE: [usize; 4] = [3, 3, 5, 5];
+const STAGE_NUM_LAYERS: [usize; 4] = [6, 6, 6, 6];
+
+/// Convolution + batch norm, optionally followed by ReLU.
+#[derive(Debug)]
+struct ConvLayer {
+    conv: Conv2d,
+    norm: BatchNorm,
+    activation: bool,
+}
+
+impl ConvLayer {
+    #[allow(clippy::too_many_arguments)]
+    fn load(
+        in_channels: usize,
+        out_channels: usize,
+        kernel_size: usize,
+        stride: usize,
+        groups: usize,
+        activation: bool,
+        batch_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let cfg = Conv2dConfig {
+            padding: kernel_size.saturating_sub(1) / 2,
+            stride,
+            dilation: 1,
+            groups,
+            ..Default::default()
+        };
+        let conv = candle_nn::conv2d_no_bias(
+            in_channels,
+            out_channels,
+            kernel_size,
+            cfg,
+            vb.pp("convolution"),
+        )
+        .map_err(|e| infer_err("load backbone convolution", e))?;
+        let norm = candle_nn::batch_norm(
+            out_channels,
+            BatchNormConfig {
+                eps: batch_norm_eps,
+                ..Default::default()
+            },
+            vb.pp("normalization"),
+        )
+        .map_err(|e| infer_err("load backbone normalization", e))?;
+        Ok(Self {
+            conv,
+            norm,
+            activation,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let x = self
+            .conv
+            .forward(x)
+            .map_err(|e| infer_err("backbone convolution", e))?;
+        let x = self
+            .norm
+            .forward_t(&x, false)
+            .map_err(|e| infer_err("backbone normalization", e))?;
+        if self.activation {
+            x.relu().map_err(|e| infer_err("backbone relu", e))
+        } else {
+            Ok(x)
+        }
+    }
+}
+
+/// Pointwise convolution followed by a depthwise one, used by the light stages.
+#[derive(Debug)]
+struct ConvLayerLight {
+    conv1: ConvLayer,
+    conv2: ConvLayer,
+}
+
+impl ConvLayerLight {
+    fn load(
+        in_channels: usize,
+        out_channels: usize,
+        kernel_size: usize,
+        batch_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            conv1: ConvLayer::load(
+                in_channels,
+                out_channels,
+                1,
+                1,
+                1,
+                false,
+                batch_norm_eps,
+                vb.pp("conv1"),
+            )?,
+            conv2: ConvLayer::load(
+                out_channels,
+                out_channels,
+                kernel_size,
+                1,
+                out_channels,
+                true,
+                batch_norm_eps,
+                vb.pp("conv2"),
+            )?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        self.conv2.forward(&self.conv1.forward(x)?)
+    }
+}
+
+#[derive(Debug)]
+enum BlockLayer {
+    Basic(ConvLayer),
+    Light(ConvLayerLight),
+}
+
+impl BlockLayer {
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        match self {
+            Self::Basic(layer) => layer.forward(x),
+            Self::Light(layer) => layer.forward(x),
+        }
+    }
+}
+
+/// One HGNetV2 block: `layer_num` convolutions whose outputs are concatenated
+/// with the input and squeezed back down by the two aggregation convolutions.
+#[derive(Debug)]
+struct BasicLayer {
+    layers: Vec<BlockLayer>,
+    aggregation: Vec<ConvLayer>,
+    residual: bool,
+}
+
+impl BasicLayer {
+    #[allow(clippy::too_many_arguments)]
+    fn load(
+        in_channels: usize,
+        middle_channels: usize,
+        out_channels: usize,
+        layer_num: usize,
+        kernel_size: usize,
+        residual: bool,
+        light_block: bool,
+        batch_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let layers_vb = vb.pp("layers");
+        let mut layers = Vec::with_capacity(layer_num);
+        for i in 0..layer_num {
+            let layer_in = if i == 0 { in_channels } else { middle_channels };
+            let vb_i = layers_vb.pp(i);
+            layers.push(if light_block {
+                BlockLayer::Light(ConvLayerLight::load(
+                    layer_in,
+                    middle_channels,
+                    kernel_size,
+                    batch_norm_eps,
+                    vb_i,
+                )?)
+            } else {
+                BlockLayer::Basic(ConvLayer::load(
+                    layer_in,
+                    middle_channels,
+                    kernel_size,
+                    1,
+                    1,
+                    true,
+                    batch_norm_eps,
+                    vb_i,
+                )?)
+            });
+        }
+
+        let total_channels = in_channels + layer_num * middle_channels;
+        let aggregation_vb = vb.pp("aggregation");
+        let aggregation = vec![
+            ConvLayer::load(
+                total_channels,
+                out_channels / 2,
+                1,
+                1,
+                1,
+                true,
+                batch_norm_eps,
+                aggregation_vb.pp(0),
+            )?,
+            ConvLayer::load(
+                out_channels / 2,
+                out_channels,
+                1,
+                1,
+                1,
+                true,
+                batch_norm_eps,
+                aggregation_vb.pp(1),
+            )?,
+        ];
+
+        Ok(Self {
+            layers,
+            aggregation,
+            residual,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let mut outputs = Vec::with_capacity(self.layers.len() + 1);
+        outputs.push(x.clone());
+        let mut hidden = x.clone();
+        for layer in &self.layers {
+            hidden = layer.forward(&hidden)?;
+            outputs.push(hidden.clone());
+        }
+        let mut hidden =
+            Tensor::cat(&outputs, 1).map_err(|e| infer_err("backbone block concat", e))?;
+        for conv in &self.aggregation {
+            hidden = conv.forward(&hidden)?;
+        }
+        if self.residual {
+            hidden = (hidden + x).map_err(|e| infer_err("backbone block residual", e))?;
+        }
+        Ok(hidden)
+    }
+}
+
+#[derive(Debug)]
+struct Stage {
+    downsample: Option<ConvLayer>,
+    blocks: Vec<BasicLayer>,
+}
+
+impl Stage {
+    fn load(index: usize, batch_norm_eps: f64, vb: VarBuilder) -> Result<Self, Error> {
+        let in_channels = STAGE_IN_CHANNELS[index];
+        let mid_channels = STAGE_MID_CHANNELS[index];
+        let out_channels = STAGE_OUT_CHANNELS[index];
+        let num_layers = STAGE_NUM_LAYERS[index];
+        let kernel_size = STAGE_KERNEL_SIZE[index];
+        let light_block = STAGE_LIGHT_BLOCK[index];
+
+        let downsample = if STAGE_DOWNSAMPLE[index] {
+            Some(ConvLayer::load(
+                in_channels,
+                in_channels,
+                3,
+                STAGE_DOWNSAMPLE_STRIDES[index],
+                in_channels,
+                false,
+                batch_norm_eps,
+                vb.pp("downsample"),
+            )?)
+        } else {
+            None
+        };
+
+        let blocks_vb = vb.pp("blocks");
+        let mut blocks = Vec::with_capacity(STAGE_NUM_BLOCKS[index]);
+        for i in 0..STAGE_NUM_BLOCKS[index] {
+            blocks.push(BasicLayer::load(
+                if i == 0 { in_channels } else { out_channels },
+                mid_channels,
+                out_channels,
+                num_layers,
+                kernel_size,
+                i != 0,
+                light_block,
+                batch_norm_eps,
+                blocks_vb.pp(i),
+            )?);
+        }
+
+        Ok(Self { downsample, blocks })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let mut hidden = match &self.downsample {
+            Some(conv) => conv.forward(x)?,
+            None => x.clone(),
+        };
+        for block in &self.blocks {
+            hidden = block.forward(&hidden)?;
+        }
+        Ok(hidden)
+    }
+}
+
+/// Stem: two parallel paths (max-pooled and doubly-convolved) concatenated,
+/// then squeezed by `stem3`/`stem4`.
+#[derive(Debug)]
+struct Embeddings {
+    stem1: ConvLayer,
+    stem2a: ConvLayer,
+    stem2b: ConvLayer,
+    stem3: ConvLayer,
+    stem4: ConvLayer,
+}
+
+impl Embeddings {
+    fn load(batch_norm_eps: f64, vb: VarBuilder) -> Result<Self, Error> {
+        let c = STEM_CHANNELS;
+        Ok(Self {
+            stem1: ConvLayer::load(
+                c[0],
+                c[1],
+                3,
+                STEM_STRIDES[0],
+                1,
+                true,
+                batch_norm_eps,
+                vb.pp("stem1"),
+            )?,
+            stem2a: ConvLayer::load(
+                c[1],
+                c[1] / 2,
+                2,
+                STEM_STRIDES[1],
+                1,
+                true,
+                batch_norm_eps,
+                vb.pp("stem2a"),
+            )?,
+            stem2b: ConvLayer::load(
+                c[1] / 2,
+                c[1],
+                2,
+                STEM_STRIDES[2],
+                1,
+                true,
+                batch_norm_eps,
+                vb.pp("stem2b"),
+            )?,
+            stem3: ConvLayer::load(
+                c[1] * 2,
+                c[1],
+                3,
+                STEM_STRIDES[3],
+                1,
+                true,
+                batch_norm_eps,
+                vb.pp("stem3"),
+            )?,
+            stem4: ConvLayer::load(
+                c[1],
+                c[2],
+                1,
+                STEM_STRIDES[4],
+                1,
+                true,
+                batch_norm_eps,
+                vb.pp("stem4"),
+            )?,
+        })
+    }
+
+    fn forward(&self, pixel_values: &Tensor) -> Result<Tensor, Error> {
+        let embedding = self.stem1.forward(pixel_values)?;
+        // Torch pads right/bottom by one before each 2x2 stride-1 convolution,
+        // and max-pools the padded tensor so both branches keep the same size.
+        let padded = pad_right_bottom(&embedding)?;
+        let branch = self.stem2a.forward(&padded)?;
+        let branch = self.stem2b.forward(&pad_right_bottom(&branch)?)?;
+        let pooled = padded
+            .max_pool2d_with_stride(2, 1)
+            .map_err(|e| infer_err("backbone stem pooling", e))?;
+        let embedding = Tensor::cat(&[&pooled, &branch], 1)
+            .map_err(|e| infer_err("backbone stem concat", e))?;
+        let embedding = self.stem3.forward(&embedding)?;
+        self.stem4.forward(&embedding)
+    }
+}
+
+/// Replicates `torch.nn.functional.pad(x, (0, 1, 0, 1))`: one zero column on
+/// the right and one zero row at the bottom.
+fn pad_right_bottom(x: &Tensor) -> Result<Tensor, Error> {
+    let x = x
+        .pad_with_zeros(D::Minus1, 0, 1)
+        .map_err(|e| infer_err("backbone stem pad width", e))?;
+    x.pad_with_zeros(D::Minus2, 0, 1)
+        .map_err(|e| infer_err("backbone stem pad height", e))
+}
+
+/// HGNetV2-L backbone returning the requested stage feature maps.
+#[derive(Debug)]
+pub(super) struct HGNetV2 {
+    embedder: Embeddings,
+    stages: Vec<Stage>,
+    return_idx: Vec<usize>,
+}
+
+impl HGNetV2 {
+    /// `return_idx` selects which stages to return, e.g. `[1, 2, 3]` for
+    /// stage2/stage3/stage4.
+    pub(super) fn load(
+        return_idx: &[usize],
+        batch_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let vb = vb.pp("model");
+        let embedder = Embeddings::load(batch_norm_eps, vb.pp("embedder"))?;
+        let stages_vb = vb.pp("encoder").pp("stages");
+        let mut stages = Vec::with_capacity(STAGE_IN_CHANNELS.len());
+        for index in 0..STAGE_IN_CHANNELS.len() {
+            stages.push(Stage::load(index, batch_norm_eps, stages_vb.pp(index))?);
+        }
+        if let Some(&bad) = return_idx.iter().find(|&&i| i >= stages.len()) {
+            return Err(Error::Config {
+                message: format!("{MODEL_NAME}: backbone return_idx {bad} is out of range"),
+            });
+        }
+        Ok(Self {
+            embedder,
+            stages,
+            return_idx: return_idx.to_vec(),
+        })
+    }
+
+    /// Runs the backbone, returning one feature map per entry of `return_idx`.
+    pub(super) fn forward(&self, pixel_values: &Tensor) -> Result<Vec<Tensor>, Error> {
+        let mut hidden = self.embedder.forward(pixel_values)?;
+        let mut outputs = Vec::with_capacity(self.return_idx.len());
+        for (index, stage) in self.stages.iter().enumerate() {
+            hidden = stage.forward(&hidden)?;
+            if self.return_idx.contains(&index) {
+                outputs.push(hidden.clone());
+            }
+        }
+        Ok(outputs)
+    }
+}

--- a/oar-ocr-vl/src/pp_doclayout/layers.rs
+++ b/oar-ocr-vl/src/pp_doclayout/layers.rs
@@ -1,0 +1,214 @@
+//! Small building blocks shared by the PP-DocLayout encoder and decoder.
+
+use super::err::infer_err;
+use crate::error::Error;
+use candle_core::Tensor;
+use candle_nn::{BatchNorm, BatchNormConfig, Conv2d, Conv2dConfig, Module, ModuleT, VarBuilder};
+
+/// The activations these checkpoints use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Activation {
+    Identity,
+    Relu,
+    Silu,
+    Gelu,
+}
+
+impl Activation {
+    /// Resolves an activation name from `config.json`.
+    pub(super) fn parse(name: &str) -> Result<Self, Error> {
+        match name {
+            "relu" => Ok(Self::Relu),
+            "silu" | "swish" => Ok(Self::Silu),
+            "gelu" => Ok(Self::Gelu),
+            "identity" | "none" => Ok(Self::Identity),
+            other => Err(Error::Config {
+                message: format!("PP-DocLayout: unsupported activation '{other}'"),
+            }),
+        }
+    }
+
+    pub(super) fn apply(&self, x: &Tensor) -> Result<Tensor, Error> {
+        match self {
+            Self::Identity => Ok(x.clone()),
+            Self::Relu => x.relu().map_err(|e| infer_err("relu", e)),
+            Self::Silu => x.silu().map_err(|e| infer_err("silu", e)),
+            Self::Gelu => x.gelu_erf().map_err(|e| infer_err("gelu", e)),
+        }
+    }
+}
+
+/// Convolution, batch norm and an optional activation, the RT-DETR
+/// `ConvNormLayer`.
+#[derive(Debug)]
+pub(super) struct ConvNormLayer {
+    conv: Conv2d,
+    norm: BatchNorm,
+    activation: Activation,
+}
+
+impl ConvNormLayer {
+    /// `padding` defaults to `(kernel_size - 1) / 2` when `None`.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn load(
+        in_channels: usize,
+        out_channels: usize,
+        kernel_size: usize,
+        stride: usize,
+        padding: Option<usize>,
+        activation: Activation,
+        batch_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let cfg = Conv2dConfig {
+            padding: padding.unwrap_or(kernel_size.saturating_sub(1) / 2),
+            stride,
+            dilation: 1,
+            groups: 1,
+            ..Default::default()
+        };
+        Ok(Self {
+            conv: candle_nn::conv2d_no_bias(
+                in_channels,
+                out_channels,
+                kernel_size,
+                cfg,
+                vb.pp("conv"),
+            )
+            .map_err(|e| infer_err("load conv-norm convolution", e))?,
+            norm: candle_nn::batch_norm(
+                out_channels,
+                BatchNormConfig {
+                    eps: batch_norm_eps,
+                    ..Default::default()
+                },
+                vb.pp("norm"),
+            )
+            .map_err(|e| infer_err("load conv-norm normalization", e))?,
+            activation,
+        })
+    }
+
+    pub(super) fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let x = self
+            .conv
+            .forward(x)
+            .map_err(|e| infer_err("conv-norm convolution", e))?;
+        let x = self
+            .norm
+            .forward_t(&x, false)
+            .map_err(|e| infer_err("conv-norm normalization", e))?;
+        self.activation.apply(&x)
+    }
+}
+
+/// `nn.Sequential(Conv2d(bias=False), BatchNorm2d)`, stored with numeric child
+/// names in the checkpoints.
+#[derive(Debug)]
+pub(super) struct SequentialConvNorm {
+    conv: Conv2d,
+    norm: BatchNorm,
+}
+
+impl SequentialConvNorm {
+    pub(super) fn load(
+        in_channels: usize,
+        out_channels: usize,
+        kernel_size: usize,
+        stride: usize,
+        batch_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let cfg = Conv2dConfig {
+            padding: kernel_size.saturating_sub(1) / 2,
+            stride,
+            dilation: 1,
+            groups: 1,
+            ..Default::default()
+        };
+        Ok(Self {
+            conv: candle_nn::conv2d_no_bias(in_channels, out_channels, kernel_size, cfg, vb.pp(0))
+                .map_err(|e| infer_err("load input projection convolution", e))?,
+            norm: candle_nn::batch_norm(
+                out_channels,
+                BatchNormConfig {
+                    eps: batch_norm_eps,
+                    ..Default::default()
+                },
+                vb.pp(1),
+            )
+            .map_err(|e| infer_err("load input projection normalization", e))?,
+        })
+    }
+
+    pub(super) fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let x = self
+            .conv
+            .forward(x)
+            .map_err(|e| infer_err("input projection convolution", e))?;
+        self.norm
+            .forward_t(&x, false)
+            .map_err(|e| infer_err("input projection normalization", e))
+    }
+}
+
+/// Convolution, batch norm and activation stored under the `convolution` /
+/// `normalization` names (`ResNetConvLayer` upstream).
+#[derive(Debug)]
+pub(super) struct NamedConvNormLayer {
+    conv: Conv2d,
+    norm: BatchNorm,
+    activation: Activation,
+}
+
+impl NamedConvNormLayer {
+    pub(super) fn load(
+        in_channels: usize,
+        out_channels: usize,
+        kernel_size: usize,
+        stride: usize,
+        activation: Activation,
+        batch_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let cfg = Conv2dConfig {
+            padding: kernel_size.saturating_sub(1) / 2,
+            stride,
+            dilation: 1,
+            groups: 1,
+            ..Default::default()
+        };
+        Ok(Self {
+            conv: candle_nn::conv2d_no_bias(
+                in_channels,
+                out_channels,
+                kernel_size,
+                cfg,
+                vb.pp("convolution"),
+            )
+            .map_err(|e| infer_err("load mask convolution", e))?,
+            norm: candle_nn::batch_norm(
+                out_channels,
+                BatchNormConfig {
+                    eps: batch_norm_eps,
+                    ..Default::default()
+                },
+                vb.pp("normalization"),
+            )
+            .map_err(|e| infer_err("load mask normalization", e))?,
+            activation,
+        })
+    }
+
+    pub(super) fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let x = self
+            .conv
+            .forward(x)
+            .map_err(|e| infer_err("mask convolution", e))?;
+        let x = self
+            .norm
+            .forward_t(&x, false)
+            .map_err(|e| infer_err("mask normalization", e))?;
+        self.activation.apply(&x)
+    }
+}

--- a/oar-ocr-vl/src/pp_doclayout/mask_head.rs
+++ b/oar-ocr-vl/src/pp_doclayout/mask_head.rs
@@ -1,0 +1,290 @@
+//! PP-DocLayoutV3 mask-feature branch.
+//!
+//! Ported from `PPDocLayoutV3MaskFeatFPN`, `PPDocLayoutV3ScaleHead` and
+//! `PPDocLayoutV3EncoderMaskOutput` in
+//! `transformers/models/pp_doclayout_v3/modular_pp_doclayout_v3.py`.
+//!
+//! The prototypes it produces are not just cosmetic: with `mask_enhanced`
+//! (the upstream default) the decoder's initial reference boxes are derived
+//! from the predicted masks rather than from the encoder's box head.
+
+use super::config::PpDocLayoutConfig;
+use super::err::infer_err;
+use super::layers::{Activation, NamedConvNormLayer};
+use crate::error::Error;
+use candle_core::Tensor;
+use candle_nn::{Conv2d, Conv2dConfig, Module, VarBuilder};
+
+/// Brings one feature level up to the finest stride with a conv per doubling.
+#[derive(Debug)]
+struct ScaleHead {
+    layers: Vec<NamedConvNormLayer>,
+    upsample: bool,
+}
+
+impl ScaleHead {
+    fn load(
+        in_channels: usize,
+        feature_channels: usize,
+        fpn_stride: usize,
+        base_stride: usize,
+        batch_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let ratio = (fpn_stride as f64 / base_stride as f64).log2().round() as i64;
+        let head_length = ratio.max(1) as usize;
+        let upsample = fpn_stride != base_stride;
+
+        let layers_vb = vb.pp("layers");
+        let mut layers = Vec::with_capacity(head_length);
+        // Upstream interleaves `Upsample` modules into the same `ModuleList`,
+        // but only the convolutions carry parameters, so the checkpoint index
+        // advances by two whenever an upsample follows.
+        let stride_between = if upsample { 2 } else { 1 };
+        for k in 0..head_length {
+            let in_c = if k == 0 {
+                in_channels
+            } else {
+                feature_channels
+            };
+            layers.push(NamedConvNormLayer::load(
+                in_c,
+                feature_channels,
+                3,
+                1,
+                Activation::Silu,
+                batch_norm_eps,
+                layers_vb.pp(k * stride_between),
+            )?);
+        }
+        Ok(Self { layers, upsample })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let mut hidden = x.clone();
+        for layer in &self.layers {
+            hidden = layer.forward(&hidden)?;
+            if self.upsample {
+                let (_, _, height, width) = hidden
+                    .dims4()
+                    .map_err(|e| infer_err("mask scale head shape", e))?;
+                hidden = hidden
+                    .upsample_bilinear2d(height * 2, width * 2, false)
+                    .map_err(|e| infer_err("mask scale head upsample", e))?;
+            }
+        }
+        Ok(hidden)
+    }
+}
+
+/// Fuses the PAN levels into a single stride-8 feature map.
+#[derive(Debug)]
+struct MaskFeatFpn {
+    scale_heads: Vec<ScaleHead>,
+    output_conv: NamedConvNormLayer,
+    order: Vec<usize>,
+}
+
+impl MaskFeatFpn {
+    fn load(cfg: &PpDocLayoutConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let strides = cfg.strides();
+        let feature_channels = *cfg
+            .mask_feature_channels
+            .first()
+            .ok_or_else(|| Error::Config {
+                message: "PP-DocLayoutV3: mask_feature_channels must have two entries".to_string(),
+            })?;
+        let out_channels = *cfg
+            .mask_feature_channels
+            .get(1)
+            .ok_or_else(|| Error::Config {
+                message: "PP-DocLayoutV3: mask_feature_channels must have two entries".to_string(),
+            })?;
+
+        let mut order: Vec<usize> = (0..strides.len()).collect();
+        order.sort_by_key(|&i| strides[i]);
+        let base_stride = strides[order[0]];
+
+        let heads_vb = vb.pp("scale_heads");
+        let mut scale_heads = Vec::with_capacity(order.len());
+        for (slot, &level) in order.iter().enumerate() {
+            scale_heads.push(ScaleHead::load(
+                cfg.encoder_hidden_dim,
+                feature_channels,
+                strides[level],
+                base_stride,
+                cfg.batch_norm_eps,
+                heads_vb.pp(slot),
+            )?);
+        }
+
+        Ok(Self {
+            scale_heads,
+            output_conv: NamedConvNormLayer::load(
+                feature_channels,
+                out_channels,
+                3,
+                1,
+                Activation::Silu,
+                cfg.batch_norm_eps,
+                vb.pp("output_conv"),
+            )?,
+            order,
+        })
+    }
+
+    fn forward(&self, features: &[Tensor]) -> Result<Tensor, Error> {
+        let mut output = self.scale_heads[0].forward(&features[self.order[0]])?;
+        let (_, _, height, width) = output.dims4().map_err(|e| infer_err("mask fpn shape", e))?;
+        for (slot, &level) in self.order.iter().enumerate().skip(1) {
+            let scaled = self.scale_heads[slot].forward(&features[level])?;
+            let scaled = scaled
+                .upsample_bilinear2d(height, width, false)
+                .map_err(|e| infer_err("mask fpn resize", e))?;
+            output = (output + scaled).map_err(|e| infer_err("mask fpn merge", e))?;
+        }
+        self.output_conv.forward(&output)
+    }
+}
+
+/// Final projection to mask prototypes.
+#[derive(Debug)]
+struct MaskOutput {
+    base_conv: NamedConvNormLayer,
+    conv: Conv2d,
+}
+
+impl MaskOutput {
+    fn load(
+        in_channels: usize,
+        num_prototypes: usize,
+        batch_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            base_conv: NamedConvNormLayer::load(
+                in_channels,
+                in_channels,
+                3,
+                1,
+                Activation::Silu,
+                batch_norm_eps,
+                vb.pp("base_conv"),
+            )?,
+            conv: candle_nn::conv2d(
+                in_channels,
+                num_prototypes,
+                1,
+                Conv2dConfig::default(),
+                vb.pp("conv"),
+            )
+            .map_err(|e| infer_err("load mask output convolution", e))?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor, Error> {
+        let x = self.base_conv.forward(x)?;
+        self.conv
+            .forward(&x)
+            .map_err(|e| infer_err("mask output convolution", e))
+    }
+}
+
+/// The complete V3 mask branch: FPN over the PAN levels, a stride-4 lateral
+/// shortcut, and the prototype projection.
+#[derive(Debug)]
+pub(super) struct MaskFeatureHead {
+    fpn: MaskFeatFpn,
+    lateral: NamedConvNormLayer,
+    output: MaskOutput,
+}
+
+impl MaskFeatureHead {
+    pub(super) fn load(cfg: &PpDocLayoutConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let out_channels = *cfg
+            .mask_feature_channels
+            .get(1)
+            .ok_or_else(|| Error::Config {
+                message: "PP-DocLayoutV3: mask_feature_channels must have two entries".to_string(),
+            })?;
+        Ok(Self {
+            fpn: MaskFeatFpn::load(cfg, vb.pp("mask_feature_head"))?,
+            lateral: NamedConvNormLayer::load(
+                cfg.x4_feat_dim,
+                out_channels,
+                3,
+                1,
+                Activation::Silu,
+                cfg.batch_norm_eps,
+                vb.pp("encoder_mask_lateral"),
+            )?,
+            output: MaskOutput::load(
+                out_channels,
+                cfg.num_prototypes,
+                cfg.batch_norm_eps,
+                vb.pp("encoder_mask_output"),
+            )?,
+        })
+    }
+
+    /// `pan` are the encoder's output levels, `x4` the stride-4 backbone map.
+    pub(super) fn forward(&self, pan: &[Tensor], x4: &Tensor) -> Result<Tensor, Error> {
+        let fused = self.fpn.forward(pan)?;
+        let (_, _, height, width) = fused
+            .dims4()
+            .map_err(|e| infer_err("mask feature shape", e))?;
+        let upsampled = fused
+            .upsample_bilinear2d(height * 2, width * 2, false)
+            .map_err(|e| infer_err("mask feature upsample", e))?;
+        let lateral = self.lateral.forward(x4)?;
+        let merged = (upsampled + lateral).map_err(|e| infer_err("mask feature merge", e))?;
+        self.output.forward(&merged)
+    }
+}
+
+/// Tight boxes around each positive mask, in normalized cxcywh form.
+///
+/// Empty masks collapse to an all-zero box, matching
+/// `mask_to_box_coordinate` upstream.
+pub(super) fn mask_to_box_coordinate(masks: &Tensor) -> Result<Tensor, Error> {
+    let (batch, count, height, width) =
+        masks.dims4().map_err(|e| infer_err("mask box shape", e))?;
+    let values = masks
+        .flatten_all()
+        .and_then(|t| t.to_vec1::<f32>())
+        .map_err(|e| infer_err("mask box to host", e))?;
+
+    let mut boxes = Vec::with_capacity(batch * count * 4);
+    for plane in 0..batch * count {
+        let mask = &values[plane * height * width..(plane + 1) * height * width];
+        let mut x_min = usize::MAX;
+        let mut y_min = usize::MAX;
+        let mut x_max = 0usize;
+        let mut y_max = 0usize;
+        let mut any = false;
+        for y in 0..height {
+            for x in 0..width {
+                if mask[y * width + x] > 0.0 {
+                    any = true;
+                    x_min = x_min.min(x);
+                    y_min = y_min.min(y);
+                    x_max = x_max.max(x);
+                    y_max = y_max.max(y);
+                }
+            }
+        }
+        if !any {
+            boxes.extend_from_slice(&[0.0; 4]);
+            continue;
+        }
+        // Upstream takes the exclusive maximum, hence the `+ 1`.
+        let x0 = x_min as f32 / width as f32;
+        let y0 = y_min as f32 / height as f32;
+        let x1 = (x_max + 1) as f32 / width as f32;
+        let y1 = (y_max + 1) as f32 / height as f32;
+        boxes.extend_from_slice(&[(x0 + x1) * 0.5, (y0 + y1) * 0.5, x1 - x0, y1 - y0]);
+    }
+
+    Tensor::from_vec(boxes, (batch, count, 4), masks.device())
+        .map_err(|e| infer_err("mask box tensor", e))
+}

--- a/oar-ocr-vl/src/pp_doclayout/mod.rs
+++ b/oar-ocr-vl/src/pp_doclayout/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let layout = PpDocLayout::from_dir(
-//!     "PaddlePaddle/PP-DocLayoutV2",
+//!     "PaddlePaddle/PP-DocLayoutV2_safetensors",
 //!     parse_device("cpu")?,
 //! )?;
 //! # let _ = layout;

--- a/oar-ocr-vl/src/pp_doclayout/mod.rs
+++ b/oar-ocr-vl/src/pp_doclayout/mod.rs
@@ -1,0 +1,44 @@
+//! Native Candle implementation of PP-DocLayoutV2 and PP-DocLayoutV3.
+//!
+//! Both checkpoints share an RT-DETR detector (HGNetV2-L backbone, hybrid
+//! encoder, deformable-attention decoder) and differ in how they predict
+//! reading order: V2 runs a separate LayoutLM-style pointer network over the
+//! surviving boxes, V3 an order head inside the decoder.
+//!
+//! Running these on Candle is what lets `oar-ocr-vl` stay ONNX-free.
+//! [`PpDocLayout`] implements
+//! [`LayoutSource`](crate::layout::LayoutSource), so it drops straight into
+//! [`DocParser`](crate::DocParser):
+//!
+//! ```no_run
+//! use oar_ocr_vl::pp_doclayout::PpDocLayout;
+//! use oar_ocr_vl::utils::parse_device;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let layout = PpDocLayout::from_dir(
+//!     "PaddlePaddle/PP-DocLayoutV2",
+//!     parse_device("cpu")?,
+//! )?;
+//! # let _ = layout;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Weights are the `model.safetensors` checkpoints published as
+//! `PaddlePaddle/PP-DocLayoutV2_safetensors` and
+//! `PaddlePaddle/PP-DocLayoutV3_safetensors`.
+
+mod config;
+mod decoder;
+mod encoder;
+mod err;
+mod hgnetv2;
+mod layers;
+mod mask_head;
+mod model;
+mod order;
+mod processing;
+mod reading_order;
+
+pub use config::{PpDocLayoutConfig, PpDocLayoutVersion, ReadingOrderConfig};
+pub use model::{Detection, PpDocLayout};

--- a/oar-ocr-vl/src/pp_doclayout/model.rs
+++ b/oar-ocr-vl/src/pp_doclayout/model.rs
@@ -1,0 +1,879 @@
+//! PP-DocLayoutV2 / V3 assembly: backbone, hybrid encoder, query selection,
+//! decoder and reading order, plus the public [`PpDocLayout`] entry point.
+//!
+//! V3 also runs a mask branch: its prototypes set the decoder's initial
+//! reference boxes when `mask_enhanced` is on (the upstream default), so it is
+//! ported here. The per-layer instance masks it can also produce are not,
+//! because every consumer of this detector works with axis-aligned boxes.
+
+use super::config::{PpDocLayoutConfig, PpDocLayoutVersion};
+use super::decoder::{Decoder, LevelShape, MlpPredictionHead, SharedHeads, inverse_sigmoid};
+use super::encoder::HybridEncoder;
+use super::err::{MODEL_NAME, infer_err};
+use super::hgnetv2::HGNetV2;
+use super::layers::SequentialConvNorm;
+use super::mask_head::mask_to_box_coordinate;
+use super::order::order_sequence;
+use super::processing::{PreprocessedImage, preprocess};
+use super::reading_order::ReadingOrder;
+use crate::error::Error;
+use crate::geometry::BoundingBox;
+use crate::layout::LayoutDetectionElement;
+use crate::layout::{LayoutDetections, LayoutSource};
+use candle_core::{DType, Device, Tensor};
+use candle_nn::{LayerNorm, Linear, Module, VarBuilder, layer_norm, linear};
+use image::RgbImage;
+use std::path::Path;
+
+/// A single detected region before it is turned into a layout element.
+#[derive(Debug, Clone)]
+pub struct Detection {
+    /// Box in original-image pixel coordinates, `[x1, y1, x2, y2]`.
+    pub bbox: [f32; 4],
+    /// Detection class id.
+    pub class_id: usize,
+    /// Sigmoid confidence.
+    pub score: f32,
+}
+
+/// The V3-only order head: a per-layer projection feeding a shared global
+/// pointer.
+#[derive(Debug)]
+struct V3OrderHead {
+    norm: LayerNorm,
+    order_heads: Vec<Linear>,
+    pointer: Linear,
+    head_size: usize,
+    /// Projects decoder queries onto the mask prototypes. With
+    /// `mask_enhanced`, the resulting masks set the decoder's initial boxes.
+    mask_query_head: MlpPredictionHead,
+    mask_enhanced: bool,
+}
+
+impl V3OrderHead {
+    fn load(cfg: &PpDocLayoutConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let order_vb = vb.pp("decoder_order_head");
+        let mut order_heads = Vec::with_capacity(cfg.decoder_layers);
+        for i in 0..cfg.decoder_layers {
+            order_heads.push(
+                linear(cfg.d_model, cfg.d_model, order_vb.pp(i))
+                    .map_err(|e| infer_err("load v3 order head", e))?,
+            );
+        }
+        Ok(Self {
+            norm: layer_norm(cfg.d_model, cfg.layer_norm_eps, vb.pp("decoder_norm"))
+                .map_err(|e| infer_err("load v3 decoder norm", e))?,
+            order_heads,
+            pointer: linear(
+                cfg.d_model,
+                cfg.global_pointer_head_size * 2,
+                vb.pp("decoder_global_pointer").pp("dense"),
+            )
+            .map_err(|e| infer_err("load v3 global pointer", e))?,
+            head_size: cfg.global_pointer_head_size,
+            mask_query_head: MlpPredictionHead::load(
+                cfg.d_model,
+                cfg.d_model,
+                cfg.num_prototypes,
+                3,
+                vb.pp("mask_query_head"),
+            )?,
+            mask_enhanced: cfg.mask_enhanced,
+        })
+    }
+
+    /// The layer norm applied to decoder states before the class and order
+    /// heads.
+    fn norm(&self) -> &LayerNorm {
+        &self.norm
+    }
+}
+
+/// The detector trunk shared by both versions.
+#[derive(Debug)]
+struct Detector {
+    backbone: HGNetV2,
+    encoder_input_proj: Vec<SequentialConvNorm>,
+    encoder: HybridEncoder,
+    decoder_input_proj: Vec<SequentialConvNorm>,
+    enc_output_dense: Linear,
+    enc_output_norm: LayerNorm,
+    enc_score_head: Linear,
+    enc_bbox_head: MlpPredictionHead,
+    decoder: Decoder,
+    num_queries: usize,
+}
+
+impl Detector {
+    fn load(
+        cfg: &PpDocLayoutConfig,
+        version: PpDocLayoutVersion,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        let vb = vb.pp("model");
+        let shared_heads = version == PpDocLayoutVersion::V3;
+        let backbone = HGNetV2::load(
+            &cfg.backbone_return_idx(),
+            cfg.batch_norm_eps,
+            vb.pp("backbone"),
+        )?;
+
+        let encoder_proj_vb = vb.pp("encoder_input_proj");
+        let mut encoder_input_proj = Vec::with_capacity(cfg.encoder_in_channels.len());
+        for (i, &in_channels) in cfg.encoder_in_channels.iter().enumerate() {
+            encoder_input_proj.push(SequentialConvNorm::load(
+                in_channels,
+                cfg.encoder_hidden_dim,
+                1,
+                1,
+                cfg.batch_norm_eps,
+                encoder_proj_vb.pp(i),
+            )?);
+        }
+
+        let decoder_proj_vb = vb.pp("decoder_input_proj");
+        let mut decoder_input_proj = Vec::with_capacity(cfg.decoder_in_channels.len());
+        for (i, &in_channels) in cfg.decoder_in_channels.iter().enumerate() {
+            decoder_input_proj.push(SequentialConvNorm::load(
+                in_channels,
+                cfg.d_model,
+                1,
+                1,
+                cfg.batch_norm_eps,
+                decoder_proj_vb.pp(i),
+            )?);
+        }
+
+        let enc_output_vb = vb.pp("enc_output");
+        Ok(Self {
+            backbone,
+            encoder_input_proj,
+            encoder: HybridEncoder::load(cfg, shared_heads, vb.pp("encoder"))?,
+            decoder_input_proj,
+            enc_output_dense: linear(cfg.d_model, cfg.d_model, enc_output_vb.pp(0))
+                .map_err(|e| infer_err("load enc_output dense", e))?,
+            enc_output_norm: layer_norm(cfg.d_model, cfg.layer_norm_eps, enc_output_vb.pp(1))
+                .map_err(|e| infer_err("load enc_output norm", e))?,
+            enc_score_head: linear(cfg.d_model, cfg.num_labels(), vb.pp("enc_score_head"))
+                .map_err(|e| infer_err("load enc_score_head", e))?,
+            enc_bbox_head: MlpPredictionHead::load(
+                cfg.d_model,
+                cfg.d_model,
+                4,
+                3,
+                vb.pp("enc_bbox_head"),
+            )?,
+            decoder: Decoder::load(cfg, shared_heads, vb.pp("decoder"))?,
+            num_queries: cfg.num_queries,
+        })
+    }
+}
+
+/// Anchor priors in logit space, plus the validity mask that zeroes out anchors
+/// too close to the image border.
+fn generate_anchors(shapes: &[LevelShape], device: &Device) -> Result<(Tensor, Tensor), Error> {
+    const GRID_SIZE: f32 = 0.05;
+    const EPS: f32 = 1e-2;
+
+    let total: usize = shapes.iter().map(|s| s.height * s.width).sum();
+    let mut anchors = Vec::with_capacity(total * 4);
+    let mut valid = Vec::with_capacity(total);
+    for (level, shape) in shapes.iter().enumerate() {
+        let wh = GRID_SIZE * 2f32.powi(level as i32);
+        for y in 0..shape.height {
+            for x in 0..shape.width {
+                let cx = (x as f32 + 0.5) / shape.width as f32;
+                let cy = (y as f32 + 0.5) / shape.height as f32;
+                let coords = [cx, cy, wh, wh];
+                let is_valid = coords.iter().all(|&c| c > EPS && c < 1.0 - EPS);
+                valid.push(if is_valid { 1.0f32 } else { 0.0 });
+                for &c in &coords {
+                    anchors.push(if is_valid {
+                        (c / (1.0 - c)).ln()
+                    } else {
+                        f32::MAX
+                    });
+                }
+            }
+        }
+    }
+
+    let anchors = Tensor::from_vec(anchors, (1, total, 4), device)
+        .map_err(|e| infer_err("build anchors", e))?;
+    let valid = Tensor::from_vec(valid, (1, total, 1), device)
+        .map_err(|e| infer_err("build anchor mask", e))?;
+    Ok((anchors, valid))
+}
+
+/// Native PP-DocLayoutV2 / V3 layout detector.
+#[derive(Debug)]
+pub struct PpDocLayout {
+    detector: Detector,
+    reading_order: Option<ReadingOrder>,
+    v3_order: Option<V3OrderHead>,
+    config: PpDocLayoutConfig,
+    version: PpDocLayoutVersion,
+    device: Device,
+    dtype: DType,
+    score_threshold: f32,
+}
+
+impl PpDocLayout {
+    /// Default score threshold for checkpoints without per-class thresholds.
+    pub const DEFAULT_SCORE_THRESHOLD: f32 = 0.5;
+
+    /// Loads a checkpoint directory containing `config.json` and
+    /// `model.safetensors`.
+    pub fn from_dir(dir: impl AsRef<Path>, device: Device) -> Result<Self, Error> {
+        let dir = dir.as_ref();
+        let config = PpDocLayoutConfig::from_path(dir.join("config.json"))?;
+        let version = config.version()?;
+
+        let weights = dir.join("model.safetensors");
+        if !weights.exists() {
+            return Err(Error::Config {
+                message: format!(
+                    "{MODEL_NAME}: {} does not contain model.safetensors",
+                    dir.display()
+                ),
+            });
+        }
+        // The checkpoints are float32 and small enough that keeping full
+        // precision costs little, and the detector is sensitive to it.
+        let dtype = DType::F32;
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&[weights], dtype, &device)
+                .map_err(|e| infer_err("map safetensors", e))?
+        };
+
+        let detector = Detector::load(&config, version, vb.clone())?;
+        let (reading_order, v3_order) = match version {
+            PpDocLayoutVersion::V2 => (
+                Some(ReadingOrder::load(
+                    &config.reading_order(),
+                    vb.pp("reading_order"),
+                )?),
+                None,
+            ),
+            PpDocLayoutVersion::V3 => (None, Some(V3OrderHead::load(&config, vb.pp("model"))?)),
+        };
+
+        Ok(Self {
+            detector,
+            reading_order,
+            v3_order,
+            config,
+            version,
+            device,
+            dtype,
+            score_threshold: Self::DEFAULT_SCORE_THRESHOLD,
+        })
+    }
+
+    /// Overrides the score threshold used when the checkpoint has no per-class
+    /// thresholds (PP-DocLayoutV3).
+    pub fn with_score_threshold(mut self, threshold: f32) -> Self {
+        self.score_threshold = threshold;
+        self
+    }
+
+    /// Which generation this instance runs.
+    pub fn version(&self) -> PpDocLayoutVersion {
+        self.version
+    }
+
+    /// The model configuration.
+    pub fn config(&self) -> &PpDocLayoutConfig {
+        &self.config
+    }
+
+    /// Detects layout regions, returning them in predicted reading order.
+    pub fn detect(&self, image: &RgbImage) -> Result<Vec<Detection>, Error> {
+        let prepared = preprocess(image, &self.device, self.dtype)?;
+        let (logits, boxes, hidden) = self.forward_detector(&prepared)?;
+        self.postprocess(&logits, &boxes, &hidden, &prepared)
+    }
+
+    /// Runs backbone, encoder and decoder, returning last-layer logits, boxes
+    /// (cxcywh, normalized) and decoder hidden states.
+    fn forward_detector(
+        &self,
+        prepared: &PreprocessedImage,
+    ) -> Result<(Tensor, Tensor, Tensor), Error> {
+        let detector = &self.detector;
+        let features = detector.backbone.forward(&prepared.pixel_values)?;
+
+        // V3's backbone also returns the stride-4 map, which feeds the mask
+        // branch rather than the encoder.
+        let skip = features
+            .len()
+            .saturating_sub(detector.encoder_input_proj.len());
+        let x4_feature = (skip > 0).then(|| features[0].clone());
+        let projected: Result<Vec<Tensor>, Error> = features[skip..]
+            .iter()
+            .zip(detector.encoder_input_proj.iter())
+            .map(|(feature, proj)| proj.forward(feature))
+            .collect();
+        let encoded = detector.encoder.forward(&projected?)?;
+        let mask_features = match &x4_feature {
+            Some(x4) => detector.encoder.mask_features(&encoded, x4)?,
+            None => None,
+        };
+
+        let mut shapes = Vec::with_capacity(encoded.len());
+        let mut flattened = Vec::with_capacity(encoded.len());
+        for (level, source) in encoded.iter().enumerate() {
+            let source = detector.decoder_input_proj[level].forward(source)?;
+            let (_, _, height, width) = source
+                .dims4()
+                .map_err(|e| infer_err("decoder source shape", e))?;
+            shapes.push(LevelShape { height, width });
+            flattened.push(
+                source
+                    .flatten_from(2)
+                    .and_then(|t| t.transpose(1, 2))
+                    .and_then(|t| t.contiguous())
+                    .map_err(|e| infer_err("decoder source flatten", e))?,
+            );
+        }
+        let source =
+            Tensor::cat(&flattened, 1).map_err(|e| infer_err("decoder source concat", e))?;
+
+        // Only the encoder head sees the anchor-masked features; the decoder
+        // cross-attends to the unmasked ones.
+        let (anchors, valid_mask) = generate_anchors(&shapes, &self.device)?;
+        let memory = source
+            .broadcast_mul(&valid_mask)
+            .map_err(|e| infer_err("anchor masking", e))?;
+        let output_memory = detector
+            .enc_output_dense
+            .forward(&memory)
+            .and_then(|t| detector.enc_output_norm.forward(&t))
+            .map_err(|e| infer_err("encoder output head", e))?;
+
+        let enc_class = detector
+            .enc_score_head
+            .forward(&output_memory)
+            .map_err(|e| infer_err("encoder score head", e))?;
+        let enc_coords = detector
+            .enc_bbox_head
+            .forward(&output_memory)?
+            .broadcast_add(&anchors)
+            .map_err(|e| infer_err("encoder box head", e))?;
+
+        let topk = self.topk_indices(&enc_class, detector.num_queries)?;
+        let index = Tensor::from_vec(topk, (1, detector.num_queries), &self.device)
+            .map_err(|e| infer_err("topk index tensor", e))?;
+
+        let reference_points = enc_coords
+            .index_select(
+                &index
+                    .flatten_all()
+                    .map_err(|e| infer_err("index flatten", e))?,
+                1,
+            )
+            .map_err(|e| infer_err("gather reference points", e))?;
+        let queries = output_memory
+            .index_select(
+                &index
+                    .flatten_all()
+                    .map_err(|e| infer_err("index flatten", e))?,
+                1,
+            )
+            .map_err(|e| infer_err("gather queries", e))?;
+
+        // PP-DocLayoutV3 replaces the encoder's initial boxes with tight boxes
+        // around the prototype masks of the selected queries.
+        let reference_points = match (&self.v3_order, &mask_features) {
+            (Some(order), Some(mask_features)) if order.mask_enhanced => {
+                let normed = order
+                    .norm
+                    .forward(&queries)
+                    .map_err(|e| infer_err("v3 query norm", e))?;
+                let mask_query = order.mask_query_head.forward(&normed)?;
+                let (_, prototypes, mask_height, mask_width) = mask_features
+                    .dims4()
+                    .map_err(|e| infer_err("mask feature shape", e))?;
+                let flat = mask_features
+                    .reshape((1, prototypes, mask_height * mask_width))
+                    .map_err(|e| infer_err("mask feature flatten", e))?;
+                let masks = mask_query
+                    .matmul(&flat)
+                    .and_then(|t| t.reshape((1, detector.num_queries, mask_height, mask_width)))
+                    .map_err(|e| infer_err("mask logits", e))?;
+                let positive = masks
+                    .gt(0f64)
+                    .and_then(|t| t.to_dtype(masks.dtype()))
+                    .map_err(|e| infer_err("mask threshold", e))?;
+                inverse_sigmoid(&mask_to_box_coordinate(&positive)?)?
+            }
+            _ => reference_points,
+        };
+
+        // V3 reuses the encoder heads inside the decoder; V2 has its own.
+        let shared = self.v3_order.as_ref().map(|order| SharedHeads {
+            class_embed: &detector.enc_score_head,
+            bbox_embed: &detector.enc_bbox_head,
+            norm: order.norm(),
+        });
+        let output =
+            detector
+                .decoder
+                .forward(&queries, &source, &reference_points, &shapes, shared)?;
+        Ok((
+            output.logits,
+            output.reference_points,
+            output.last_hidden_state,
+        ))
+    }
+
+    /// Indices of the `k` highest per-position maximum class logits, in
+    /// descending score order, matching `torch.topk`.
+    fn topk_indices(&self, enc_class: &Tensor, k: usize) -> Result<Vec<u32>, Error> {
+        let scores = enc_class
+            .max(candle_core::D::Minus1)
+            .map_err(|e| infer_err("encoder class max", e))?
+            .flatten_all()
+            .and_then(|t| t.to_vec1::<f32>())
+            .map_err(|e| infer_err("encoder class to host", e))?;
+        let mut order: Vec<u32> = (0..scores.len() as u32).collect();
+        order.sort_by(|&a, &b| {
+            scores[b as usize]
+                .total_cmp(&scores[a as usize])
+                .then(a.cmp(&b))
+        });
+        order.truncate(k);
+        Ok(order)
+    }
+
+    /// Applies thresholds and reading order, mapping boxes back to the
+    /// original image size.
+    fn postprocess(
+        &self,
+        logits: &Tensor,
+        boxes: &Tensor,
+        hidden: &Tensor,
+        prepared: &PreprocessedImage,
+    ) -> Result<Vec<Detection>, Error> {
+        let logit_values = logits
+            .flatten_all()
+            .and_then(|t| t.to_vec1::<f32>())
+            .map_err(|e| infer_err("logits to host", e))?;
+        let box_values = boxes
+            .flatten_all()
+            .and_then(|t| t.to_vec1::<f32>())
+            .map_err(|e| infer_err("boxes to host", e))?;
+
+        let selection = self.select(
+            &logit_values,
+            logits.dim(1).map_err(|e| infer_err("logits shape", e))?,
+        )?;
+        if selection.num_valid == 0 {
+            return Ok(Vec::new());
+        }
+
+        let order_logits = self.order_logits(&selection, &box_values, hidden)?;
+        let sequence = order_sequence(&order_logits)?;
+        self.collect(&selection, &sequence, &logit_values, &box_values, prepared)
+    }
+
+    /// Which queries survive thresholding, and in what order they enter the
+    /// reading-order stage.
+    ///
+    /// Upstream instead takes the top `num_queries` over the flattened
+    /// `(query, class)` score matrix, which lets one query surface twice under
+    /// two labels. Keeping the per-query argmax gives one box per query, which
+    /// is what every consumer of this detector expects; the two agree whenever
+    /// a query has a single class above its threshold.
+    fn select(&self, logits: &[f32], num_queries: usize) -> Result<Selection, Error> {
+        let num_labels = self.config.num_labels();
+        let thresholds = match self.version {
+            PpDocLayoutVersion::V2 => Some(self.config.class_thresholds.as_ref().ok_or_else(
+                || Error::Config {
+                    message: format!("{MODEL_NAME}: PP-DocLayoutV2 config has no class_thresholds"),
+                },
+            )?),
+            PpDocLayoutVersion::V3 => None,
+        };
+
+        let mut best_class = Vec::with_capacity(num_queries);
+        let mut kept = Vec::with_capacity(num_queries);
+        for q in 0..num_queries {
+            let row = &logits[q * num_labels..(q + 1) * num_labels];
+            let (class_id, &best) = row
+                .iter()
+                .enumerate()
+                .max_by(|(_, a), (_, b)| a.total_cmp(b))
+                .expect("class logits are never empty");
+            best_class.push(class_id);
+            let threshold = thresholds.map_or(self.score_threshold, |t| t[class_id]);
+            kept.push(sigmoid(best) >= threshold);
+        }
+
+        // Surviving queries move to the front, keeping their relative order.
+        let mut permutation: Vec<usize> = (0..num_queries).collect();
+        permutation.sort_by_key(|&q| !kept[q]);
+
+        Ok(Selection {
+            num_valid: kept.iter().filter(|&&k| k).count(),
+            best_class,
+            permutation,
+        })
+    }
+
+    /// Pairwise "comes before" logits over the selected queries.
+    fn order_logits(
+        &self,
+        selection: &Selection,
+        boxes: &[f32],
+        hidden: &Tensor,
+    ) -> Result<Tensor, Error> {
+        match (&self.reading_order, &self.v3_order) {
+            (Some(reading_order), _) => {
+                let class_order =
+                    self.config
+                        .class_order
+                        .as_ref()
+                        .ok_or_else(|| Error::Config {
+                            message: format!(
+                                "{MODEL_NAME}: PP-DocLayoutV2 config has no class_order"
+                            ),
+                        })?;
+                let mut ro_boxes = Vec::with_capacity(selection.permutation.len());
+                let mut ro_labels = Vec::with_capacity(selection.permutation.len());
+                for (slot, &query) in selection.permutation.iter().enumerate() {
+                    let valid = slot < selection.num_valid;
+                    // Padded slots carry a zero box and the reading-order
+                    // category of class 0, as upstream's zero-fill does.
+                    ro_boxes.push(if valid {
+                        // The pointer network consumes boxes on a 0..=1000 grid.
+                        clamped_corners(&boxes[query * 4..query * 4 + 4], 1000.0)
+                    } else {
+                        [0.0; 4]
+                    });
+                    ro_labels.push(if valid {
+                        class_order[selection.best_class[query]] as u32
+                    } else {
+                        class_order[0] as u32
+                    });
+                }
+                reading_order.forward(&ro_boxes, &ro_labels, selection.num_valid, &self.device)
+            }
+            (None, Some(order)) => self.v3_order_logits(order, hidden),
+            (None, None) => Err(Error::Config {
+                message: format!("{MODEL_NAME}: no reading-order head was loaded"),
+            }),
+        }
+    }
+
+    fn v3_order_logits(&self, order: &V3OrderHead, hidden: &Tensor) -> Result<Tensor, Error> {
+        let normed = order
+            .norm
+            .forward(hidden)
+            .map_err(|e| infer_err("v3 decoder norm", e))?;
+        let last = order.order_heads.last().ok_or_else(|| Error::Config {
+            message: format!("{MODEL_NAME}: PP-DocLayoutV3 has no order heads"),
+        })?;
+        let projected = last
+            .forward(&normed)
+            .map_err(|e| infer_err("v3 order projection", e))?;
+
+        let (batch, seq, _) = projected
+            .dims3()
+            .map_err(|e| infer_err("v3 order shape", e))?;
+        let pair = order
+            .pointer
+            .forward(&projected)
+            .and_then(|t| t.reshape((batch, seq, 2, order.head_size)))
+            .map_err(|e| infer_err("v3 global pointer", e))?;
+        let queries = pair
+            .narrow(2, 0, 1)
+            .and_then(|t| t.squeeze(2))
+            .and_then(|t| t.contiguous())
+            .map_err(|e| infer_err("v3 pointer queries", e))?;
+        let keys = pair
+            .narrow(2, 1, 1)
+            .and_then(|t| t.squeeze(2))
+            .and_then(|t| t.contiguous())
+            .map_err(|e| infer_err("v3 pointer keys", e))?;
+        let logits = queries
+            .matmul(
+                &keys
+                    .transpose(1, 2)
+                    .and_then(|t| t.contiguous())
+                    .map_err(|e| infer_err("v3 pointer transpose", e))?,
+            )
+            .map_err(|e| infer_err("v3 pointer logits", e))?;
+        let logits = (logits / (order.head_size as f64).sqrt())
+            .map_err(|e| infer_err("v3 pointer scale", e))?;
+
+        let keep: Vec<u8> = (0..seq)
+            .flat_map(|i| (0..seq).map(move |j| u8::from(i < j)))
+            .collect();
+        let keep = Tensor::from_vec(keep, (1, seq, seq), logits.device())
+            .and_then(|t| t.broadcast_as(logits.shape()))
+            .and_then(|t| t.contiguous())
+            .map_err(|e| infer_err("v3 pointer mask", e))?;
+        let masked = Tensor::full(-1e4f32, logits.shape(), logits.device())
+            .and_then(|t| t.to_dtype(logits.dtype()))
+            .map_err(|e| infer_err("v3 pointer fill", e))?;
+        keep.where_cond(&logits, &masked)
+            .map_err(|e| infer_err("v3 pointer masking", e))
+    }
+
+    /// Turns surviving queries into detections sorted by reading order.
+    fn collect(
+        &self,
+        selection: &Selection,
+        sequence: &[usize],
+        logits: &[f32],
+        boxes: &[f32],
+        prepared: &PreprocessedImage,
+    ) -> Result<Vec<Detection>, Error> {
+        let num_labels = self.config.num_labels();
+        let mut detections: Vec<(usize, Detection)> = Vec::with_capacity(selection.num_valid);
+        for (slot, &query) in selection
+            .permutation
+            .iter()
+            .enumerate()
+            .take(selection.num_valid)
+        {
+            let class_id = selection.best_class[query];
+            let score = sigmoid(logits[query * num_labels + class_id]);
+            let corners = scaled_corners_f32(&boxes[query * 4..query * 4 + 4], 1.0);
+            let bbox = [
+                corners[0] * prepared.original_width as f32,
+                corners[1] * prepared.original_height as f32,
+                corners[2] * prepared.original_width as f32,
+                corners[3] * prepared.original_height as f32,
+            ];
+            detections.push((
+                self.rank_of(sequence, slot, query),
+                Detection {
+                    bbox,
+                    class_id,
+                    score,
+                },
+            ));
+        }
+        detections.sort_by_key(|(rank, _)| *rank);
+        Ok(detections.into_iter().map(|(_, d)| d).collect())
+    }
+
+    /// Reading-order rank of one surviving query.
+    ///
+    /// The two versions index `sequence` differently, because they build the
+    /// order logits from different things:
+    ///
+    /// * V2 feeds the pointer network the survivors-first permutation, so row
+    ///   `slot` of the logits is `permutation[slot]`. Upstream matches this by
+    ///   permuting `logits` and `pred_boxes` the same way inside `forward`.
+    /// * V3 reads the order head straight off the decoder states, which stay in
+    ///   query order, so row `query` is the one to look at. Upstream does the
+    ///   same with `order_seqs.gather(dim=1, index=index)`.
+    ///
+    /// Using `slot` for V3 only agrees when the survivors happen to be queries
+    /// `0..num_valid`, which is common (queries arrive sorted by encoder score)
+    /// but not guaranteed: one query below the threshold shifts every later
+    /// element onto a neighbour's rank.
+    fn rank_of(&self, sequence: &[usize], slot: usize, query: usize) -> usize {
+        match self.version {
+            PpDocLayoutVersion::V2 => sequence[slot],
+            PpDocLayoutVersion::V3 => sequence[query],
+        }
+    }
+}
+
+/// Which queries survive thresholding, and the order they are fed to the
+/// reading-order stage in: survivors first, in query order.
+struct Selection {
+    /// Number of queries above their threshold.
+    num_valid: usize,
+    /// Argmax class per query, indexed by query.
+    best_class: Vec<usize>,
+    /// Queries reordered so the survivors come first.
+    permutation: Vec<usize>,
+}
+
+fn sigmoid(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+/// Converts a normalized cxcywh box to corner form scaled by `scale` and
+/// clamped to `[0, scale]`.
+fn clamped_corners(box_cxcywh: &[f32], scale: f32) -> [f32; 4] {
+    let corners = scaled_corners_f32(box_cxcywh, scale);
+    [
+        corners[0].clamp(0.0, scale),
+        corners[1].clamp(0.0, scale),
+        corners[2].clamp(0.0, scale),
+        corners[3].clamp(0.0, scale),
+    ]
+}
+
+fn scaled_corners_f32(box_cxcywh: &[f32], scale: f32) -> [f32; 4] {
+    let (cx, cy, w, h) = (box_cxcywh[0], box_cxcywh[1], box_cxcywh[2], box_cxcywh[3]);
+    [
+        (cx - 0.5 * w) * scale,
+        (cy - 0.5 * h) * scale,
+        (cx + 0.5 * w) * scale,
+        (cy + 0.5 * h) * scale,
+    ]
+}
+
+impl LayoutSource for PpDocLayout {
+    fn detect(&self, image: &RgbImage) -> Result<LayoutDetections, Error> {
+        let detections = PpDocLayout::detect(self, image)?;
+        let elements = detections
+            .into_iter()
+            .map(|d| LayoutDetectionElement {
+                bbox: BoundingBox::from_coords(d.bbox[0], d.bbox[1], d.bbox[2], d.bbox[3]),
+                element_type: self.config.label(d.class_id).to_string(),
+                score: d.score,
+            })
+            .collect();
+        // `detect` already returns the regions in predicted reading order.
+        Ok(LayoutDetections::new(elements))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::safetensors;
+
+    /// Compares the ported model against a PyTorch reference dump.
+    ///
+    /// Ignored by default: it needs a local checkpoint plus a reference file
+    /// captured from `transformers`. Run it with
+    ///
+    /// ```text
+    /// OAR_PP_DOCLAYOUT_DIR=$PWD/models/PaddlePaddle/PP-DocLayoutV2 \
+    /// OAR_PP_DOCLAYOUT_REF=/tmp/ref_v2.safetensors \
+    ///     cargo test --release -p oar-ocr-vl -- --ignored pytorch_reference
+    /// ```
+    ///
+    /// The dump must contain `pixel_values`, `logits`, `pred_boxes` and
+    /// `order_logits` from `PPDocLayoutV{2,3}ForObjectDetection`. Per-stage
+    /// deviations are printed so a failure points at the offending module.
+    ///
+    /// One caveat for V2: `torch.argsort` is not stable, so the reference
+    /// feeds the pointer network in an arbitrary order. Set `OAR_PP_PERM` to
+    /// that order (a comma-separated query list) to compare `order_logits`
+    /// against it; without it only the detector outputs are meaningful.
+    #[test]
+    #[ignore = "requires a local checkpoint and a PyTorch reference dump"]
+    fn matches_the_pytorch_reference() {
+        let dir = std::env::var("OAR_PP_DOCLAYOUT_DIR")
+            .expect("set OAR_PP_DOCLAYOUT_DIR to a PP-DocLayout checkpoint directory");
+        let reference_path = std::env::var("OAR_PP_DOCLAYOUT_REF")
+            .expect("set OAR_PP_DOCLAYOUT_REF to a PyTorch reference dump");
+
+        let device = Device::Cpu;
+        let model = PpDocLayout::from_dir(&dir, device.clone()).expect("load checkpoint");
+        let reference = safetensors::load(&reference_path, &device).expect("load reference dump");
+
+        let maxdiff = |a: &Tensor, b: &Tensor| -> f32 {
+            (a - b)
+                .and_then(|d| d.abs())
+                .and_then(|d| d.max_all())
+                .and_then(|d| d.to_scalar::<f32>())
+                .expect("compare tensors")
+        };
+
+        // Stage-by-stage, so a failure says which module drifted.
+        let pixel_values = reference["pixel_values"].clone();
+        let detector = &model.detector;
+        let features = detector.backbone.forward(&pixel_values).expect("backbone");
+        let skip = features.len() - detector.encoder_input_proj.len();
+        let projected: Vec<Tensor> = features[skip..]
+            .iter()
+            .zip(detector.encoder_input_proj.iter())
+            .map(|(feature, proj)| proj.forward(feature).expect("input projection"))
+            .collect();
+        for (i, actual) in projected.iter().enumerate() {
+            println!(
+                "encoder_input_proj.{i}: {}",
+                maxdiff(actual, &reference[&format!("encoder_input_proj.{i}")])
+            );
+        }
+        let encoded = detector.encoder.forward(&projected).expect("encoder");
+        for (i, actual) in encoded.iter().enumerate() {
+            println!(
+                "encoder.{i}: {}",
+                maxdiff(
+                    actual,
+                    &reference[&format!("encoder.last_hidden_state.{i}")]
+                )
+            );
+        }
+
+        let prepared = PreprocessedImage {
+            pixel_values,
+            original_width: 800,
+            original_height: 800,
+        };
+        let (logits, boxes, hidden) = model.forward_detector(&prepared).expect("detector");
+        // V2 returns its outputs already permuted, so compare against the raw
+        // per-layer stacks, which both versions expose unpermuted.
+        let last_layer = |name: &str| -> Tensor {
+            let stacked = &reference[name];
+            let last = stacked.dim(1).expect("layer dimension") - 1;
+            stacked
+                .narrow(1, last, 1)
+                .and_then(|t| t.squeeze(1))
+                .expect("last layer")
+        };
+        for (name, actual, expected) in [
+            ("logits", &logits, last_layer("intermediate_logits")),
+            (
+                "pred_boxes",
+                &boxes,
+                last_layer("intermediate_reference_points"),
+            ),
+        ] {
+            let diff = maxdiff(actual, &expected);
+            println!("{name}: {diff}");
+            assert!(diff < 2e-3, "{name} differs from the reference by {diff}");
+        }
+
+        let box_values = boxes.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let logit_values = logits.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let mut selection = model.select(&logit_values, 300).expect("selection");
+        println!("num_valid: {}", selection.num_valid);
+        if let Some(head) = order_permutation_override() {
+            let mut rest: Vec<usize> = selection
+                .permutation
+                .iter()
+                .copied()
+                .filter(|q| !head.contains(q))
+                .collect();
+            let mut merged = head;
+            merged.append(&mut rest);
+            selection.permutation = merged;
+        }
+        let order_logits = model
+            .order_logits(&selection, &box_values, &hidden)
+            .expect("order logits");
+        let diff = maxdiff(&order_logits, &reference["order_logits"]);
+        println!("order_logits: {diff}");
+        if model.version == PpDocLayoutVersion::V3 || std::env::var("OAR_PP_PERM").is_ok() {
+            assert!(
+                diff < 1.0,
+                "order_logits differ from the reference by {diff}"
+            );
+        }
+    }
+
+    /// Replays `torch.argsort`'s unstable ordering when `OAR_PP_PERM` is set.
+    fn order_permutation_override() -> Option<Vec<usize>> {
+        std::env::var("OAR_PP_PERM")
+            .ok()
+            .filter(|spec| !spec.trim().is_empty())
+            .map(|spec| {
+                spec.split(',')
+                    .map(|entry| entry.trim().parse().expect("query index"))
+                    .collect()
+            })
+    }
+}

--- a/oar-ocr-vl/src/pp_doclayout/model.rs
+++ b/oar-ocr-vl/src/pp_doclayout/model.rs
@@ -219,8 +219,15 @@ pub struct PpDocLayout {
 }
 
 impl PpDocLayout {
-    /// Default score threshold for checkpoints without per-class thresholds.
-    pub const DEFAULT_SCORE_THRESHOLD: f32 = 0.5;
+    /// Default score threshold for checkpoints without per-class thresholds,
+    /// which in practice means PP-DocLayoutV3.
+    ///
+    /// `0.3` is what `oar-ocr-core`'s ONNX path uses for V3
+    /// (`LayoutDetectionConfig::with_pp_doclayoutv3_defaults`), so swapping in
+    /// this detector keeps the same regions. It is deliberately lower than the
+    /// `0.5` that `transformers`' `post_process_object_detection` defaults to;
+    /// V3 scores conservatively and 0.5 drops real regions.
+    pub const DEFAULT_SCORE_THRESHOLD: f32 = 0.3;
 
     /// Loads a checkpoint directory containing `config.json` and
     /// `model.safetensors`.

--- a/oar-ocr-vl/src/pp_doclayout/model.rs
+++ b/oar-ocr-vl/src/pp_doclayout/model.rs
@@ -216,9 +216,18 @@ pub struct PpDocLayout {
     device: Device,
     dtype: DType,
     score_threshold: f32,
+    max_elements: usize,
 }
 
 impl PpDocLayout {
+    /// Default cap on returned regions, matching `max_elements` in
+    /// `oar-ocr-core`'s layout configuration.
+    ///
+    /// A checkpoint has 300 queries, and `DocParser` runs the VL recognizer
+    /// once per region, so an unbounded detector turns a pathological page
+    /// into hundreds of generation calls.
+    pub const DEFAULT_MAX_ELEMENTS: usize = 100;
+
     /// Default score threshold for checkpoints without per-class thresholds,
     /// which in practice means PP-DocLayoutV3.
     ///
@@ -274,6 +283,7 @@ impl PpDocLayout {
             device,
             dtype,
             score_threshold: Self::DEFAULT_SCORE_THRESHOLD,
+            max_elements: Self::DEFAULT_MAX_ELEMENTS,
         })
     }
 
@@ -281,6 +291,16 @@ impl PpDocLayout {
     /// thresholds (PP-DocLayoutV3).
     pub fn with_score_threshold(mut self, threshold: f32) -> Self {
         self.score_threshold = threshold;
+        self
+    }
+
+    /// Caps how many regions [`detect`](Self::detect) returns.
+    ///
+    /// When more regions clear their threshold, the lowest-scoring ones are
+    /// dropped; the survivors keep their reading order. `usize::MAX` disables
+    /// the cap.
+    pub fn with_max_elements(mut self, max_elements: usize) -> Self {
+        self.max_elements = max_elements;
         self
     }
 
@@ -507,14 +527,35 @@ impl PpDocLayout {
         let mut kept = Vec::with_capacity(num_queries);
         for q in 0..num_queries {
             let row = &logits[q * num_labels..(q + 1) * num_labels];
-            let (class_id, &best) = row
+            let passes = |class_id: usize, logit: f32| {
+                sigmoid(logit) >= thresholds.map_or(self.score_threshold, |t| t[class_id])
+            };
+            // Thresholds are per class for V2, so the highest-scoring class is
+            // not necessarily the one that qualifies: a 0.49 class gated at
+            // 0.5 loses to a 0.48 class gated at 0.4. Upstream keeps the
+            // latter because it ranks every (query, class) pair, so pick the
+            // best class among those that clear their own threshold and only
+            // fall back to the plain argmax when none does.
+            let eligible = row
                 .iter()
                 .enumerate()
-                .max_by(|(_, a), (_, b)| a.total_cmp(b))
-                .expect("class logits are never empty");
-            best_class.push(class_id);
-            let threshold = thresholds.map_or(self.score_threshold, |t| t[class_id]);
-            kept.push(sigmoid(best) >= threshold);
+                .filter(|&(class_id, &logit)| passes(class_id, logit))
+                .max_by(|(_, a), (_, b)| a.total_cmp(b));
+            match eligible {
+                Some((class_id, _)) => {
+                    best_class.push(class_id);
+                    kept.push(true);
+                }
+                None => {
+                    let (class_id, _) = row
+                        .iter()
+                        .enumerate()
+                        .max_by(|(_, a), (_, b)| a.total_cmp(b))
+                        .expect("class logits are never empty");
+                    best_class.push(class_id);
+                    kept.push(false);
+                }
+            }
         }
 
         // Surviving queries move to the front, keeping their relative order.
@@ -662,6 +703,12 @@ impl PpDocLayout {
                     score,
                 },
             ));
+        }
+        // Over the cap, drop the least confident regions rather than an
+        // arbitrary tail, then restore reading order among the survivors.
+        if detections.len() > self.max_elements {
+            detections.sort_by(|(_, a), (_, b)| b.score.total_cmp(&a.score));
+            detections.truncate(self.max_elements);
         }
         detections.sort_by_key(|(rank, _)| *rank);
         Ok(detections.into_iter().map(|(_, d)| d).collect())

--- a/oar-ocr-vl/src/pp_doclayout/order.rs
+++ b/oar-ocr-vl/src/pp_doclayout/order.rs
@@ -1,0 +1,89 @@
+//! Turning pairwise order logits into a reading sequence.
+//!
+//! Ported from `_get_order_seqs` in
+//! `transformers/models/pp_doclayout_v3/image_processing_pp_doclayout_v3.py`,
+//! which both PP-DocLayout versions share.
+
+use super::err::infer_err;
+use crate::error::Error;
+use candle_core::Tensor;
+
+/// Ranks queries by how many pairwise comparisons place them late in the
+/// document, returning `rank[query]` for a single-image `(1, n, n)` logit
+/// tensor.
+pub(super) fn order_sequence(order_logits: &Tensor) -> Result<Vec<usize>, Error> {
+    let (batch, rows, cols) = order_logits
+        .dims3()
+        .map_err(|e| infer_err("order logits shape", e))?;
+    if batch != 1 || rows != cols {
+        return Err(Error::Config {
+            message: format!(
+                "PP-DocLayout: expected square single-image order logits, got ({batch}, {rows}, {cols})"
+            ),
+        });
+    }
+    let scores = order_logits
+        .flatten_all()
+        .and_then(|t| t.to_vec1::<f32>())
+        .map_err(|e| infer_err("order logits to host", e))?;
+
+    let mut votes = vec![0f64; rows];
+    for (j, vote) in votes.iter_mut().enumerate() {
+        let mut total = 0f64;
+        for i in 0..j {
+            total += sigmoid(scores[i * cols + j]) as f64;
+        }
+        for i in (j + 1)..rows {
+            total += 1.0 - sigmoid(scores[j * cols + i]) as f64;
+        }
+        *vote = total;
+    }
+
+    let mut pointers: Vec<usize> = (0..rows).collect();
+    pointers.sort_by(|&a, &b| votes[a].total_cmp(&votes[b]).then(a.cmp(&b)));
+
+    let mut sequence = vec![0usize; rows];
+    for (rank, &query) in pointers.iter().enumerate() {
+        sequence[query] = rank;
+    }
+    Ok(sequence)
+}
+
+fn sigmoid(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{Device, Tensor};
+
+    /// A strictly increasing "i before j" signal must rank queries in index
+    /// order.
+    #[test]
+    fn ranks_a_confident_forward_chain_in_order() {
+        let n = 4;
+        let mut data = vec![0f32; n * n];
+        for i in 0..n {
+            for j in 0..n {
+                data[i * n + j] = if i < j { 10.0 } else { -10.0 };
+            }
+        }
+        let logits = Tensor::from_vec(data, (1, n, n), &Device::Cpu).unwrap();
+        assert_eq!(order_sequence(&logits).unwrap(), vec![0, 1, 2, 3]);
+    }
+
+    /// Reversing the signal reverses the sequence.
+    #[test]
+    fn ranks_a_reversed_chain_backwards() {
+        let n = 3;
+        let mut data = vec![0f32; n * n];
+        for i in 0..n {
+            for j in 0..n {
+                data[i * n + j] = if i < j { -10.0 } else { 10.0 };
+            }
+        }
+        let logits = Tensor::from_vec(data, (1, n, n), &Device::Cpu).unwrap();
+        assert_eq!(order_sequence(&logits).unwrap(), vec![2, 1, 0]);
+    }
+}

--- a/oar-ocr-vl/src/pp_doclayout/processing.rs
+++ b/oar-ocr-vl/src/pp_doclayout/processing.rs
@@ -1,0 +1,93 @@
+//! PP-DocLayout image preprocessing.
+//!
+//! `preprocessor_config.json` asks for a bicubic resize to 800x800, a `1/255`
+//! rescale and an identity normalization (mean 0, std 1). The filter matches
+//! the one `oar-ocr-core`'s ONNX PP-DocLayout path uses, so both backends see
+//! the same pixels.
+
+use super::err::proc_err;
+use crate::error::Error;
+use candle_core::{DType, Device, Tensor};
+use image::RgbImage;
+use image::imageops::FilterType;
+
+/// Input size both checkpoints are trained and exported at.
+pub(super) const INPUT_SIZE: u32 = 800;
+
+/// Model input plus the source dimensions needed to map boxes back.
+pub(super) struct PreprocessedImage {
+    /// `(1, 3, 800, 800)` float tensor.
+    pub pixel_values: Tensor,
+    pub original_width: u32,
+    pub original_height: u32,
+}
+
+/// Resizes to the fixed 800x800 input and scales pixels into `[0, 1]`.
+pub(super) fn preprocess(
+    image: &RgbImage,
+    device: &Device,
+    dtype: DType,
+) -> Result<PreprocessedImage, Error> {
+    let (original_width, original_height) = (image.width(), image.height());
+    if original_width == 0 || original_height == 0 {
+        return Err(Error::Config {
+            message: "PP-DocLayout: input image has zero width or height".to_string(),
+        });
+    }
+
+    let resized = image::imageops::resize(image, INPUT_SIZE, INPUT_SIZE, FilterType::CatmullRom);
+
+    let pixels = INPUT_SIZE as usize * INPUT_SIZE as usize;
+    let mut data = vec![0f32; 3 * pixels];
+    for (index, pixel) in resized.pixels().enumerate() {
+        data[index] = pixel[0] as f32 / 255.0;
+        data[pixels + index] = pixel[1] as f32 / 255.0;
+        data[2 * pixels + index] = pixel[2] as f32 / 255.0;
+    }
+
+    let pixel_values = Tensor::from_vec(
+        data,
+        (1, 3, INPUT_SIZE as usize, INPUT_SIZE as usize),
+        device,
+    )
+    .and_then(|t| t.to_dtype(dtype))
+    .map_err(|e| proc_err("build PP-DocLayout input tensor", e))?;
+
+    Ok(PreprocessedImage {
+        pixel_values,
+        original_width,
+        original_height,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn produces_a_normalized_fixed_size_tensor() {
+        let image = RgbImage::from_pixel(37, 11, image::Rgb([255, 0, 128]));
+        let prepared = preprocess(&image, &Device::Cpu, DType::F32).unwrap();
+        assert_eq!(
+            prepared.pixel_values.dims(),
+            &[1, 3, INPUT_SIZE as usize, INPUT_SIZE as usize]
+        );
+        assert_eq!(prepared.original_width, 37);
+        assert_eq!(prepared.original_height, 11);
+
+        let values = prepared
+            .pixel_values
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        assert!(values.iter().all(|v| (0.0..=1.0).contains(v)));
+        assert!((values[0] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rejects_empty_images() {
+        let image = RgbImage::new(0, 0);
+        assert!(preprocess(&image, &Device::Cpu, DType::F32).is_err());
+    }
+}

--- a/oar-ocr-vl/src/pp_doclayout/reading_order.rs
+++ b/oar-ocr-vl/src/pp_doclayout/reading_order.rs
@@ -1,0 +1,657 @@
+//! PP-DocLayoutV2 reading-order pointer network.
+//!
+//! Ported from `transformers/models/pp_doclayout_v2/modular_pp_doclayout_v2.py`
+//! (`PPDocLayoutV2ReadingOrder`), which is LayoutLMv3's encoder with a
+//! box-relation attention bias and a global-pointer head on top.
+//!
+//! The network sees the surviving detections as a token sequence
+//! `[start, pred * n, end, pad ...]` and emits a pairwise "comes before" logit
+//! matrix that [`super::order`] turns into a reading sequence.
+
+use super::config::ReadingOrderConfig;
+use super::err::infer_err;
+use crate::error::Error;
+use candle_core::{D, DType, Device, Tensor};
+use candle_nn::{
+    Conv2d, Conv2dConfig, Embedding, LayerNorm, Linear, Module, VarBuilder, embedding, layer_norm,
+    linear,
+};
+
+/// Softmax variant from the CogView paper, used verbatim by LayoutLMv3.
+fn cogview_softmax(scores: &Tensor) -> Result<Tensor, Error> {
+    const ALPHA: f64 = 32.0;
+    let scaled = (scores / ALPHA).map_err(|e| infer_err("cogview scale", e))?;
+    let max = scaled
+        .max_keepdim(D::Minus1)
+        .map_err(|e| infer_err("cogview max", e))?;
+    let shifted = (scaled
+        .broadcast_sub(&max)
+        .map_err(|e| infer_err("cogview shift", e))?
+        * ALPHA)
+        .map_err(|e| infer_err("cogview rescale", e))?;
+    candle_nn::ops::softmax_last_dim(&shifted).map_err(|e| infer_err("cogview softmax", e))
+}
+
+/// LayoutLM-style token, position and spatial embeddings.
+#[derive(Debug)]
+struct TextEmbeddings {
+    word_embeddings: Embedding,
+    token_type_embeddings: Embedding,
+    position_embeddings: Embedding,
+    x_position_embeddings: Embedding,
+    y_position_embeddings: Embedding,
+    h_position_embeddings: Embedding,
+    w_position_embeddings: Embedding,
+    spatial_proj: Linear,
+    norm: LayerNorm,
+    padding_idx: u32,
+    max_2d_position: usize,
+}
+
+impl TextEmbeddings {
+    fn load(cfg: &ReadingOrderConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let hidden = cfg.hidden_size;
+        let spatial_dim = 4 * cfg.coordinate_size + 2 * cfg.shape_size;
+        Ok(Self {
+            word_embeddings: embedding(cfg.vocab_size, hidden, vb.pp("word_embeddings"))
+                .map_err(|e| infer_err("load reading-order word embeddings", e))?,
+            token_type_embeddings: embedding(
+                cfg.type_vocab_size,
+                hidden,
+                vb.pp("token_type_embeddings"),
+            )
+            .map_err(|e| infer_err("load reading-order token type embeddings", e))?,
+            position_embeddings: embedding(
+                cfg.max_position_embeddings,
+                hidden,
+                vb.pp("position_embeddings"),
+            )
+            .map_err(|e| infer_err("load reading-order position embeddings", e))?,
+            x_position_embeddings: embedding(
+                cfg.max_2d_position_embeddings,
+                cfg.coordinate_size,
+                vb.pp("x_position_embeddings"),
+            )
+            .map_err(|e| infer_err("load reading-order x embeddings", e))?,
+            y_position_embeddings: embedding(
+                cfg.max_2d_position_embeddings,
+                cfg.coordinate_size,
+                vb.pp("y_position_embeddings"),
+            )
+            .map_err(|e| infer_err("load reading-order y embeddings", e))?,
+            h_position_embeddings: embedding(
+                cfg.max_2d_position_embeddings,
+                cfg.shape_size,
+                vb.pp("h_position_embeddings"),
+            )
+            .map_err(|e| infer_err("load reading-order h embeddings", e))?,
+            w_position_embeddings: embedding(
+                cfg.max_2d_position_embeddings,
+                cfg.shape_size,
+                vb.pp("w_position_embeddings"),
+            )
+            .map_err(|e| infer_err("load reading-order w embeddings", e))?,
+            spatial_proj: linear(spatial_dim, hidden, vb.pp("spatial_proj"))
+                .map_err(|e| infer_err("load reading-order spatial projection", e))?,
+            norm: layer_norm(hidden, cfg.layer_norm_eps, vb.pp("norm"))
+                .map_err(|e| infer_err("load reading-order embedding norm", e))?,
+            padding_idx: cfg.pad_token_id,
+            max_2d_position: cfg.max_2d_position_embeddings,
+        })
+    }
+
+    /// `input_ids` is `(batch, seq)`, `boxes` is `(batch, seq, 4)` xyxy in the
+    /// 0..=1000 range.
+    fn forward(
+        &self,
+        input_ids: &[Vec<u32>],
+        boxes: &[Vec<[u32; 4]>],
+        device: &Device,
+    ) -> Result<Tensor, Error> {
+        let batch = input_ids.len();
+        let seq = input_ids[0].len();
+
+        let flat_ids: Vec<u32> = input_ids.iter().flatten().copied().collect();
+        let ids = Tensor::from_vec(flat_ids, (batch, seq), device)
+            .map_err(|e| infer_err("reading-order input ids", e))?;
+        let words = self
+            .word_embeddings
+            .forward(&ids)
+            .map_err(|e| infer_err("reading-order word lookup", e))?;
+
+        let position_ids: Vec<u32> = input_ids
+            .iter()
+            .flat_map(|row| {
+                let mut running = 0u32;
+                row.iter()
+                    .map(|&id| {
+                        if id != self.padding_idx {
+                            running += 1;
+                            running + self.padding_idx
+                        } else {
+                            self.padding_idx
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        let positions = Tensor::from_vec(position_ids, (batch, seq), device)
+            .map_err(|e| infer_err("reading-order position ids", e))?;
+        let position_embeddings = self
+            .position_embeddings
+            .forward(&positions)
+            .map_err(|e| infer_err("reading-order position lookup", e))?;
+
+        let token_types = Tensor::zeros((batch, seq), DType::U32, device)
+            .map_err(|e| infer_err("reading-order token types", e))?;
+        let token_type_embeddings = self
+            .token_type_embeddings
+            .forward(&token_types)
+            .map_err(|e| infer_err("reading-order token type lookup", e))?;
+
+        let spatial = self.spatial_embeddings(boxes, batch, seq, device)?;
+        let spatial = self
+            .spatial_proj
+            .forward(&spatial)
+            .map_err(|e| infer_err("reading-order spatial projection", e))?;
+
+        let embeddings = (words + token_type_embeddings)
+            .and_then(|t| t + position_embeddings)
+            .and_then(|t| t + spatial)
+            .map_err(|e| infer_err("reading-order embedding sum", e))?;
+        Ok(embeddings)
+    }
+
+    fn spatial_embeddings(
+        &self,
+        boxes: &[Vec<[u32; 4]>],
+        batch: usize,
+        seq: usize,
+        device: &Device,
+    ) -> Result<Tensor, Error> {
+        let limit = (self.max_2d_position - 1) as u32;
+        let mut left = Vec::with_capacity(batch * seq);
+        let mut upper = Vec::with_capacity(batch * seq);
+        let mut right = Vec::with_capacity(batch * seq);
+        let mut lower = Vec::with_capacity(batch * seq);
+        let mut heights = Vec::with_capacity(batch * seq);
+        let mut widths = Vec::with_capacity(batch * seq);
+        for row in boxes {
+            for b in row {
+                let (x0, y0, x1, y1) = (
+                    b[0].min(limit),
+                    b[1].min(limit),
+                    b[2].min(limit),
+                    b[3].min(limit),
+                );
+                left.push(x0);
+                upper.push(y0);
+                right.push(x1);
+                lower.push(y1);
+                heights.push(y1.saturating_sub(y0).min(1023));
+                widths.push(x1.saturating_sub(x0).min(1023));
+            }
+        }
+
+        let lookup =
+            |values: Vec<u32>, table: &Embedding, what: &'static str| -> Result<Tensor, Error> {
+                let ids = Tensor::from_vec(values, (batch, seq), device)
+                    .map_err(|e| infer_err(what, e))?;
+                table.forward(&ids).map_err(|e| infer_err(what, e))
+            };
+
+        let parts = vec![
+            lookup(
+                left,
+                &self.x_position_embeddings,
+                "reading-order left embedding",
+            )?,
+            lookup(
+                upper,
+                &self.y_position_embeddings,
+                "reading-order upper embedding",
+            )?,
+            lookup(
+                right,
+                &self.x_position_embeddings,
+                "reading-order right embedding",
+            )?,
+            lookup(
+                lower,
+                &self.y_position_embeddings,
+                "reading-order lower embedding",
+            )?,
+            lookup(
+                heights,
+                &self.h_position_embeddings,
+                "reading-order height embedding",
+            )?,
+            lookup(
+                widths,
+                &self.w_position_embeddings,
+                "reading-order width embedding",
+            )?,
+        ];
+        Tensor::cat(&parts, D::Minus1).map_err(|e| infer_err("reading-order spatial concat", e))
+    }
+}
+
+/// Pairwise box-relation attention bias: a RoPE-style encoding of relative
+/// positions and sizes, projected to one bias per attention head.
+#[derive(Debug)]
+struct PositionRelationEmbedding {
+    pos_proj: Conv2d,
+    inv_freq: Vec<f64>,
+    scale: f64,
+}
+
+impl PositionRelationEmbedding {
+    fn load(cfg: &ReadingOrderConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let dim = cfg.relation_bias_embed_dim;
+        let half_dim = dim / 2;
+        let inv_freq = (0..dim)
+            .step_by(2)
+            .map(|i| 1.0 / cfg.relation_bias_theta.powf(i as f64 / half_dim as f64))
+            .collect();
+        Ok(Self {
+            pos_proj: candle_nn::conv2d(
+                dim * 4,
+                cfg.num_attention_heads,
+                1,
+                Conv2dConfig::default(),
+                vb.pp("pos_proj"),
+            )
+            .map_err(|e| infer_err("load reading-order relation projection", e))?,
+            inv_freq,
+            scale: cfg.relation_bias_scale,
+        })
+    }
+
+    /// `boxes` is `(batch, seq, 4)` in cxcywh form; returns `(batch, heads,
+    /// seq, seq)`.
+    fn forward(&self, boxes: &[Vec<[f32; 4]>], device: &Device) -> Result<Tensor, Error> {
+        const EPSILON: f64 = 1e-5;
+        let batch = boxes.len();
+        let seq = boxes[0].len();
+        let freq_len = self.inv_freq.len();
+        let channels = 4 * 2 * freq_len;
+
+        let mut data = vec![0f32; batch * channels * seq * seq];
+        for (b, row) in boxes.iter().enumerate() {
+            for i in 0..seq {
+                let source = row[i];
+                for (j, &target) in row.iter().enumerate() {
+                    let relative = [
+                        ((source[0] - target[0]).abs() as f64 / (source[2] as f64 + EPSILON) + 1.0)
+                            .ln(),
+                        ((source[1] - target[1]).abs() as f64 / (source[3] as f64 + EPSILON) + 1.0)
+                            .ln(),
+                        ((source[2] as f64 + EPSILON) / (target[2] as f64 + EPSILON)).ln(),
+                        ((source[3] as f64 + EPSILON) / (target[3] as f64 + EPSILON)).ln(),
+                    ];
+                    for (r, value) in relative.iter().enumerate() {
+                        for (k, &freq) in self.inv_freq.iter().enumerate() {
+                            let angle = value * self.scale * freq;
+                            let sin_channel = r * 2 * freq_len + k;
+                            let cos_channel = sin_channel + freq_len;
+                            let plane = b * channels * seq * seq + i * seq + j;
+                            data[plane + sin_channel * seq * seq] = angle.sin() as f32;
+                            data[plane + cos_channel * seq * seq] = angle.cos() as f32;
+                        }
+                    }
+                }
+            }
+        }
+
+        let embedding = Tensor::from_vec(data, (batch, channels, seq, seq), device)
+            .map_err(|e| infer_err("reading-order relation embedding", e))?;
+        self.pos_proj
+            .forward(&embedding)
+            .map_err(|e| infer_err("reading-order relation projection", e))
+    }
+}
+
+/// One LayoutLMv3-style encoder layer with the relation bias added to the raw
+/// attention scores.
+#[derive(Debug)]
+struct EncoderLayer {
+    query: Linear,
+    key: Linear,
+    value: Linear,
+    attention_output: Linear,
+    attention_norm: LayerNorm,
+    intermediate: Linear,
+    output: Linear,
+    output_norm: LayerNorm,
+    num_heads: usize,
+    head_dim: usize,
+}
+
+impl EncoderLayer {
+    fn load(cfg: &ReadingOrderConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let hidden = cfg.hidden_size;
+        let attention_vb = vb.pp("attention");
+        let self_vb = attention_vb.pp("self");
+        let output_vb = attention_vb.pp("output");
+        Ok(Self {
+            query: linear(hidden, hidden, self_vb.pp("query"))
+                .map_err(|e| infer_err("load reading-order query", e))?,
+            key: linear(hidden, hidden, self_vb.pp("key"))
+                .map_err(|e| infer_err("load reading-order key", e))?,
+            value: linear(hidden, hidden, self_vb.pp("value"))
+                .map_err(|e| infer_err("load reading-order value", e))?,
+            attention_output: linear(hidden, hidden, output_vb.pp("dense"))
+                .map_err(|e| infer_err("load reading-order attention output", e))?,
+            attention_norm: layer_norm(hidden, cfg.layer_norm_eps, output_vb.pp("norm"))
+                .map_err(|e| infer_err("load reading-order attention norm", e))?,
+            intermediate: linear(
+                hidden,
+                cfg.intermediate_size,
+                vb.pp("intermediate").pp("dense"),
+            )
+            .map_err(|e| infer_err("load reading-order intermediate", e))?,
+            output: linear(cfg.intermediate_size, hidden, vb.pp("output").pp("dense"))
+                .map_err(|e| infer_err("load reading-order output", e))?,
+            output_norm: layer_norm(hidden, cfg.layer_norm_eps, vb.pp("output").pp("norm"))
+                .map_err(|e| infer_err("load reading-order output norm", e))?,
+            num_heads: cfg.num_attention_heads,
+            head_dim: hidden / cfg.num_attention_heads,
+        })
+    }
+
+    fn forward(
+        &self,
+        hidden: &Tensor,
+        attention_mask: &Tensor,
+        relation_bias: &Tensor,
+    ) -> Result<Tensor, Error> {
+        let (batch, seq, _) = hidden
+            .dims3()
+            .map_err(|e| infer_err("reading-order layer shape", e))?;
+        let split = |t: Tensor| -> Result<Tensor, Error> {
+            t.reshape((batch, seq, self.num_heads, self.head_dim))
+                .and_then(|t| t.transpose(1, 2))
+                .and_then(|t| t.contiguous())
+                .map_err(|e| infer_err("reading-order head split", e))
+        };
+
+        let query = split(
+            self.query
+                .forward(hidden)
+                .map_err(|e| infer_err("reading-order query projection", e))?,
+        )?;
+        let key = split(
+            self.key
+                .forward(hidden)
+                .map_err(|e| infer_err("reading-order key projection", e))?,
+        )?;
+        let value = split(
+            self.value
+                .forward(hidden)
+                .map_err(|e| infer_err("reading-order value projection", e))?,
+        )?;
+
+        // Upstream scales the query rather than the scores to avoid overflow.
+        let scaled_query = (query / (self.head_dim as f64).sqrt())
+            .map_err(|e| infer_err("reading-order query scale", e))?;
+        let scores = scaled_query
+            .matmul(
+                &key.transpose(2, 3)
+                    .and_then(|t| t.contiguous())
+                    .map_err(|e| infer_err("reading-order key transpose", e))?,
+            )
+            .map_err(|e| infer_err("reading-order scores", e))?;
+        // The relation bias is added unscaled, unlike LayoutLMv3.
+        let scores = (scores + relation_bias)
+            .map_err(|e| infer_err("reading-order relation bias", e))?
+            .broadcast_add(attention_mask)
+            .map_err(|e| infer_err("reading-order attention mask", e))?;
+
+        let probs = cogview_softmax(&scores)?;
+        let context = probs
+            .matmul(&value)
+            .map_err(|e| infer_err("reading-order context", e))?
+            .transpose(1, 2)
+            .map_err(|e| infer_err("reading-order context transpose", e))?
+            .reshape((batch, seq, self.num_heads * self.head_dim))
+            .map_err(|e| infer_err("reading-order context reshape", e))?;
+
+        let attention = self
+            .attention_output
+            .forward(&context)
+            .map_err(|e| infer_err("reading-order attention output", e))?;
+        let hidden = self
+            .attention_norm
+            .forward(
+                &(attention + hidden)
+                    .map_err(|e| infer_err("reading-order attention residual", e))?,
+            )
+            .map_err(|e| infer_err("reading-order attention norm", e))?;
+
+        let intermediate = self
+            .intermediate
+            .forward(&hidden)
+            .and_then(|t| t.gelu_erf())
+            .map_err(|e| infer_err("reading-order intermediate", e))?;
+        let output = self
+            .output
+            .forward(&intermediate)
+            .map_err(|e| infer_err("reading-order output", e))?;
+        self.output_norm
+            .forward(
+                &(output + &hidden).map_err(|e| infer_err("reading-order output residual", e))?,
+            )
+            .map_err(|e| infer_err("reading-order output norm", e))
+    }
+}
+
+/// Global pointer head: projects to query/key halves and scores every ordered
+/// pair, keeping only the strictly upper triangle.
+#[derive(Debug)]
+struct GlobalPointer {
+    dense: Linear,
+    head_size: usize,
+    tril_mask: bool,
+}
+
+impl GlobalPointer {
+    fn load(
+        hidden_size: usize,
+        head_size: usize,
+        tril_mask: bool,
+        vb: VarBuilder,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            dense: linear(hidden_size, head_size * 2, vb.pp("dense"))
+                .map_err(|e| infer_err("load global pointer", e))?,
+            head_size,
+            tril_mask,
+        })
+    }
+
+    fn forward(&self, inputs: &Tensor) -> Result<Tensor, Error> {
+        let (batch, seq, _) = inputs
+            .dims3()
+            .map_err(|e| infer_err("global pointer shape", e))?;
+        let projected = self
+            .dense
+            .forward(inputs)
+            .and_then(|t| t.reshape((batch, seq, 2, self.head_size)))
+            .map_err(|e| infer_err("global pointer projection", e))?;
+        let queries = projected
+            .narrow(2, 0, 1)
+            .and_then(|t| t.squeeze(2))
+            .and_then(|t| t.contiguous())
+            .map_err(|e| infer_err("global pointer queries", e))?;
+        let keys = projected
+            .narrow(2, 1, 1)
+            .and_then(|t| t.squeeze(2))
+            .and_then(|t| t.contiguous())
+            .map_err(|e| infer_err("global pointer keys", e))?;
+
+        let logits = queries
+            .matmul(
+                &keys
+                    .transpose(1, 2)
+                    .and_then(|t| t.contiguous())
+                    .map_err(|e| infer_err("global pointer key transpose", e))?,
+            )
+            .map_err(|e| infer_err("global pointer logits", e))?;
+        let logits = (logits / (self.head_size as f64).sqrt())
+            .map_err(|e| infer_err("global pointer scale", e))?;
+
+        if !self.tril_mask {
+            return Ok(logits);
+        }
+        let keep: Vec<u8> = (0..seq)
+            .flat_map(|i| (0..seq).map(move |j| u8::from(i < j)))
+            .collect();
+        let keep = Tensor::from_vec(keep, (1, seq, seq), logits.device())
+            .and_then(|t| t.broadcast_as(logits.shape()))
+            .and_then(|t| t.contiguous())
+            .map_err(|e| infer_err("global pointer mask", e))?;
+        let masked = Tensor::full(-1e4f32, logits.shape(), logits.device())
+            .and_then(|t| t.to_dtype(logits.dtype()))
+            .map_err(|e| infer_err("global pointer fill", e))?;
+        keep.where_cond(&logits, &masked)
+            .map_err(|e| infer_err("global pointer masking", e))
+    }
+}
+
+/// The complete V2 reading-order network.
+#[derive(Debug)]
+pub(super) struct ReadingOrder {
+    embeddings: TextEmbeddings,
+    label_embeddings: Embedding,
+    label_features_projection: Linear,
+    layers: Vec<EncoderLayer>,
+    relation_bias: PositionRelationEmbedding,
+    relative_head: GlobalPointer,
+    config: ReadingOrderConfig,
+}
+
+impl ReadingOrder {
+    pub(super) fn load(cfg: &ReadingOrderConfig, vb: VarBuilder) -> Result<Self, Error> {
+        let encoder_vb = vb.pp("encoder");
+        let layers_vb = encoder_vb.pp("layer");
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        for i in 0..cfg.num_hidden_layers {
+            layers.push(EncoderLayer::load(cfg, layers_vb.pp(i))?);
+        }
+        Ok(Self {
+            embeddings: TextEmbeddings::load(cfg, vb.pp("embeddings"))?,
+            label_embeddings: embedding(
+                cfg.num_classes,
+                cfg.hidden_size,
+                vb.pp("label_embeddings"),
+            )
+            .map_err(|e| infer_err("load reading-order label embeddings", e))?,
+            label_features_projection: linear(
+                cfg.hidden_size,
+                cfg.hidden_size,
+                vb.pp("label_features_projection"),
+            )
+            .map_err(|e| infer_err("load reading-order label projection", e))?,
+            layers,
+            relation_bias: PositionRelationEmbedding::load(cfg, encoder_vb.pp("rel_bias_module"))?,
+            relative_head: GlobalPointer::load(
+                cfg.hidden_size,
+                cfg.global_pointer_head_size,
+                cfg.tril_mask,
+                vb.pp("relative_head"),
+            )?,
+            config: cfg.clone(),
+        })
+    }
+
+    /// `boxes` are xyxy on a 0..=1000 grid, `labels` are reading-order
+    /// categories, and `num_valid` is how many leading entries are real
+    /// detections. Returns `(1, num_boxes, num_boxes)` order logits.
+    ///
+    /// Upstream truncates the boxes to integers for the embedding lookups but
+    /// keeps the fractional values for the relation bias, so both forms are
+    /// derived here from the same input.
+    pub(super) fn forward(
+        &self,
+        boxes: &[[f32; 4]],
+        labels: &[u32],
+        num_valid: usize,
+        device: &Device,
+    ) -> Result<Tensor, Error> {
+        let seq_len = boxes.len();
+        let padded_len = seq_len + 2;
+
+        let mut input_ids = vec![self.config.pad_token_id; padded_len];
+        input_ids[0] = self.config.start_token_id;
+        for slot in input_ids.iter_mut().take(num_valid + 1).skip(1) {
+            *slot = self.config.pred_token_id;
+        }
+        input_ids[num_valid + 1] = self.config.end_token_id;
+
+        let mut padded_boxes = Vec::with_capacity(padded_len);
+        padded_boxes.push([0f32; 4]);
+        padded_boxes.extend_from_slice(boxes);
+        padded_boxes.push([0f32; 4]);
+        let integer_boxes: Vec<[u32; 4]> = padded_boxes
+            .iter()
+            .map(|b| [b[0] as u32, b[1] as u32, b[2] as u32, b[3] as u32])
+            .collect();
+
+        let embeddings = self
+            .embeddings
+            .forward(&[input_ids], &[integer_boxes], device)?;
+
+        let label_ids = Tensor::from_vec(labels.to_vec(), (1, seq_len), device)
+            .map_err(|e| infer_err("reading-order labels", e))?;
+        let label_projection = self
+            .label_embeddings
+            .forward(&label_ids)
+            .and_then(|t| self.label_features_projection.forward(&t))
+            .map_err(|e| infer_err("reading-order label projection", e))?;
+        let pad = Tensor::zeros(
+            (1, 1, self.config.hidden_size),
+            label_projection.dtype(),
+            device,
+        )
+        .map_err(|e| infer_err("reading-order label padding", e))?;
+        let label_projection = Tensor::cat(&[&pad, &label_projection, &pad], 1)
+            .map_err(|e| infer_err("reading-order label concat", e))?;
+
+        let hidden = (embeddings + label_projection)
+            .map_err(|e| infer_err("reading-order embedding merge", e))?;
+        let mut hidden = self
+            .embeddings
+            .norm
+            .forward(&hidden)
+            .map_err(|e| infer_err("reading-order embedding norm", e))?;
+
+        let mask_row: Vec<f32> = (0..padded_len)
+            .map(|i| if i < num_valid + 2 { 0.0 } else { f32::MIN })
+            .collect();
+        let attention_mask = Tensor::from_vec(mask_row, (1, 1, 1, padded_len), device)
+            .map_err(|e| infer_err("reading-order attention mask", e))?;
+
+        let relation_boxes: Vec<[f32; 4]> = padded_boxes
+            .iter()
+            .map(|b| {
+                [
+                    (b[0] + b[2]) * 0.5,
+                    (b[1] + b[3]) * 0.5,
+                    (b[2] - b[0]).max(1e-3),
+                    (b[3] - b[1]).max(1e-3),
+                ]
+            })
+            .collect();
+        let relation_bias = self.relation_bias.forward(&[relation_boxes], device)?;
+
+        for layer in &self.layers {
+            hidden = layer.forward(&hidden, &attention_mask, &relation_bias)?;
+        }
+
+        let tokens = hidden
+            .narrow(1, 1, seq_len)
+            .and_then(|t| t.contiguous())
+            .map_err(|e| infer_err("reading-order token slice", e))?;
+        self.relative_head.forward(&tokens)
+    }
+}

--- a/oar-ocr-vl/src/structure.rs
+++ b/oar-ocr-vl/src/structure.rs
@@ -49,9 +49,25 @@ impl StructureResult {
         self
     }
 
-    /// Renders the page as Markdown.
+    /// Renders the page as Markdown, skipping
+    /// [`DEFAULT_MARKDOWN_IGNORE_LABELS`] so running heads and page furniture
+    /// stay out of the prose — the same labels
+    /// [`DocParser::parse_to_markdown`] drops.
+    ///
+    /// This is the crate's lightweight renderer: every paragraph title becomes
+    /// `##`. For output that mirrors PaddleOCR-VL, including heading levels
+    /// derived from numbering (`1.2` becomes `###`), use
+    /// [`DocParser::parse_to_markdown_openocr`] or
+    /// [`to_markdown_openocr`](crate::utils::to_markdown_openocr).
+    ///
+    /// [`DEFAULT_MARKDOWN_IGNORE_LABELS`]: crate::utils::DEFAULT_MARKDOWN_IGNORE_LABELS
+    /// [`DocParser::parse_to_markdown`]: crate::DocParser::parse_to_markdown
+    /// [`DocParser::parse_to_markdown_openocr`]: crate::DocParser::parse_to_markdown_openocr
     pub fn to_markdown(&self) -> String {
-        crate::utils::to_markdown(&self.layout_elements, &[])
+        crate::utils::to_markdown(
+            &self.layout_elements,
+            &crate::utils::default_markdown_ignore_labels(),
+        )
     }
 }
 

--- a/oar-ocr-vl/src/structure.rs
+++ b/oar-ocr-vl/src/structure.rs
@@ -49,24 +49,21 @@ impl StructureResult {
         self
     }
 
-    /// Renders the page as Markdown, skipping
+    /// Renders the page as Markdown with the defaults
+    /// [`DocParser::parse_to_markdown`] uses: skipping
     /// [`DEFAULT_MARKDOWN_IGNORE_LABELS`] so running heads and page furniture
-    /// stay out of the prose — the same labels
-    /// [`DocParser::parse_to_markdown`] drops.
+    /// stay out of the prose, and centring captions and tables.
     ///
-    /// This is the crate's lightweight renderer: every paragraph title becomes
-    /// `##`. For output that mirrors PaddleOCR-VL, including heading levels
-    /// derived from numbering (`1.2` becomes `###`), use
-    /// [`DocParser::parse_to_markdown_openocr`] or
-    /// [`to_markdown_openocr`](crate::utils::to_markdown_openocr).
+    /// Call [`to_markdown`](crate::utils::to_markdown) directly to choose
+    /// other labels or turn the centring off.
     ///
     /// [`DEFAULT_MARKDOWN_IGNORE_LABELS`]: crate::utils::DEFAULT_MARKDOWN_IGNORE_LABELS
     /// [`DocParser::parse_to_markdown`]: crate::DocParser::parse_to_markdown
-    /// [`DocParser::parse_to_markdown_openocr`]: crate::DocParser::parse_to_markdown_openocr
     pub fn to_markdown(&self) -> String {
         crate::utils::to_markdown(
             &self.layout_elements,
             &crate::utils::default_markdown_ignore_labels(),
+            true,
         )
     }
 }

--- a/oar-ocr-vl/src/structure.rs
+++ b/oar-ocr-vl/src/structure.rs
@@ -1,0 +1,492 @@
+//! Document structure types produced by [`DocParser`](crate::DocParser).
+//!
+//! Ported from `oar-ocr-core`'s `domain::structure` and trimmed to what a VL
+//! pipeline actually fills in: the classic pipeline's cell grids, per-stage
+//! confidences and stitching metadata have no producer here, so they are not
+//! carried as fields that would always read back empty.
+
+use crate::geometry::BoundingBox;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// A parsed page: its layout elements in reading order, plus the recognized
+/// tables and formulas.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StructureResult {
+    /// Path of the source image, or `<memory>` for in-memory input.
+    pub input_path: Arc<str>,
+    /// Index of the page within a batch.
+    pub index: usize,
+    /// Detected regions, in reading order.
+    pub layout_elements: Vec<LayoutElement>,
+    /// Recognized tables.
+    pub tables: Vec<TableResult>,
+    /// Recognized formulas.
+    pub formulas: Vec<FormulaResult>,
+}
+
+impl StructureResult {
+    /// Creates an empty result for one page.
+    pub fn new(input_path: impl Into<Arc<str>>, index: usize) -> Self {
+        Self {
+            input_path: input_path.into(),
+            index,
+            layout_elements: Vec::new(),
+            tables: Vec::new(),
+            formulas: Vec::new(),
+        }
+    }
+
+    /// Attaches the detected layout elements.
+    pub fn with_layout_elements(mut self, elements: Vec<LayoutElement>) -> Self {
+        self.layout_elements = elements;
+        self
+    }
+
+    /// Attaches the recognized tables.
+    pub fn with_tables(mut self, tables: Vec<TableResult>) -> Self {
+        self.tables = tables;
+        self
+    }
+
+    /// Renders the page as Markdown.
+    pub fn to_markdown(&self) -> String {
+        crate::utils::to_markdown(&self.layout_elements, &[])
+    }
+}
+
+/// A layout element detected in the document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LayoutElement {
+    /// Bounding box of the element
+    pub bbox: BoundingBox,
+    /// Type of the layout element
+    pub element_type: LayoutElementType,
+    /// Confidence score for the detection
+    pub confidence: f32,
+    /// Optional label for the element (original model label)
+    pub label: Option<String>,
+    /// Optional text content for the element
+    pub text: Option<String>,
+    /// Reading order index (1-based).
+    ///
+    /// This index represents the element's position in the reading order.
+    /// Only elements that should be included in reading flow (text, tables,
+    /// formulas, images, etc.) will have an order index assigned.
+    /// Headers, footers, and other auxiliary elements may have `None`.
+    pub order_index: Option<u32>,
+}
+
+impl LayoutElement {
+    /// Creates a new layout element.
+    pub fn new(bbox: BoundingBox, element_type: LayoutElementType, confidence: f32) -> Self {
+        Self {
+            bbox,
+            element_type,
+            confidence,
+            label: None,
+            text: None,
+            order_index: None,
+        }
+    }
+
+    /// Sets the label for the element.
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    /// Sets the text content for the element.
+    pub fn with_text(mut self, text: impl Into<String>) -> Self {
+        self.text = Some(text.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum LayoutElementType {
+    /// Document title
+    DocTitle,
+    /// Paragraph/section title
+    ParagraphTitle,
+    /// General text content
+    Text,
+    /// Table of contents
+    Content,
+    /// Abstract section
+    Abstract,
+
+    /// Image or figure
+    Image,
+    /// Table
+    Table,
+    /// Chart or graph
+    Chart,
+    /// Mathematical formula
+    Formula,
+
+    /// Figure caption/title
+    FigureTitle,
+    /// Table caption/title
+    TableTitle,
+    /// Chart caption/title
+    ChartTitle,
+    /// Combined figure/table/chart title (PP-DocLayout)
+    FigureTableChartTitle,
+
+    /// Page header
+    Header,
+    /// Header image
+    HeaderImage,
+    /// Page footer
+    Footer,
+    /// Footer image
+    FooterImage,
+    /// Footnote
+    Footnote,
+
+    /// Stamp or official seal
+    Seal,
+    /// Page number
+    Number,
+    /// Reference section
+    Reference,
+    /// Reference content (PP-DocLayout_plus-L)
+    ReferenceContent,
+    /// Algorithm block
+    Algorithm,
+    /// Formula number
+    FormulaNumber,
+    /// Marginal/aside text
+    AsideText,
+    /// List items
+    List,
+
+    /// Generic document region block (PP-DocBlockLayout)
+    /// Used for hierarchical layout ordering and block grouping
+    Region,
+
+    /// Other/unknown (original label preserved in LayoutElement.label)
+    Other,
+}
+
+impl LayoutElementType {
+    /// Returns the string representation of the element type.
+    ///
+    /// This returns the PP-StructureV3 compatible label string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            // Document Structure
+            LayoutElementType::DocTitle => "doc_title",
+            LayoutElementType::ParagraphTitle => "paragraph_title",
+            LayoutElementType::Text => "text",
+            LayoutElementType::Content => "content",
+            LayoutElementType::Abstract => "abstract",
+
+            // Visual Elements
+            LayoutElementType::Image => "image",
+            LayoutElementType::Table => "table",
+            LayoutElementType::Chart => "chart",
+            LayoutElementType::Formula => "formula",
+
+            // Captions
+            LayoutElementType::FigureTitle => "figure_title",
+            LayoutElementType::TableTitle => "table_title",
+            LayoutElementType::ChartTitle => "chart_title",
+            LayoutElementType::FigureTableChartTitle => "figure_table_chart_title",
+
+            // Page Structure
+            LayoutElementType::Header => "header",
+            LayoutElementType::HeaderImage => "header_image",
+            LayoutElementType::Footer => "footer",
+            LayoutElementType::FooterImage => "footer_image",
+            LayoutElementType::Footnote => "footnote",
+
+            // Special Elements
+            LayoutElementType::Seal => "seal",
+            LayoutElementType::Number => "number",
+            LayoutElementType::Reference => "reference",
+            LayoutElementType::ReferenceContent => "reference_content",
+            LayoutElementType::Algorithm => "algorithm",
+            LayoutElementType::FormulaNumber => "formula_number",
+            LayoutElementType::AsideText => "aside_text",
+            LayoutElementType::List => "list",
+
+            // Region (PP-DocBlockLayout)
+            LayoutElementType::Region => "region",
+
+            // Fallback
+            LayoutElementType::Other => "other",
+        }
+    }
+
+    /// Creates a LayoutElementType from a string label with fine-grained mapping.
+    ///
+    /// This method maps model output labels to their corresponding fine-grained types,
+    /// preserving the full PP-StructureV3 label set (20/23 classes).
+    pub fn from_label(label: &str) -> Self {
+        match label.to_lowercase().as_str() {
+            // Document Structure
+            "doc_title" => LayoutElementType::DocTitle,
+            "paragraph_title" | "title" => LayoutElementType::ParagraphTitle,
+            "text" | "paragraph" => LayoutElementType::Text,
+            "content" => LayoutElementType::Content,
+            "abstract" => LayoutElementType::Abstract,
+
+            // Visual Elements
+            "image" | "figure" => LayoutElementType::Image,
+            "table" => LayoutElementType::Table,
+            "chart" | "flowchart" => LayoutElementType::Chart,
+            "formula" | "equation" | "display_formula" | "inline_formula" => {
+                LayoutElementType::Formula
+            }
+
+            // Captions
+            "figure_title" => LayoutElementType::FigureTitle,
+            "table_title" => LayoutElementType::TableTitle,
+            "chart_title" => LayoutElementType::ChartTitle,
+            "figure_table_chart_title" | "caption" => LayoutElementType::FigureTableChartTitle,
+
+            // Page Structure
+            "header" => LayoutElementType::Header,
+            "header_image" => LayoutElementType::HeaderImage,
+            "footer" => LayoutElementType::Footer,
+            "footer_image" => LayoutElementType::FooterImage,
+            "footnote" | "vision_footnote" => LayoutElementType::Footnote,
+
+            // Special Elements
+            "seal" => LayoutElementType::Seal,
+            "number" => LayoutElementType::Number,
+            "reference" => LayoutElementType::Reference,
+            "reference_content" => LayoutElementType::ReferenceContent,
+            "algorithm" => LayoutElementType::Algorithm,
+            "formula_number" => LayoutElementType::FormulaNumber,
+            "aside_text" => LayoutElementType::AsideText,
+            "list" => LayoutElementType::List,
+            "vertical_text" => LayoutElementType::Text,
+
+            // Region (PP-DocBlockLayout)
+            "region" => LayoutElementType::Region,
+
+            // Everything else maps to Other
+            // The original label is preserved in LayoutElement.label
+            _ => LayoutElementType::Other,
+        }
+    }
+
+    /// Returns the semantic category for this element type.
+    ///
+    /// This method groups fine-grained types into broader semantic categories,
+    /// useful for processing logic that doesn't need fine-grained distinctions.
+    ///
+    /// # Categories
+    ///
+    /// - **Title**: DocTitle, ParagraphTitle
+    /// - **Text**: Text, Content, Abstract
+    /// - **Visual**: Image, Chart
+    /// - **Table**: Table
+    /// - **Caption**: FigureTitle, TableTitle, ChartTitle, FigureTableChartTitle
+    /// - **Header**: Header, HeaderImage
+    /// - **Footer**: Footer, FooterImage, Footnote
+    /// - **Formula**: Formula, FormulaNumber
+    /// - **Special**: Seal, Number, Reference, ReferenceContent, Algorithm, AsideText
+    /// - **List**: List
+    /// - **Other**: Other
+    pub fn semantic_category(&self) -> &'static str {
+        match self {
+            // Title category
+            LayoutElementType::DocTitle | LayoutElementType::ParagraphTitle => "title",
+
+            // Text category
+            LayoutElementType::Text | LayoutElementType::Content | LayoutElementType::Abstract => {
+                "text"
+            }
+
+            // Visual category
+            LayoutElementType::Image | LayoutElementType::Chart => "visual",
+
+            // Table category
+            LayoutElementType::Table => "table",
+
+            // Caption category
+            LayoutElementType::FigureTitle
+            | LayoutElementType::TableTitle
+            | LayoutElementType::ChartTitle
+            | LayoutElementType::FigureTableChartTitle => "caption",
+
+            // Header category
+            LayoutElementType::Header | LayoutElementType::HeaderImage => "header",
+
+            // Footer category
+            LayoutElementType::Footer
+            | LayoutElementType::FooterImage
+            | LayoutElementType::Footnote => "footer",
+
+            // Formula category
+            LayoutElementType::Formula | LayoutElementType::FormulaNumber => "formula",
+
+            // Special category
+            LayoutElementType::Seal
+            | LayoutElementType::Number
+            | LayoutElementType::Reference
+            | LayoutElementType::ReferenceContent
+            | LayoutElementType::Algorithm
+            | LayoutElementType::AsideText => "special",
+
+            // List category
+            LayoutElementType::List => "list",
+
+            // Region category (PP-DocBlockLayout)
+            LayoutElementType::Region => "region",
+
+            // Other
+            LayoutElementType::Other => "other",
+        }
+    }
+
+    /// Returns whether this element type is a title variant.
+    pub fn is_title(&self) -> bool {
+        matches!(
+            self,
+            LayoutElementType::DocTitle | LayoutElementType::ParagraphTitle
+        )
+    }
+
+    /// Returns whether this element type is a visual element (image, chart, figure).
+    pub fn is_visual(&self) -> bool {
+        matches!(self, LayoutElementType::Image | LayoutElementType::Chart)
+    }
+
+    /// Returns whether this element type is a caption variant.
+    pub fn is_caption(&self) -> bool {
+        matches!(
+            self,
+            LayoutElementType::FigureTitle
+                | LayoutElementType::TableTitle
+                | LayoutElementType::ChartTitle
+                | LayoutElementType::FigureTableChartTitle
+        )
+    }
+
+    /// Returns whether this element type is a header variant.
+    pub fn is_header(&self) -> bool {
+        matches!(
+            self,
+            LayoutElementType::Header | LayoutElementType::HeaderImage
+        )
+    }
+
+    /// Returns whether this element type is a footer variant.
+    pub fn is_footer(&self) -> bool {
+        matches!(
+            self,
+            LayoutElementType::Footer
+                | LayoutElementType::FooterImage
+                | LayoutElementType::Footnote
+        )
+    }
+
+    /// Returns whether this element type is a formula variant.
+    pub fn is_formula(&self) -> bool {
+        matches!(
+            self,
+            LayoutElementType::Formula | LayoutElementType::FormulaNumber
+        )
+    }
+
+    /// Returns whether this element type contains text content that should be OCR'd.
+    pub fn should_ocr(&self) -> bool {
+        matches!(
+            self,
+            LayoutElementType::Text
+                | LayoutElementType::Content
+                | LayoutElementType::Abstract
+                | LayoutElementType::DocTitle
+                | LayoutElementType::ParagraphTitle
+                | LayoutElementType::FigureTitle
+                | LayoutElementType::TableTitle
+                | LayoutElementType::ChartTitle
+                | LayoutElementType::FigureTableChartTitle
+                | LayoutElementType::Header
+                | LayoutElementType::HeaderImage
+                | LayoutElementType::Footer
+                | LayoutElementType::FooterImage
+                | LayoutElementType::Footnote
+                | LayoutElementType::Reference
+                | LayoutElementType::ReferenceContent
+                | LayoutElementType::Algorithm
+                | LayoutElementType::AsideText
+                | LayoutElementType::List
+                | LayoutElementType::Number
+        )
+    }
+}
+
+/// Result of table recognition.
+///
+/// A VL backend recognizes a table region in one shot and returns HTML, so
+/// there is no cell grid or per-stage confidence here — the classic pipeline's
+/// cell detection, structure tokens and stitching all live in `oar-ocr-core`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableResult {
+    /// Bounding box of the table in the original image
+    pub bbox: BoundingBox,
+    /// Table type (wired or wireless)
+    pub table_type: TableType,
+    /// HTML structure of the table (if available)
+    pub html_structure: Option<String>,
+}
+
+impl TableResult {
+    /// Creates a new table result.
+    pub fn new(bbox: BoundingBox, table_type: TableType) -> Self {
+        Self {
+            bbox,
+            table_type,
+            html_structure: None,
+        }
+    }
+
+    /// Sets the HTML structure.
+    pub fn with_html_structure(mut self, html: impl Into<String>) -> Self {
+        self.html_structure = Some(html.into());
+        self
+    }
+
+    /// Returns true if this table has recognized structure.
+    pub fn has_structure(&self) -> bool {
+        self.html_structure.is_some()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TableType {
+    /// Table with visible borders
+    Wired,
+    /// Table without visible borders
+    Wireless,
+    /// Unknown table type
+    Unknown,
+}
+
+/// Result of formula recognition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FormulaResult {
+    /// Bounding box of the formula in the original image
+    pub bbox: BoundingBox,
+    /// LaTeX representation of the formula
+    pub latex: String,
+    /// Confidence score for the recognition
+    pub confidence: f32,
+}
+
+impl FormulaResult {
+    /// Creates a new formula result.
+    pub fn new(bbox: BoundingBox, latex: impl Into<String>, confidence: f32) -> Self {
+        Self {
+            bbox,
+            latex: latex.into(),
+            confidence,
+        }
+    }
+}

--- a/oar-ocr-vl/src/utils.rs
+++ b/oar-ocr-vl/src/utils.rs
@@ -489,53 +489,6 @@ pub fn default_markdown_ignore_labels() -> Vec<String> {
         .collect()
 }
 
-/// Convert layout elements to Markdown format.
-///
-/// Every paragraph title becomes `##`. For PaddleOCR-VL-faithful output,
-/// including heading levels derived from numbering, use
-/// [`to_markdown_openocr`].
-///
-/// # Arguments
-/// * `elements` - Layout elements with recognized text
-/// * `ignore_labels` - Labels to skip in markdown output, usually
-///   [`default_markdown_ignore_labels`]
-pub fn to_markdown(elements: &[LayoutElement], ignore_labels: &[String]) -> String {
-    let mut markdown = String::new();
-
-    for (i, element) in elements.iter().enumerate() {
-        let text = match &element.text {
-            Some(t) if !t.trim().is_empty() => t.trim(),
-            _ => continue,
-        };
-
-        if let Some(label) = &element.label
-            && ignore_labels.iter().any(|l| l == label)
-        {
-            continue;
-        }
-
-        let content = match element.element_type {
-            LayoutElementType::DocTitle => format_heading(text, 1),
-            LayoutElementType::ParagraphTitle => format_heading(text, 2),
-            LayoutElementType::Table => text::format_table(text),
-            LayoutElementType::Formula => text::format_formula(text),
-            LayoutElementType::Image | LayoutElementType::Chart | LayoutElementType::Seal => {
-                format_figure(text, i)
-            }
-            LayoutElementType::List => format_list(text),
-            LayoutElementType::Algorithm => format_code(text),
-            _ => text::format_text(text),
-        };
-
-        if !content.is_empty() {
-            markdown.push_str(&content);
-            markdown.push_str("\n\n");
-        }
-    }
-
-    markdown.trim().to_string()
-}
-
 // --- OpenOCR / PaddleX markdown compatibility ---
 
 // Matches PaddleX `compile_title_pattern()` in:
@@ -623,14 +576,20 @@ fn openocr_format_first_line(
     parts.join(splitter)
 }
 
-/// Convert layout elements to OpenOCR (PaddleX) markdown format.
+/// Renders layout elements as Markdown.
 ///
-/// This matches `PaddleOCRVLResult._to_markdown(pretty=...)` when labels come from PP-DocLayoutV2/V3.
-pub fn to_markdown_openocr(
-    elements: &[LayoutElement],
-    ignore_labels: &[String],
-    pretty: bool,
-) -> String {
+/// Matches `PaddleOCRVLResult._to_markdown(pretty=...)` when labels come from
+/// PP-DocLayoutV2/V3: headings take their level from the section numbering
+/// (`1.2 Foo` becomes `### 1.2 Foo`), and `abstract`, `reference` and
+/// `content` blocks get their own handling.
+///
+/// # Arguments
+/// * `elements` - Layout elements with recognized text, in reading order
+/// * `ignore_labels` - Labels to leave out, usually
+///   [`default_markdown_ignore_labels`]
+/// * `pretty` - Centre captions and tables with inline HTML, as the reference
+///   does. With `false` they stay plain text and table markup is unwrapped.
+pub fn to_markdown(elements: &[LayoutElement], ignore_labels: &[String], pretty: bool) -> String {
     let mut markdown = String::new();
 
     for element in elements {
@@ -725,66 +684,6 @@ pub fn to_markdown_openocr(
     }
 
     markdown
-}
-
-fn format_heading(text: &str, level: usize) -> String {
-    let prefix = "#".repeat(level.min(6));
-    let cleaned = remove_newlines_in_heading(text);
-    let processed = text::process_text(cleaned.trim());
-    format!("{} {}", prefix, processed)
-}
-
-fn format_figure(text: &str, index: usize) -> String {
-    if text.starts_with("![") {
-        return text.to_string();
-    }
-    if text.starts_with("figures/") || text.starts_with("imgs/") {
-        return format!("![Figure {}]({})", index + 1, text);
-    }
-    if text.starts_with("data:image/") {
-        return format!("![Figure {}]({})", index + 1, text);
-    }
-    format!("*Figure {}: {}*", index + 1, text)
-}
-
-fn format_list(text: &str) -> String {
-    let lines: Vec<&str> = text.lines().collect();
-    let mut result = String::new();
-    for line in lines {
-        let trimmed = line.trim();
-        if !trimmed.is_empty() {
-            if trimmed.starts_with('-')
-                || trimmed.starts_with('*')
-                || trimmed
-                    .chars()
-                    .next()
-                    .map(|c| c.is_ascii_digit())
-                    .unwrap_or(false)
-            {
-                result.push_str(trimmed);
-            } else {
-                result.push_str("- ");
-                result.push_str(trimmed);
-            }
-            result.push('\n');
-        }
-    }
-    result.trim_end().to_string()
-}
-
-fn format_code(text: &str) -> String {
-    format!("```\n{}\n```", text.trim())
-}
-
-fn remove_newlines_in_heading(text: &str) -> String {
-    fn is_chinese(c: char) -> bool {
-        ('\u{4e00}'..='\u{9fff}').contains(&c)
-    }
-    if text.chars().any(is_chinese) {
-        text.replace('\n', "")
-    } else {
-        text.replace('\n', " ")
-    }
 }
 
 pub use self::table::convert_otsl_to_html;
@@ -966,6 +865,50 @@ pub fn crop_margin(img: &RgbImage) -> RgbImage {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn titled(label: &str, text: &str) -> LayoutElement {
+        LayoutElement::new(
+            BoundingBox::from_coords(0.0, 0.0, 10.0, 10.0),
+            LayoutElementType::from_label(label),
+            0.9,
+        )
+        .with_label(label)
+        .with_text(text)
+    }
+
+    /// The single renderer keeps the reference behaviour that the removed
+    /// lightweight one lacked: heading depth follows the section numbering
+    /// rather than being a flat `##`.
+    #[test]
+    fn headings_take_their_level_from_the_numbering() {
+        let elements = vec![
+            titled("doc_title", "A Paper"),
+            titled("paragraph_title", "1 Introduction"),
+            titled("paragraph_title", "1.2 Background"),
+            titled("paragraph_title", "1.2.3 Details"),
+        ];
+        let markdown = to_markdown(&elements, &default_markdown_ignore_labels(), true);
+        let headings: Vec<&str> = markdown.lines().filter(|l| l.starts_with('#')).collect();
+        assert_eq!(
+            headings,
+            vec![
+                "# A Paper",
+                "## 1 Introduction",
+                "### 1.2 Background",
+                "#### 1.2.3 Details",
+            ]
+        );
+    }
+
+    /// `pretty` is the only knob left; it decides whether captions are centred
+    /// with inline HTML.
+    #[test]
+    fn pretty_controls_caption_centring() {
+        let elements = vec![titled("figure_title", "Figure 1: a plot")];
+        let ignore = default_markdown_ignore_labels();
+        assert!(to_markdown(&elements, &ignore, true).contains("text-align: center"));
+        assert!(!to_markdown(&elements, &ignore, false).contains("text-align: center"));
+    }
 
     #[test]
     fn test_parse_device_cpu() {

--- a/oar-ocr-vl/src/utils.rs
+++ b/oar-ocr-vl/src/utils.rs
@@ -464,11 +464,41 @@ pub fn rotate_half(x: &Tensor) -> Result<Tensor, Error> {
     })
 }
 
+/// Labels PP-StructureV3 leaves out of Markdown: running heads, page
+/// furniture and marginalia.
+///
+/// `formula_number` is here because PaddleOCR-VL drops it too, unless it was
+/// merged into the preceding formula.
+pub const DEFAULT_MARKDOWN_IGNORE_LABELS: [&str; 8] = [
+    "number",
+    "footnote",
+    "header",
+    "header_image",
+    "footer",
+    "footer_image",
+    "aside_text",
+    "formula_number",
+];
+
+/// [`DEFAULT_MARKDOWN_IGNORE_LABELS`] as owned strings, for the `ignore_labels`
+/// arguments below.
+pub fn default_markdown_ignore_labels() -> Vec<String> {
+    DEFAULT_MARKDOWN_IGNORE_LABELS
+        .iter()
+        .map(|label| (*label).to_string())
+        .collect()
+}
+
 /// Convert layout elements to Markdown format.
+///
+/// Every paragraph title becomes `##`. For PaddleOCR-VL-faithful output,
+/// including heading levels derived from numbering, use
+/// [`to_markdown_openocr`].
 ///
 /// # Arguments
 /// * `elements` - Layout elements with recognized text
-/// * `ignore_labels` - Labels to skip in markdown output
+/// * `ignore_labels` - Labels to skip in markdown output, usually
+///   [`default_markdown_ignore_labels`]
 pub fn to_markdown(elements: &[LayoutElement], ignore_labels: &[String]) -> String {
     let mut markdown = String::new();
 

--- a/oar-ocr-vl/src/utils.rs
+++ b/oar-ocr-vl/src/utils.rs
@@ -11,11 +11,11 @@ pub mod image;
 pub mod table;
 pub mod text;
 
+use crate::error::Error;
+use crate::geometry::BoundingBox;
+use crate::structure::{LayoutElement, LayoutElementType};
 use ::image::{GrayImage, RgbImage};
 use candle_core::{DType, Device, Tensor};
-use oar_ocr_core::core::OCRError;
-use oar_ocr_core::domain::structure::{LayoutElement, LayoutElementType};
-use oar_ocr_core::processors::BoundingBox;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashSet;
@@ -44,7 +44,7 @@ use std::collections::HashSet;
 /// use oar_ocr_vl::utils::parse_device;
 ///
 /// # #[allow(unused_variables)]
-/// # fn main() -> Result<(), oar_ocr_core::core::OCRError> {
+/// # fn main() -> Result<(), oar_ocr_vl::Error> {
 /// // CPU is always available
 /// let cpu = parse_device("cpu")?;
 ///
@@ -63,15 +63,15 @@ use std::collections::HashSet;
 /// # }
 /// ```
 #[cfg(not(feature = "cuda"))]
-fn cuda_not_enabled() -> OCRError {
-    OCRError::ConfigError {
+fn cuda_not_enabled() -> Error {
+    Error::Config {
         message: "CUDA support not enabled. Compile with --features cuda".to_string(),
     }
 }
 
 #[cfg(not(all(feature = "metal", target_os = "macos")))]
-fn metal_not_enabled() -> OCRError {
-    OCRError::ConfigError {
+fn metal_not_enabled() -> Error {
+    Error::Config {
         message: "Metal support not enabled. Compile on macOS with --features metal".to_string(),
     }
 }
@@ -83,28 +83,26 @@ fn parse_device_with_ordinal(
     prefix: &str,
     device_name: &str,
     creator: impl Fn(usize) -> candle_core::Result<Device>,
-) -> Result<Device, OCRError> {
-    let ordinal_str = s
-        .strip_prefix(prefix)
-        .ok_or_else(|| OCRError::ConfigError {
-            message: format!("Invalid {} device string '{}'", device_name, s),
-        })?;
-    let ordinal: usize = ordinal_str.parse().map_err(|_| OCRError::ConfigError {
+) -> Result<Device, Error> {
+    let ordinal_str = s.strip_prefix(prefix).ok_or_else(|| Error::Config {
+        message: format!("Invalid {} device string '{}'", device_name, s),
+    })?;
+    let ordinal: usize = ordinal_str.parse().map_err(|_| Error::Config {
         message: format!("Invalid {} device ordinal in '{}'", device_name, s),
     })?;
-    creator(ordinal).map_err(|e| OCRError::ConfigError {
+    creator(ordinal).map_err(|e| Error::Config {
         message: format!("Failed to create {} device {}: {}", device_name, ordinal, e),
     })
 }
 
-pub fn parse_device(device_str: &str) -> Result<Device, OCRError> {
+pub fn parse_device(device_str: &str) -> Result<Device, Error> {
     let device_str = device_str.to_lowercase();
     match device_str.as_str() {
         "cpu" => Ok(Device::Cpu),
         "cuda" | "gpu" => {
             #[cfg(feature = "cuda")]
             {
-                Device::new_cuda(0).map_err(|e| OCRError::ConfigError {
+                Device::new_cuda(0).map_err(|e| Error::Config {
                     message: format!("Failed to create CUDA device: {}", e),
                 })
             }
@@ -116,7 +114,7 @@ pub fn parse_device(device_str: &str) -> Result<Device, OCRError> {
         "metal" => {
             #[cfg(all(feature = "metal", target_os = "macos"))]
             {
-                Device::new_metal(0).map_err(|e| OCRError::ConfigError {
+                Device::new_metal(0).map_err(|e| Error::Config {
                     message: format!("Failed to create Metal device: {}", e),
                 })
             }
@@ -145,7 +143,7 @@ pub fn parse_device(device_str: &str) -> Result<Device, OCRError> {
                 Err(metal_not_enabled())
             }
         }
-        _ => Err(OCRError::ConfigError {
+        _ => Err(Error::Config {
             message: format!(
                 "Unknown device: '{}'. Use 'cpu', 'cuda', 'cuda:N', 'metal', or 'metal:N'",
                 device_str
@@ -224,13 +222,13 @@ fn bf16_works(device: &Device) -> bool {
     }
 }
 
-/// Convert Candle error to OCRError for inference operations.
+/// Convert Candle error to Error for inference operations.
 pub fn candle_to_ocr_inference(
     model_name: &str,
     context: impl Into<String>,
     err: candle_core::Error,
-) -> OCRError {
-    OCRError::Inference {
+) -> Error {
+    Error::Inference {
         model_name: model_name.to_string(),
         context: context.into(),
         source: Box::new(err),
@@ -267,13 +265,13 @@ pub fn error_chain_message(prefix: &str, e: &(dyn std::error::Error + 'static)) 
     chain
 }
 
-/// Convert Candle error to OCRError for processing operations.
+/// Convert Candle error to Error for processing operations.
 pub fn candle_to_ocr_processing(
-    kind: oar_ocr_core::core::errors::ProcessingStage,
+    kind: crate::error::ProcessingStage,
     context: impl Into<String>,
     err: candle_core::Error,
-) -> OCRError {
-    OCRError::Processing {
+) -> Error {
+    Error::Processing {
         kind,
         context: context.into(),
         source: Box::new(err),
@@ -291,13 +289,13 @@ pub fn candle_to_ocr_processing(
 pub fn collect_safetensors(
     model_dir: &std::path::Path,
     model_name: &str,
-) -> Result<Vec<std::path::PathBuf>, OCRError> {
+) -> Result<Vec<std::path::PathBuf>, Error> {
     let single = model_dir.join("model.safetensors");
     if single.exists() {
         return Ok(vec![single]);
     }
 
-    let read_dir = std::fs::read_dir(model_dir).map_err(|e| OCRError::ConfigError {
+    let read_dir = std::fs::read_dir(model_dir).map_err(|e| Error::Config {
         message: format!(
             "{model_name}: cannot read model dir {}: {e}",
             model_dir.display()
@@ -308,7 +306,7 @@ pub fn collect_safetensors(
         // Propagate per-entry I/O errors instead of silently dropping them, so a
         // partially-failed directory scan can't masquerade as "no shards found".
         let path = entry
-            .map_err(|e| OCRError::ConfigError {
+            .map_err(|e| Error::Config {
                 message: format!(
                     "{model_name}: error reading entry in model dir {}: {e}",
                     model_dir.display()
@@ -325,7 +323,7 @@ pub fn collect_safetensors(
     }
     shards.sort();
     if shards.is_empty() {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "{model_name}: no model.safetensors or model-*.safetensors found in {}",
                 model_dir.display()
@@ -344,9 +342,9 @@ pub fn load_json_config<T: serde::de::DeserializeOwned>(
     path: impl AsRef<std::path::Path>,
     model_name: &str,
     file_name: &str,
-) -> Result<T, OCRError> {
+) -> Result<T, Error> {
     let contents = std::fs::read_to_string(path)?;
-    serde_json::from_str(&contents).map_err(|e| OCRError::ConfigError {
+    serde_json::from_str(&contents).map_err(|e| Error::Config {
         message: format!("failed to parse {model_name} {file_name}: {e}"),
     })
 }
@@ -367,9 +365,9 @@ pub fn validate_image_mean_std(
     model_name: &str,
     image_mean: &[f32],
     image_std: &[f32],
-) -> Result<(), OCRError> {
+) -> Result<(), Error> {
     if image_mean.len() != 3 || image_std.len() != 3 {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!(
                 "{model_name} image_mean/std must have length 3, got mean={} std={}",
                 image_mean.len(),
@@ -387,9 +385,9 @@ pub fn validate_patch_merge_temporal(
     patch_size: usize,
     merge_size: usize,
     temporal_patch_size: usize,
-) -> Result<(), OCRError> {
+) -> Result<(), Error> {
     if patch_size == 0 || merge_size == 0 || temporal_patch_size == 0 {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!("{model_name} patch_size/merge_size/temporal_patch_size must be > 0"),
         });
     }
@@ -405,7 +403,7 @@ pub fn vision_inv_freq(
     theta: f64,
     model_name: &str,
     device: &Device,
-) -> Result<Tensor, OCRError> {
+) -> Result<Tensor, Error> {
     let mut inv_freq = Vec::with_capacity(dim / 2);
     for i in (0..dim).step_by(2) {
         let v = 1f64 / theta.powf(i as f64 / dim as f64);
@@ -413,7 +411,7 @@ pub fn vision_inv_freq(
     }
     Tensor::from_vec(inv_freq, (dim / 2,), device).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             format!("{model_name}: vision inv_freq tensor failed"),
             e,
         )
@@ -425,10 +423,10 @@ pub fn vision_inv_freq(
 /// Operates on the final axis only, so it is rank-agnostic — both the 4D
 /// text-attention tensors `(batch, heads, seq, head_dim)` and the 3D
 /// vision-attention tensors `(seq, heads, head_dim)` share this path.
-pub fn rotate_half(x: &Tensor) -> Result<Tensor, OCRError> {
+pub fn rotate_half(x: &Tensor) -> Result<Tensor, Error> {
     let d = x.dim(candle_core::D::Minus1).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "rotate_half dim failed",
             e,
         )
@@ -436,7 +434,7 @@ pub fn rotate_half(x: &Tensor) -> Result<Tensor, OCRError> {
     let half = d / 2;
     let x1 = x.narrow(candle_core::D::Minus1, 0, half).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "rotate_half slice x1 failed",
             e,
         )
@@ -445,21 +443,21 @@ pub fn rotate_half(x: &Tensor) -> Result<Tensor, OCRError> {
         .narrow(candle_core::D::Minus1, half, d - half)
         .map_err(|e| {
             candle_to_ocr_processing(
-                oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+                crate::error::ProcessingStage::TensorOperation,
                 "rotate_half slice x2 failed",
                 e,
             )
         })?;
     let nx2 = x2.neg().map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "rotate_half neg failed",
             e,
         )
     })?;
     Tensor::cat(&[&nx2, &x1], candle_core::D::Minus1).map_err(|e| {
         candle_to_ocr_processing(
-            oar_ocr_core::core::errors::ProcessingStage::TensorOperation,
+            crate::error::ProcessingStage::TensorOperation,
             "rotate_half cat failed",
             e,
         )
@@ -948,7 +946,7 @@ mod tests {
     #[test]
     fn test_error_chain_message_includes_sources() {
         let root = std::io::Error::other("CUDA_ERROR_OUT_OF_MEMORY");
-        let err = OCRError::Inference {
+        let err = Error::Inference {
             model_name: "PaddleOCR-VL".to_string(),
             context: "vision attn softmax".to_string(),
             source: Box::new(root),
@@ -991,7 +989,7 @@ mod tests {
     fn test_parse_device_invalid() {
         let result = parse_device("invalid");
         assert!(result.is_err());
-        if let Err(OCRError::ConfigError { message }) = result {
+        if let Err(Error::Config { message }) = result {
             assert!(message.contains("Unknown device"));
         }
     }
@@ -1012,7 +1010,7 @@ mod tests {
     fn test_parse_device_metal_invalid_ordinal() {
         let result = parse_device("metal:abc");
         assert!(result.is_err());
-        if let Err(OCRError::ConfigError { message }) = result {
+        if let Err(Error::Config { message }) = result {
             assert!(message.contains("Invalid Metal device ordinal"));
         }
     }
@@ -1022,13 +1020,13 @@ mod tests {
     fn test_parse_device_metal_not_enabled() {
         let result = parse_device("metal");
         assert!(result.is_err());
-        if let Err(OCRError::ConfigError { message }) = result {
+        if let Err(Error::Config { message }) = result {
             assert!(message.contains("Metal support not enabled"));
         }
 
         let result = parse_device("metal:0");
         assert!(result.is_err());
-        if let Err(OCRError::ConfigError { message }) = result {
+        if let Err(Error::Config { message }) = result {
             assert!(message.contains("Metal support not enabled"));
         }
     }

--- a/oar-ocr-vl/src/utils/image.rs
+++ b/oar-ocr-vl/src/utils/image.rs
@@ -350,8 +350,16 @@ pub fn resize_for_mineru(image: &RgbImage, min_edge: u32, max_aspect_ratio: f32)
 }
 
 /// Loads an image from disk and converts it to RGB.
+///
+/// The format comes from the file's contents, not its name, so extensionless
+/// and mislabelled files load. `image::open` would pick the decoder from the
+/// path suffix and reject both.
 pub fn load_image(path: impl AsRef<std::path::Path>) -> Result<RgbImage, crate::Error> {
-    Ok(image::open(path.as_ref())?.to_rgb8())
+    let file = std::io::BufReader::new(std::fs::File::open(path.as_ref())?);
+    let decoded = image::ImageReader::new(file)
+        .with_guessed_format()?
+        .decode()?;
+    Ok(decoded.to_rgb8())
 }
 
 /// Decodes an image from memory and converts it to RGB.
@@ -362,6 +370,26 @@ pub fn load_image_from_memory(bytes: &[u8]) -> Result<RgbImage, crate::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Callers pass paths straight from a CLI, where an extensionless or
+    /// mislabelled file is ordinary. The format must come from the bytes.
+    #[test]
+    fn loads_images_whose_name_does_not_match_their_format() {
+        let dir = std::env::temp_dir().join("oar_vl_load_image_by_content");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let mut png = Vec::new();
+        RgbImage::from_pixel(3, 2, ::image::Rgb([1, 2, 3]))
+            .write_with_encoder(::image::codecs::png::PngEncoder::new(&mut png))
+            .expect("encode png");
+
+        for name in ["no_extension", "actually_a_png.jpg"] {
+            let path = dir.join(name);
+            std::fs::write(&path, &png).expect("write fixture");
+            let loaded = load_image(&path).expect("load by content");
+            assert_eq!(loaded.dimensions(), (3, 2));
+            let _ = std::fs::remove_file(&path);
+        }
+    }
 
     #[test]
     fn test_patchify_merge_grouped_ordering() {

--- a/oar-ocr-vl/src/utils/image.rs
+++ b/oar-ocr-vl/src/utils/image.rs
@@ -1,6 +1,6 @@
+use crate::error::Error;
 use image::RgbImage;
 use image::imageops::FilterType;
-use oar_ocr_core::core::OCRError;
 use rayon::prelude::*;
 
 /// Convert an RGB image to a CHW tensor buffer with normalization and parallel processing.
@@ -180,9 +180,9 @@ pub fn smart_resize(
     factor: u32,
     min_pixels: u32,
     max_pixels: u32,
-) -> Result<(u32, u32), OCRError> {
+) -> Result<(u32, u32), Error> {
     if factor == 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "smart_resize: factor must be > 0".to_string(),
         });
     }
@@ -194,7 +194,7 @@ pub fn smart_resize(
     let max_dim = height.max(width);
     let min_dim = height.min(width);
     if min_dim > 0.0 && (max_dim / min_dim) > 200.0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: format!(
                 "smart_resize: absolute aspect ratio must be <= 200, got {:.3}",
                 max_dim / min_dim
@@ -218,7 +218,7 @@ pub fn smart_resize(
         }
         // After scaling down, ensure we don't violate min_pixels due to quantization
         if (h_bar * w_bar) < min_pixels as f64 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "smart_resize: cannot satisfy both min_pixels={} and max_pixels={} constraints after quantization",
                     min_pixels, max_pixels
@@ -238,7 +238,7 @@ pub fn smart_resize(
         }
         // After scaling up, ensure we don't violate max_pixels due to quantization
         if (h_bar * w_bar) > max_pixels as f64 {
-            return Err(OCRError::InvalidInput {
+            return Err(Error::InvalidInput {
                 message: format!(
                     "smart_resize: cannot satisfy both min_pixels={} and max_pixels={} constraints after quantization",
                     min_pixels, max_pixels
@@ -258,22 +258,22 @@ pub fn clamp_to_max_image_size(
     width: u32,
     factor: u32,
     max_image_size: usize,
-) -> Result<(u32, u32), OCRError> {
+) -> Result<(u32, u32), Error> {
     if factor == 0 {
-        return Err(OCRError::InvalidInput {
+        return Err(Error::InvalidInput {
             message: "clamp_to_max_image_size: factor must be > 0".to_string(),
         });
     }
-    let max_image_size = u32::try_from(max_image_size).map_err(|_| OCRError::ConfigError {
+    let max_image_size = u32::try_from(max_image_size).map_err(|_| Error::Config {
         message: format!("max_image_size too large: {max_image_size}"),
     })?;
     if max_image_size == 0 {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: "max_image_size must be > 0".to_string(),
         });
     }
     if max_image_size < factor {
-        return Err(OCRError::ConfigError {
+        return Err(Error::Config {
             message: format!("max_image_size {max_image_size} must be >= factor={factor}"),
         });
     }
@@ -349,6 +349,16 @@ pub fn resize_for_mineru(image: &RgbImage, min_edge: u32, max_aspect_ratio: f32)
     out.into_owned()
 }
 
+/// Loads an image from disk and converts it to RGB.
+pub fn load_image(path: impl AsRef<std::path::Path>) -> Result<RgbImage, crate::Error> {
+    Ok(image::open(path.as_ref())?.to_rgb8())
+}
+
+/// Decodes an image from memory and converts it to RGB.
+pub fn load_image_from_memory(bytes: &[u8]) -> Result<RgbImage, crate::Error> {
+    Ok(image::load_from_memory(bytes)?.to_rgb8())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -422,7 +432,7 @@ mod tests {
     }
 
     #[test]
-    fn test_smart_resize_factor_divisibility() -> Result<(), OCRError> {
+    fn test_smart_resize_factor_divisibility() -> Result<(), Error> {
         let (h, w) = smart_resize(100, 200, 28, 147_384, 2_822_400)?;
         assert_eq!(h % 28, 0);
         assert_eq!(w % 28, 0);
@@ -430,7 +440,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clamp_to_max_image_size_keeps_factor_divisible() -> Result<(), OCRError> {
+    fn test_clamp_to_max_image_size_keeps_factor_divisible() -> Result<(), Error> {
         let factor = 32;
         let (h, w) = clamp_to_max_image_size(3008, 512, factor, 2048)?;
         assert!(h <= 2048);


### PR DESCRIPTION
## Summary

Makes `oar-ocr-vl` a self-contained Candle crate: it no longer depends on `oar-ocr-core` or pulls ONNX Runtime into the tree. The piece that forced that dependency — layout detection — is now a native port of **PP-DocLayoutV2/V3**, so the whole VL pipeline runs on one backend.

Installing the crate is correspondingly simpler:

```toml
[dependencies]
oar-ocr-vl = "0.9"          # was: oar-ocr-core + oar-ocr-vl with download-binaries
```

The crate's only remaining features are `cuda` and `metal`.

## What's new

**`pp_doclayout`** — RT-DETR detector (HGNetV2-L backbone, hybrid encoder, deformable-attention decoder) shared by both generations, which differ in how they predict reading order:

- **V2** runs a LayoutLM-style pointer network over the surviving boxes.
- **V3** uses an order head inside the decoder, plus a mask branch whose prototypes seed the decoder's initial reference boxes (`mask_enhanced`, the upstream default).

Weights are the `model.safetensors` checkpoints published as `PaddlePaddle/PP-DocLayoutV{2,3}_safetensors` (54M / 33M params).

**`LayoutSource`** — a small trait decoupling `DocParser` from *how* layout is produced. `PpDocLayout` is the built-in implementation; anything else (a remote service, a cached run, an ONNX model in your own code) can implement it. Regions are consumed in the order the source returns them, so the geometric XY-cut fallback is gone — both checkpoints predict reading order directly.

**Vendored support types** — `Error`, `BoundingBox`, `StructureResult`/`LayoutElement`/`TableResult`, and bbox cropping, previously borrowed from `oar-ocr-core`. `structure` is trimmed to what a VL pipeline actually fills in, so no field reads back permanently empty.

## Usage

```bash
cargo run -p oar-ocr-vl --features cuda --example doc_parser -- \
    --model-name paddleocr-vl \
    --model-dir PaddlePaddle/PaddleOCR-VL \
    --layout-dir PaddlePaddle/PP-DocLayoutV3 \
    --device cuda \
    document.jpg
```

The example's `--layout-model <file>.onnx` flag becomes `--layout-dir <checkpoint dir>`.

## Fidelity

Preprocessing matches the classic path exactly (CatmullRom, 800×800, `1/255`, mean 0 / std 1, RGB). The postprocessing chain — `mask_to_box_coordinate` including its empty-mask zeroing, `inverse_sigmoid`'s eps clamp, the order-vote formula, and the V2 pointer network's token and attention-mask construction — follows the reference `transformers` implementation.

Two deliberate departures, both documented in code:

- Class selection uses a per-query argmax rather than a top-k over the flattened `(query, class)` matrix, giving one box per query. The two agree whenever a query has a single class above its threshold.
- `normalize_before: true` (pre-LN encoder) is rejected at load rather than silently running the wrong layer order; both shipped checkpoints are post-LN.

An ignored `matches_the_pytorch_reference` test compares the port stage-by-stage against a PyTorch dump; see its doc comment for how to run it.

## Verification

- All three CI clippy invocations clean under `-D warnings`, plus a new `-p oar-ocr-core --no-default-features` lint job.
- `cargo test --workspace` green; `RUSTDOCFLAGS="-D warnings" cargo doc` clean.
- Both checkpoints exercised on real fixtures; V2 and V3 produce consistent, correctly ordered detections on multi-column pages.
- Every Rust snippet in `docs/usage.md` was extracted and compiled — these are not doctested, and several had drifted to imports that no longer exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
