### PR TITLE
refactor(vl): query Metal memory via Candle

### DIFF
--- a/oar-ocr-vl/Cargo.toml
+++ b/oar-ocr-vl/Cargo.toml
@@ -36,7 +36,6 @@ metal = [
     "candle-core/metal",
     "candle-nn/metal",
     "candle-transformers/metal",
-    "dep:objc2-metal",
 ]
 
 [dependencies]
@@ -47,9 +46,6 @@ candle-transformers = "0.11.0"
 html-escape = "0.2"
 half = "2"
 image.workspace = true
-# Only used to query Metal working-set memory; must stay on the same major
-# version candle-core links so `MTLDevice` is the same type.
-objc2-metal = { version = "0.3.1", optional = true }
 once_cell = "1.19"
 rand = "0.10"
 rayon.workspace = true

--- a/oar-ocr-vl/src/utils.rs
+++ b/oar-ocr-vl/src/utils.rs
@@ -242,7 +242,7 @@ pub fn candle_to_ocr_inference(
 /// exceeding it makes the driver page resources every dispatch. Reporting it
 /// lets memory-aware fallbacks (chunked vision attention) engage there.
 ///
-/// The Metal figure is conservative: `currentAllocatedSize` counts candle's
+/// The Metal figure is conservative: candle's `current_allocated_size` counts
 /// pooled buffers, which it only releases on `wait_until_completed`, so free
 /// memory reads lower as the pool warms up. Callers should treat it as a lower
 /// bound rather than a stable measure of what is available.
@@ -259,10 +259,9 @@ pub fn free_device_memory(device: &Device) -> Option<usize> {
     }
     #[cfg(all(feature = "metal", target_os = "macos"))]
     if let Device::Metal(dev) = device {
-        use objc2_metal::MTLDevice;
-        let raw = dev.metal_device().as_ref();
-        let budget = raw.recommendedMaxWorkingSetSize() as usize;
-        let allocated = raw.currentAllocatedSize();
+        let raw = dev.metal_device();
+        let budget = raw.recommended_max_working_set_size();
+        let allocated = raw.current_allocated_size();
         // A zero budget means the driver declined to report one; unknown, not
         // "nothing free".
         return (budget > 0).then(|| budget.saturating_sub(allocated));


### PR DESCRIPTION
## Summary

Drop the direct `objc2-metal` dependency from `oar-ocr-vl`. Metal working-set headroom is now read through Candle's own wrappers (`recommended_max_working_set_size` / `current_allocated_size`) instead of `objc2_metal::MTLDevice`.

The previous path required `oar-ocr-vl` to stay on the same `objc2-metal` major as `candle-core` so the `MTLDevice` types matched. Candle 0.11 already exposes the same two queries, so the extra crate is unnecessary. Semantics of `free_device_memory` are unchanged: chunked vision attention still sees a conservative lower bound on Metal free memory.

## Test plan

- [x] `cargo clippy --all-targets -p oar-ocr-vl --features metal -- -D warnings`
- [x] `cargo test -p oar-ocr-vl --features metal` (190 passed, including Metal device/SDPA tests)
- [x] `cargo test --workspace` (697 passed)