### PR TITLE
build: prepare v0.9.1 dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "oar-ocr-derive", "oar-ocr-core", "oar-ocr-vl"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.95"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ repository = "https://github.com/greatv/oar-ocr"
 homepage = "https://github.com/greatv/oar-ocr"
 
 [workspace.dependencies]
-oar-ocr-core = { version = "0.9.0", path = "oar-ocr-core", default-features = false }
-oar-ocr-derive = { version = "0.9.0", path = "oar-ocr-derive", default-features = false }
+oar-ocr-core = { version = "0.9.1", path = "oar-ocr-core", default-features = false }
+oar-ocr-derive = { version = "0.9.1", path = "oar-ocr-derive", default-features = false }
 
 # Shared third-party dependencies (kept in sync via workspace inheritance).
 clap = { version = "4.5.42", features = ["derive"] }

--- a/oar-ocr-core/Cargo.toml
+++ b/oar-ocr-core/Cargo.toml
@@ -46,11 +46,9 @@ multiversion = { version = "0.8", optional = true }
 nalgebra = "0.35"
 ndarray = "0.17"
 oar-ocr-derive.workspace = true
-# Pinned exactly: `ort` is pre-release, so a caret requirement lets Cargo pick
-# up the next release candidate on a fresh resolve. rc.13 renames every
-# execution-provider type (`CPUExecutionProvider` -> `CPU`, ...), which breaks
-# the build without any change on our side. Unpin together with that migration.
-ort = { version = "=2.0.0-rc.12", default-features = false, features = [ "std", "ndarray", "tracing", "copy-dylibs" ] }
+# Pinned exactly because `ort` is pre-release and later release candidates may
+# make source-incompatible API changes on a fresh resolve.
+ort = { version = "=2.0.0-rc.13", default-features = false, features = [ "std", "ndarray", "tracing", "copy-dylibs" ] }
 rayon.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/oar-ocr-core/src/core/inference/ort_infer_config.rs
+++ b/oar-ocr-core/src/core/inference/ort_infer_config.rs
@@ -82,8 +82,7 @@ impl OrtInfer {
         for ep in eps {
             match ep {
                 EP::CPU => {
-                    providers
-                        .push(ort::execution_providers::CPUExecutionProvider::default().build());
+                    providers.push(ort::ep::CPU::default().build());
                 }
                 #[cfg(feature = "cuda")]
                 EP::CUDA {
@@ -93,11 +92,8 @@ impl OrtInfer {
                     cudnn_conv_algo_search,
                     cudnn_conv_use_max_workspace,
                 } => {
-                    use ort::execution_providers::{
-                        ArenaExtendStrategy, cuda::ConvAlgorithmSearch,
-                    };
-                    let mut cuda_provider =
-                        ort::execution_providers::CUDAExecutionProvider::default();
+                    use ort::ep::{ArenaExtendStrategy, cuda::ConvAlgorithmSearch};
+                    let mut cuda_provider = ort::ep::CUDA::default();
                     if let Some(id) = device_id {
                         cuda_provider = cuda_provider.with_device_id(*id);
                     }
@@ -154,7 +150,7 @@ impl OrtInfer {
                     dump_ep_context_model,
                     ep_context_file_path,
                 } => {
-                    let mut trt_provider = ort::ep::TensorRTExecutionProvider::default();
+                    let mut trt_provider = ort::ep::TensorRT::default();
                     if let Some(id) = device_id {
                         trt_provider = trt_provider.with_device_id(*id);
                     }
@@ -193,8 +189,7 @@ impl OrtInfer {
                 }
                 #[cfg(feature = "directml")]
                 EP::DirectML { device_id } => {
-                    let mut dml_provider =
-                        ort::execution_providers::DirectMLExecutionProvider::default();
+                    let mut dml_provider = ort::ep::DirectML::default();
                     if let Some(id) = device_id {
                         dml_provider = dml_provider.with_device_id(*id);
                     }
@@ -209,11 +204,8 @@ impl OrtInfer {
                         OrtCoreMLComputeUnits, OrtCoreMLModelFormat,
                         OrtCoreMLSpecializationStrategy,
                     };
-                    use ort::execution_providers::coreml::{
-                        ComputeUnits, ModelFormat, SpecializationStrategy,
-                    };
-                    let mut coreml_provider =
-                        ort::execution_providers::CoreMLExecutionProvider::default();
+                    use ort::ep::coreml::{ComputeUnits, ModelFormat, SpecializationStrategy};
+                    let mut coreml_provider = ort::ep::CoreML::default();
                     if let Some(units) = _coreml_config.and_then(|config| config.compute_units) {
                         let units = match units {
                             OrtCoreMLComputeUnits::All => ComputeUnits::All,
@@ -276,16 +268,14 @@ impl OrtInfer {
                 }
                 #[cfg(feature = "webgpu")]
                 EP::WebGPU => {
-                    providers
-                        .push(ort::execution_providers::WebGPUExecutionProvider::default().build());
+                    providers.push(ort::ep::WebGPU::default().build());
                 }
                 #[cfg(feature = "openvino")]
                 EP::OpenVINO {
                     device_type,
                     num_threads,
                 } => {
-                    let mut openvino_provider =
-                        ort::execution_providers::OpenVINOExecutionProvider::default();
+                    let mut openvino_provider = ort::ep::OpenVINO::default();
                     if let Some(device) = device_type {
                         openvino_provider = openvino_provider.with_device_type(device.clone());
                     }

--- a/oar-ocr-derive/Cargo.toml
+++ b/oar-ocr-derive/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["development-tools::procedural-macro-helpers"]
 proc-macro = true
 
 [dependencies]
-darling = "0.23"
+darling = "0.24"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
+syn = { version = "3", features = ["full", "parsing", "extra-traits"] }


### PR DESCRIPTION
## Summary

- set the workspace release version to `0.9.1`
- update ONNX Runtime from `ort 2.0.0-rc.12` to `2.0.0-rc.13`
- migrate internal execution-provider construction to the renamed `ort::ep` APIs
- update the derive stack to `darling 0.24` and `syn 3`

## Why

`ort 2.0.0-rc.13` renamed its execution-provider types and module paths, so the dependency cannot be upgraded without a source migration. These changes are internal and preserve OAR-OCR's public API, making `0.9.1` the appropriate patch release.

## Impact

Existing OAR-OCR configuration and builder APIs remain unchanged. CPU and CUDA inference continue to produce the expected outputs with the updated runtime.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `run_tests.sh`: 57/57 classic CPU/CUDA example runs passed
- `run_vl.sh`: 35/35 CUDA VL example runs passed
- manually checked OCR, table, chart, formula, seal, and full-page parsing outputs; no systematic accuracy regression observed
