### PR TITLE
fix(vl): stop CUDA-graph disposal from poisoning the stream-ordered allocator

### DIFF
--- a/oar-ocr-vl/build.rs
+++ b/oar-ocr-vl/build.rs
@@ -105,6 +105,22 @@ fn validate_cuda_aggregator(sources: &[std::path::PathBuf]) {
     }
 }
 
+fn nvcc_major_version(nvcc: &std::ffi::OsStr) -> Option<u32> {
+    let output = Command::new(nvcc).arg("--version").output().ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The last line reads "Cuda compilation tools, release 13.2, V13.2.78".
+    let release = stdout
+        .lines()
+        .find_map(|line| line.split("release ").nth(1).map(str::to_owned))?;
+    release
+        .split([',', ' '])
+        .next()?
+        .split('.')
+        .next()?
+        .parse()
+        .ok()
+}
+
 fn main() {
     let mut cuda_sources = Vec::new();
     collect_cuda_sources(Path::new("src"), &mut cuda_sources);
@@ -129,9 +145,16 @@ fn main() {
         let out_dir = std::path::PathBuf::from(
             std::env::var_os("OUT_DIR").expect("Cargo always sets OUT_DIR"),
         );
-        let output = Command::new(&nvcc)
+        let mut command = Command::new(&nvcc);
+        command
             .args(["--ptx", "--std=c++17", "-O3"])
-            .arg(format!("--gpu-architecture={cuda_arch}"))
+            .arg(format!("--gpu-architecture={cuda_arch}"));
+        // CUDA 13 CCCL headers fatal out (MSVC C1189) under cl.exe's
+        // traditional preprocessor; request the conforming one.
+        if target_os == "windows" && nvcc_major_version(&nvcc).is_some_and(|major| major >= 13) {
+            command.arg("-Xcompiler").arg("/Zc:preprocessor");
+        }
+        let output = command
             .arg("-o")
             .arg(out_dir.join("oar_vl_kernels.ptx"))
             .arg("src/cuda_kernels.cu")

--- a/oar-ocr-vl/build.rs
+++ b/oar-ocr-vl/build.rs
@@ -134,6 +134,11 @@ fn main() {
     let metal_enabled = std::env::var_os("CARGO_FEATURE_METAL").is_some();
     let cuda_enabled = std::env::var_os("CARGO_FEATURE_CUDA").is_some();
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    // The build host triple (e.g. x86_64-pc-windows-msvc): -Xcompiler options
+    // go to the *host* compiler, so gate MSVC-only flags on HOST, not target.
+    let host_is_msvc = std::env::var("HOST")
+        .map(|host| host.ends_with("-msvc"))
+        .unwrap_or_default();
 
     if metal_enabled && target_os != "macos" {
         panic!("oar-ocr-vl feature `metal` is only supported on macOS targets");
@@ -151,7 +156,7 @@ fn main() {
             .arg(format!("--gpu-architecture={cuda_arch}"));
         // CUDA 13 CCCL headers fatal out (MSVC C1189) under cl.exe's
         // traditional preprocessor; request the conforming one.
-        if target_os == "windows" && nvcc_major_version(&nvcc).is_some_and(|major| major >= 13) {
+        if host_is_msvc && nvcc_major_version(&nvcc).is_some_and(|major| major >= 13) {
             command.arg("-Xcompiler").arg("/Zc:preprocessor");
         }
         let output = command

--- a/oar-ocr-vl/src/attention.rs
+++ b/oar-ocr-vl/src/attention.rs
@@ -850,9 +850,7 @@ impl RotaryEmbedding {
                 let position_ids = position_ids.to_dtype(DType::F32).map_err(|e| {
                     candle_to_ocr_processing(
                         crate::error::ProcessingStage::TensorOperation,
-                        format!(
-                            "RotaryEmbedding: position_ids cast to f32 failed (dims {dims:?})"
-                        ),
+                        format!("RotaryEmbedding: position_ids cast to f32 failed (dims {dims:?})"),
                         e,
                     )
                 })?;

--- a/oar-ocr-vl/src/attention.rs
+++ b/oar-ocr-vl/src/attention.rs
@@ -850,7 +850,9 @@ impl RotaryEmbedding {
                 let position_ids = position_ids.to_dtype(DType::F32).map_err(|e| {
                     candle_to_ocr_processing(
                         crate::error::ProcessingStage::TensorOperation,
-                        "RotaryEmbedding: position_ids cast to f32 failed",
+                        format!(
+                            "RotaryEmbedding: position_ids cast to f32 failed (dims {dims:?})"
+                        ),
                         e,
                     )
                 })?;

--- a/oar-ocr-vl/src/decoder_graph.rs
+++ b/oar-ocr-vl/src/decoder_graph.rs
@@ -65,21 +65,20 @@ pub(crate) fn report_stashed_cuda_error(device: &Device, context: &'static str) 
     }
 }
 
-/// Drain errors that dropping graph-bound buffers stashed on the context.
-/// Freeing memory owned by a destroyed graph fails with
-/// CUDA_ERROR_INVALID_VALUE inside cudarc's drop glue; that one is expected
-/// here. Anything else is a real failure and must still be reported.
+/// Drain a CudaContext by `check_err`ing until it comes back clean. cudarc
+/// may record several errors in a row, so a single drain would drop all but
+/// the last one.
 #[cfg(feature = "cuda")]
-pub(crate) fn drain_cuda_graph_drop_errors(device: &Device) {
-    use candle_core::cuda_backend::cudarc::driver::{result::DriverError, sys::CUresult};
-
+pub(crate) fn drain_cuda_context_errors(device: &Device) {
     let Device::Cuda(cuda) = device else {
         return;
     };
-    match cuda.cuda_stream().context().check_err() {
-        Ok(()) | Err(DriverError(CUresult::CUDA_ERROR_INVALID_VALUE)) => {}
-        Err(error) => {
-            tracing::warn!("unexpected CUDA error stashed during CUDA graph disposal: {error}");
+    let stream = cuda.cuda_stream();
+    let context = stream.context().clone();
+    loop {
+        match context.check_err() {
+            Ok(()) => break,
+            Err(error) => tracing::warn!("stashed CUDA error during CUDA graph teardown: {error}"),
         }
     }
 }
@@ -90,7 +89,7 @@ pub(crate) fn drain_cuda_graph_drop_errors(device: &Device) {
 #[cfg(feature = "cuda")]
 pub(crate) fn drop_and_drain<T>(value: T, device: &Device) {
     drop(value);
-    drain_cuda_graph_drop_errors(device);
+    drain_cuda_context_errors(device);
 }
 
 /// Last-field guard for graph-owning model structs: the model's `Drop`
@@ -115,7 +114,7 @@ impl CudaGraphDrainGuard {
 #[cfg(feature = "cuda")]
 impl Drop for CudaGraphDrainGuard {
     fn drop(&mut self) {
-        drain_cuda_graph_drop_errors(&self.device);
+        drain_cuda_context_errors(&self.device);
     }
 }
 

--- a/oar-ocr-vl/src/decoder_graph.rs
+++ b/oar-ocr-vl/src/decoder_graph.rs
@@ -52,6 +52,38 @@ pub(crate) fn cuda_graph_error(
     }
 }
 
+/// Surface a CUDA error that drop glue stashed on the context *before* graph
+/// teardown runs, so preexisting failures are reported rather than silently
+/// overwritten or cleared by the teardown drain below.
+#[cfg(feature = "cuda")]
+pub(crate) fn report_stashed_cuda_error(device: &Device, context: &'static str) {
+    let Device::Cuda(cuda) = device else {
+        return;
+    };
+    if let Err(error) = cuda.cuda_stream().context().check_err() {
+        tracing::warn!("stashed CUDA error before {context}: {error}");
+    }
+}
+
+/// Drain errors that dropping graph-bound buffers stashed on the context.
+/// Freeing memory owned by a destroyed graph fails with
+/// CUDA_ERROR_INVALID_VALUE inside cudarc's drop glue; that one is expected
+/// here. Anything else is a real failure and must still be reported.
+#[cfg(feature = "cuda")]
+pub(crate) fn drain_cuda_graph_drop_errors(device: &Device) {
+    use candle_core::cuda_backend::cudarc::driver::{result::DriverError, sys::CUresult};
+
+    let Device::Cuda(cuda) = device else {
+        return;
+    };
+    match cuda.cuda_stream().context().check_err() {
+        Ok(()) | Err(DriverError(CUresult::CUDA_ERROR_INVALID_VALUE)) => {}
+        Err(error) => {
+            tracing::warn!("unexpected CUDA error stashed during CUDA graph disposal: {error}");
+        }
+    }
+}
+
 #[cfg(feature = "cuda")]
 pub(crate) fn sync_graph_tensor(
     model_name: &str,
@@ -201,18 +233,14 @@ impl SingleTokenDecoderCudaGraph {
             cache_len: _,
         } = self;
         let device = hidden_input.device().clone();
+        report_stashed_cuda_error(&device, "decoder CUDA graph disposal");
         drop(graph);
         drop(logits_output);
         drop(kv_lengths);
         drop(_query_lengths);
         drop(position_input);
         drop(hidden_input);
-        // Drops above may have stashed errors on the context (freeing
-        // graph-bound memory fails inside cudarc's drop glue). Surface and
-        // clear them here so they cannot poison the next CUDA call.
-        if let Device::Cuda(cuda) = device {
-            let _ = cuda.cuda_stream().context().check_err();
-        }
+        drain_cuda_graph_drop_errors(&device);
     }
 }
 

--- a/oar-ocr-vl/src/decoder_graph.rs
+++ b/oar-ocr-vl/src/decoder_graph.rs
@@ -170,8 +170,12 @@ impl std::fmt::Debug for CudaGraphKvLengths {
 /// Captured storage for a batch-1, query-length-1 decoder graph.
 ///
 /// The graph owns raw pointers into every tensor below, the model's fixed KV
-/// storage, its weights, and the external LM head. Keep `graph` first so it is
-/// destroyed before the tensors when this value is dropped.
+/// storage, its weights, and the external LM head. Dispose through
+/// [`Self::dispose`] rather than a plain drop: tensors that were allocated
+/// while the stream was capturing (or whose events/addresses were baked into
+/// graph nodes) must not be handed back to the stream-ordered allocator after
+/// the exec is destroyed — doing so poisons the allocator and makes later,
+/// unrelated allocations fail with CUDA_ERROR_INVALID_VALUE.
 #[cfg(feature = "cuda")]
 pub(crate) struct SingleTokenDecoderCudaGraph {
     pub(crate) graph: candle_core::cuda_backend::cudarc::driver::CudaGraph,
@@ -181,6 +185,30 @@ pub(crate) struct SingleTokenDecoderCudaGraph {
     pub(crate) kv_lengths: CudaGraphKvLengths,
     pub(crate) logits_output: Tensor,
     pub(crate) cache_len: usize,
+}
+
+#[cfg(feature = "cuda")]
+impl SingleTokenDecoderCudaGraph {
+    pub(crate) fn dispose(self) {
+        let Self {
+            graph,
+            hidden_input,
+            position_input,
+            _query_lengths,
+            kv_lengths,
+            logits_output,
+            cache_len: _,
+        } = self;
+        // Leak every buffer the capture touched; their storage (a few hundred
+        // KB per bucket) is reclaimed at process exit. Only the exec itself is
+        // destroyed.
+        std::mem::forget(logits_output);
+        std::mem::forget(kv_lengths);
+        std::mem::forget(_query_lengths);
+        std::mem::forget(position_input);
+        std::mem::forget(hidden_input);
+        drop(graph);
+    }
 }
 
 #[cfg(feature = "cuda")]

--- a/oar-ocr-vl/src/decoder_graph.rs
+++ b/oar-ocr-vl/src/decoder_graph.rs
@@ -171,11 +171,11 @@ impl std::fmt::Debug for CudaGraphKvLengths {
 ///
 /// The graph owns raw pointers into every tensor below, the model's fixed KV
 /// storage, its weights, and the external LM head. Dispose through
-/// [`Self::dispose`] rather than a plain drop: tensors that were allocated
-/// while the stream was capturing (or whose events/addresses were baked into
-/// graph nodes) must not be handed back to the stream-ordered allocator after
-/// the exec is destroyed — doing so poisons the allocator and makes later,
-/// unrelated allocations fail with CUDA_ERROR_INVALID_VALUE.
+/// [`Self::dispose`] rather than a plain drop: the length buffers service the
+/// graph's HtoD updates, and handing them (or any capture-time allocation)
+/// back to the stream-ordered allocator poisons it, making later, unrelated
+/// allocations fail with CUDA_ERROR_INVALID_VALUE. The input/output tensors
+/// are allocated outside the capture and may be dropped normally.
 #[cfg(feature = "cuda")]
 pub(crate) struct SingleTokenDecoderCudaGraph {
     pub(crate) graph: candle_core::cuda_backend::cudarc::driver::CudaGraph,
@@ -199,14 +199,13 @@ impl SingleTokenDecoderCudaGraph {
             logits_output,
             cache_len: _,
         } = self;
-        // Leak every buffer the capture touched; their storage (a few hundred
-        // KB per bucket) is reclaimed at process exit. Only the exec itself is
-        // destroyed.
-        std::mem::forget(logits_output);
+        // Leak the two small length buffers (a few dozen bytes per captured
+        // graph); everything sizable was allocated outside the capture.
         std::mem::forget(kv_lengths);
         std::mem::forget(_query_lengths);
-        std::mem::forget(position_input);
-        std::mem::forget(hidden_input);
+        drop(logits_output);
+        drop(position_input);
+        drop(hidden_input);
         drop(graph);
     }
 }

--- a/oar-ocr-vl/src/decoder_graph.rs
+++ b/oar-ocr-vl/src/decoder_graph.rs
@@ -171,11 +171,12 @@ impl std::fmt::Debug for CudaGraphKvLengths {
 ///
 /// The graph owns raw pointers into every tensor below, the model's fixed KV
 /// storage, its weights, and the external LM head. Dispose through
-/// [`Self::dispose`] rather than a plain drop: the length buffers service the
-/// graph's HtoD updates, and handing them (or any capture-time allocation)
-/// back to the stream-ordered allocator poisons it, making later, unrelated
-/// allocations fail with CUDA_ERROR_INVALID_VALUE. The input/output tensors
-/// are allocated outside the capture and may be dropped normally.
+/// [`Self::dispose`] rather than a plain drop: freeing buffers that are bound
+/// to a CUDA graph fails inside cudarc's drop glue, which *stashes* the error
+/// on the context; the next unrelated fallible CUDA call would then return
+/// that stale CUDA_ERROR_INVALID_VALUE. `dispose` drops everything and then
+/// drains the stashed error so nothing leaks and no context state is kept
+/// alive by forgotten tensors.
 #[cfg(feature = "cuda")]
 pub(crate) struct SingleTokenDecoderCudaGraph {
     pub(crate) graph: candle_core::cuda_backend::cudarc::driver::CudaGraph,
@@ -199,14 +200,19 @@ impl SingleTokenDecoderCudaGraph {
             logits_output,
             cache_len: _,
         } = self;
-        // Leak the two small length buffers (a few dozen bytes per captured
-        // graph); everything sizable was allocated outside the capture.
-        std::mem::forget(kv_lengths);
-        std::mem::forget(_query_lengths);
+        let device = hidden_input.device().clone();
+        drop(graph);
         drop(logits_output);
+        drop(kv_lengths);
+        drop(_query_lengths);
         drop(position_input);
         drop(hidden_input);
-        drop(graph);
+        // Drops above may have stashed errors on the context (freeing
+        // graph-bound memory fails inside cudarc's drop glue). Surface and
+        // clear them here so they cannot poison the next CUDA call.
+        if let Device::Cuda(cuda) = device {
+            let _ = cuda.cuda_stream().context().check_err();
+        }
     }
 }
 

--- a/oar-ocr-vl/src/decoder_graph.rs
+++ b/oar-ocr-vl/src/decoder_graph.rs
@@ -67,9 +67,12 @@ pub(crate) fn report_stashed_cuda_error(device: &Device, context: &'static str) 
 
 /// Drain a CudaContext by `check_err`ing until it comes back clean. cudarc
 /// may record several errors in a row, so a single drain would drop all but
-/// the last one.
+/// the last one. The expected graph-bound free failure (stashed as
+/// CUDA_ERROR_INVALID_VALUE) is suppressed; anything else is reported.
 #[cfg(feature = "cuda")]
 pub(crate) fn drain_cuda_context_errors(device: &Device) {
+    use candle_core::cuda_backend::cudarc::driver::{result::DriverError, sys::CUresult};
+
     let Device::Cuda(cuda) = device else {
         return;
     };
@@ -78,7 +81,10 @@ pub(crate) fn drain_cuda_context_errors(device: &Device) {
     loop {
         match context.check_err() {
             Ok(()) => break,
-            Err(error) => tracing::warn!("stashed CUDA error during CUDA graph teardown: {error}"),
+            Err(DriverError(CUresult::CUDA_ERROR_INVALID_VALUE)) => {}
+            Err(error) => {
+                tracing::warn!("stashed CUDA error during CUDA graph teardown: {error}");
+            }
         }
     }
 }

--- a/oar-ocr-vl/src/decoder_graph.rs
+++ b/oar-ocr-vl/src/decoder_graph.rs
@@ -84,6 +84,41 @@ pub(crate) fn drain_cuda_graph_drop_errors(device: &Device) {
     }
 }
 
+/// Drop one graph-bound value and immediately drain whatever its destructor
+/// stashed. cudarc records at most one error on the context, so draining
+/// after every drop keeps teardown failures from overwriting each other.
+#[cfg(feature = "cuda")]
+pub(crate) fn drop_and_drain<T>(value: T, device: &Device) {
+    drop(value);
+    drain_cuda_graph_drop_errors(device);
+}
+
+/// Last-field guard for graph-owning model structs: the model's `Drop`
+/// disposes cached graphs, but Rust frees the remaining fields (KV caches,
+/// weights, embeddings) only afterwards, and those frees can also stash
+/// errors. Declared last so it drops last and drains whatever they left.
+#[cfg(feature = "cuda")]
+#[derive(Debug)]
+pub(crate) struct CudaGraphDrainGuard {
+    device: Device,
+}
+
+#[cfg(feature = "cuda")]
+impl CudaGraphDrainGuard {
+    pub(crate) fn new(device: &Device) -> Self {
+        Self {
+            device: device.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl Drop for CudaGraphDrainGuard {
+    fn drop(&mut self) {
+        drain_cuda_graph_drop_errors(&self.device);
+    }
+}
+
 #[cfg(feature = "cuda")]
 pub(crate) fn sync_graph_tensor(
     model_name: &str,
@@ -234,13 +269,12 @@ impl SingleTokenDecoderCudaGraph {
         } = self;
         let device = hidden_input.device().clone();
         report_stashed_cuda_error(&device, "decoder CUDA graph disposal");
-        drop(graph);
-        drop(logits_output);
-        drop(kv_lengths);
-        drop(_query_lengths);
-        drop(position_input);
-        drop(hidden_input);
-        drain_cuda_graph_drop_errors(&device);
+        drop_and_drain(graph, &device);
+        drop_and_drain(logits_output, &device);
+        drop_and_drain(kv_lengths, &device);
+        drop_and_drain(_query_lengths, &device);
+        drop_and_drain(position_input, &device);
+        drop_and_drain(hidden_input, &device);
     }
 }
 

--- a/oar-ocr-vl/src/glmocr/model.rs
+++ b/oar-ocr-vl/src/glmocr/model.rs
@@ -4,6 +4,8 @@ use super::mtp::GlmOcrMtpModel;
 use super::processing::{GlmOcrImageInputs, preprocess_image};
 use super::text::GlmOcrTextModel;
 use super::vision::GlmOcrVisionModel;
+#[cfg(feature = "cuda")]
+use crate::decoder_graph::CudaGraphDrainGuard;
 use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{D, DType, Device, IndexOp, Tensor};
@@ -33,6 +35,11 @@ pub struct GlmOcr {
     lm_head: Linear,
     eos_token_ids: Vec<u32>,
     image_token_id: u32,
+    // Must stay the last field: the captured decoder graphs read the LM head
+    // owned here, so this guard drops last and drains CUDA errors the head's
+    // free may stash (see CudaGraphDrainGuard).
+    #[cfg(feature = "cuda")]
+    _drain_guard: CudaGraphDrainGuard,
 }
 
 impl GlmOcr {
@@ -101,6 +108,8 @@ impl GlmOcr {
             EosTokenId::Multiple(v) => v.clone(),
         };
 
+        #[cfg(feature = "cuda")]
+        let _drain_guard = CudaGraphDrainGuard::new(&device);
         Ok(Self {
             device,
             dtype,
@@ -114,6 +123,8 @@ impl GlmOcr {
             lm_head,
             eos_token_ids,
             image_token_id,
+            #[cfg(feature = "cuda")]
+            _drain_guard,
         })
     }
 

--- a/oar-ocr-vl/src/glmocr/mtp.rs
+++ b/oar-ocr-vl/src/glmocr/mtp.rs
@@ -16,7 +16,9 @@ use candle_nn::{
 use std::cell::RefCell;
 
 struct GlmMtpCudaGraph {
-    // The graph owns device pointers into all tensors below. Drop it first.
+    // The graph owns device pointers into all tensors below; dispose via
+    // `dispose` so capture-touched buffers are never returned to the
+    // stream-ordered allocator (see SingleTokenDecoderCudaGraph::dispose).
     graph: candle_core::cuda_backend::cudarc::driver::CudaGraph,
     token_input: Tensor,
     previous_hidden_input: Tensor,
@@ -26,6 +28,30 @@ struct GlmMtpCudaGraph {
     hidden_output: Tensor,
     token_output: Tensor,
     cache_len: usize,
+}
+
+impl GlmMtpCudaGraph {
+    fn dispose(self) {
+        let Self {
+            graph,
+            token_input,
+            previous_hidden_input,
+            position_input,
+            _query_lengths,
+            kv_lengths,
+            hidden_output,
+            token_output,
+            cache_len: _,
+        } = self;
+        std::mem::forget(token_output);
+        std::mem::forget(hidden_output);
+        std::mem::forget(kv_lengths);
+        std::mem::forget(_query_lengths);
+        std::mem::forget(position_input);
+        std::mem::forget(previous_hidden_input);
+        std::mem::forget(token_input);
+        drop(graph);
+    }
 }
 
 impl std::fmt::Debug for GlmMtpCudaGraph {
@@ -383,7 +409,9 @@ impl GlmOcrMtpModel {
     }
 
     fn invalidate_cuda_graph(&self) {
-        self.graph.borrow_mut().take();
+        if let Some(graph) = self.graph.borrow_mut().take() {
+            graph.dispose();
+        }
     }
 
     pub(super) fn disable_cuda_graph(&self) {

--- a/oar-ocr-vl/src/glmocr/mtp.rs
+++ b/oar-ocr-vl/src/glmocr/mtp.rs
@@ -43,16 +43,21 @@ impl GlmMtpCudaGraph {
             token_output,
             cache_len: _,
         } = self;
-        // Leak the two small length buffers; the rest was allocated outside
-        // the capture (see SingleTokenDecoderCudaGraph::dispose).
-        std::mem::forget(kv_lengths);
-        std::mem::forget(_query_lengths);
+        let device = token_input.device().clone();
+        drop(graph);
         drop(token_output);
         drop(hidden_output);
+        drop(kv_lengths);
+        drop(_query_lengths);
         drop(position_input);
         drop(previous_hidden_input);
         drop(token_input);
-        drop(graph);
+        // Drops above may stash errors on the context; drain them so they
+        // cannot poison the next CUDA call (see
+        // SingleTokenDecoderCudaGraph::dispose).
+        if let Device::Cuda(cuda) = device {
+            let _ = cuda.cuda_stream().context().check_err();
+        }
     }
 }
 

--- a/oar-ocr-vl/src/glmocr/mtp.rs
+++ b/oar-ocr-vl/src/glmocr/mtp.rs
@@ -43,13 +43,15 @@ impl GlmMtpCudaGraph {
             token_output,
             cache_len: _,
         } = self;
-        std::mem::forget(token_output);
-        std::mem::forget(hidden_output);
+        // Leak the two small length buffers; the rest was allocated outside
+        // the capture (see SingleTokenDecoderCudaGraph::dispose).
         std::mem::forget(kv_lengths);
         std::mem::forget(_query_lengths);
-        std::mem::forget(position_input);
-        std::mem::forget(previous_hidden_input);
-        std::mem::forget(token_input);
+        drop(token_output);
+        drop(hidden_output);
+        drop(position_input);
+        drop(previous_hidden_input);
+        drop(token_input);
         drop(graph);
     }
 }
@@ -304,7 +306,7 @@ impl GlmOcrMtpModel {
         let stream = cuda.cuda_stream();
         let _htod_cache = cuda.enable_cuda_graph_htod_cache();
 
-        let (_, warm_token) = self.forward_dynamic(
+        let (warm_hidden, warm_token) = self.forward_dynamic(
             &token_input,
             &previous_hidden_input,
             &position_input,
@@ -312,26 +314,45 @@ impl GlmOcrMtpModel {
             kv_lengths.tensor(),
         )?;
         sync_graph_tensor("GLM-OCR", &warm_token, "warm MTP CUDA graph")?;
+        // Allocate the output buffers before capture so they belong to the
+        // regular stream-ordered pool; a capture-time allocation lives in the
+        // graph's private pool and can never be returned to the allocator
+        // safely. Prime the copies so the captured run sees warm kernels.
+        let hidden_output = Tensor::zeros_like(&warm_hidden)
+            .map_err(|e| candle_to_ocr_inference("GLM-OCR", "MTP hidden output", e))?;
+        let token_output = Tensor::zeros_like(&warm_token)
+            .map_err(|e| candle_to_ocr_inference("GLM-OCR", "MTP token output", e))?;
+        hidden_output
+            .slice_set(&warm_hidden, 0, 0)
+            .map_err(|e| candle_to_ocr_inference("GLM-OCR", "prime MTP hidden copy", e))?;
+        token_output
+            .slice_set(&warm_token, 0, 0)
+            .map_err(|e| candle_to_ocr_inference("GLM-OCR", "prime MTP token copy", e))?;
 
         stream
             .begin_capture(CUstreamCaptureMode_enum::CU_STREAM_CAPTURE_MODE_GLOBAL)
             .map_err(|e| cuda_graph_error("GLM-OCR", "begin MTP CUDA graph capture", e))?;
-        let captured_output = self.forward_dynamic(
-            &token_input,
-            &previous_hidden_input,
-            &position_input,
-            &query_lengths,
-            kv_lengths.tensor(),
-        );
-        let (hidden_output, token_output) = match captured_output {
-            Ok(output) => output,
-            Err(error) => {
-                let _ = stream.end_capture(
-                    CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
-                );
-                return Err(error);
-            }
-        };
+        let captured_output: Result<(), Error> = (|| {
+            let (hidden, token) = self.forward_dynamic(
+                &token_input,
+                &previous_hidden_input,
+                &position_input,
+                &query_lengths,
+                kv_lengths.tensor(),
+            )?;
+            hidden_output
+                .slice_set(&hidden, 0, 0)
+                .map_err(|e| candle_to_ocr_inference("GLM-OCR", "record MTP hidden copy", e))?;
+            token_output
+                .slice_set(&token, 0, 0)
+                .map_err(|e| candle_to_ocr_inference("GLM-OCR", "record MTP token copy", e))
+        })();
+        if let Err(error) = captured_output {
+            let _ = stream.end_capture(
+                CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
+            );
+            return Err(error);
+        }
         let graph = stream
             .end_capture(
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
@@ -428,5 +449,13 @@ impl GlmOcrMtpModel {
 
     pub(super) fn kv_cache_len(&self) -> usize {
         self.layer.kv_cache_len()
+    }
+}
+
+impl Drop for GlmOcrMtpModel {
+    fn drop(&mut self) {
+        // A cached graph must go through dispose: plainly dropping it returns
+        // graph-bound buffers to the allocator and poisons it.
+        self.invalidate_cuda_graph();
     }
 }

--- a/oar-ocr-vl/src/glmocr/mtp.rs
+++ b/oar-ocr-vl/src/glmocr/mtp.rs
@@ -7,8 +7,8 @@
 use super::config::GlmOcrTextConfig;
 use super::text::{GlmOcrTextDecoderLayer, GlmOcrTextRotaryEmbedding};
 use crate::decoder_graph::{
-    CudaGraphKvLengths, cuda_graph_error, drain_cuda_graph_drop_errors, report_stashed_cuda_error,
-    sync_graph_tensor,
+    CudaGraphDrainGuard, CudaGraphKvLengths, cuda_graph_error, drop_and_drain,
+    report_stashed_cuda_error, sync_graph_tensor,
 };
 use crate::error::Error;
 use crate::utils::candle_to_ocr_inference;
@@ -48,15 +48,14 @@ impl GlmMtpCudaGraph {
         } = self;
         let device = token_input.device().clone();
         report_stashed_cuda_error(&device, "CUDA graph disposal");
-        drop(graph);
-        drop(token_output);
-        drop(hidden_output);
-        drop(kv_lengths);
-        drop(_query_lengths);
-        drop(position_input);
-        drop(previous_hidden_input);
-        drop(token_input);
-        drain_cuda_graph_drop_errors(&device);
+        drop_and_drain(graph, &device);
+        drop_and_drain(token_output, &device);
+        drop_and_drain(hidden_output, &device);
+        drop_and_drain(kv_lengths, &device);
+        drop_and_drain(_query_lengths, &device);
+        drop_and_drain(position_input, &device);
+        drop_and_drain(previous_hidden_input, &device);
+        drop_and_drain(token_input, &device);
     }
 }
 
@@ -79,6 +78,9 @@ pub(super) struct GlmOcrMtpModel {
     shared_norm: RmsNorm,
     shared_head: Linear,
     rotary_emb: GlmOcrTextRotaryEmbedding,
+    // Must stay the last field: it drops last and drains CUDA errors the
+    // other fields' frees may stash (see CudaGraphDrainGuard).
+    _drain_guard: CudaGraphDrainGuard,
 }
 
 impl GlmOcrMtpModel {
@@ -111,6 +113,7 @@ impl GlmOcrMtpModel {
         .map_err(|e| candle_to_ocr_inference("GLM-OCR", "load MTP shared head", e))?;
         let rotary_emb = GlmOcrTextRotaryEmbedding::new(cfg, vb.device())?;
 
+        let _drain_guard = CudaGraphDrainGuard::new(vb_language_model.device());
         Ok(Self {
             graph: RefCell::new(None),
             embed_tokens,
@@ -121,6 +124,7 @@ impl GlmOcrMtpModel {
             shared_norm,
             shared_head,
             rotary_emb,
+            _drain_guard,
         })
     }
 

--- a/oar-ocr-vl/src/glmocr/mtp.rs
+++ b/oar-ocr-vl/src/glmocr/mtp.rs
@@ -6,7 +6,10 @@
 
 use super::config::GlmOcrTextConfig;
 use super::text::{GlmOcrTextDecoderLayer, GlmOcrTextRotaryEmbedding};
-use crate::decoder_graph::{CudaGraphKvLengths, cuda_graph_error, sync_graph_tensor};
+use crate::decoder_graph::{
+    CudaGraphKvLengths, cuda_graph_error, drain_cuda_graph_drop_errors, report_stashed_cuda_error,
+    sync_graph_tensor,
+};
 use crate::error::Error;
 use crate::utils::candle_to_ocr_inference;
 use candle_core::{D, DType, Device, Tensor};
@@ -44,6 +47,7 @@ impl GlmMtpCudaGraph {
             cache_len: _,
         } = self;
         let device = token_input.device().clone();
+        report_stashed_cuda_error(&device, "CUDA graph disposal");
         drop(graph);
         drop(token_output);
         drop(hidden_output);
@@ -52,12 +56,7 @@ impl GlmMtpCudaGraph {
         drop(position_input);
         drop(previous_hidden_input);
         drop(token_input);
-        // Drops above may stash errors on the context; drain them so they
-        // cannot poison the next CUDA call (see
-        // SingleTokenDecoderCudaGraph::dispose).
-        if let Device::Cuda(cuda) = device {
-            let _ = cuda.cuda_stream().context().check_err();
-        }
+        drain_cuda_graph_drop_errors(&device);
     }
 }
 

--- a/oar-ocr-vl/src/glmocr/text.rs
+++ b/oar-ocr-vl/src/glmocr/text.rs
@@ -1063,7 +1063,9 @@ impl GlmOcrTextDecoderLayer {
 
 #[cfg(feature = "cuda")]
 struct GlmVerificationCudaGraph {
-    // The graph owns device pointers into all tensors below. Drop it first.
+    // The graph owns device pointers into all tensors below; dispose via
+    // `dispose` so capture-touched buffers are never returned to the
+    // stream-ordered allocator (see SingleTokenDecoderCudaGraph::dispose).
     graph: candle_core::cuda_backend::cudarc::driver::CudaGraph,
     hidden_input: Tensor,
     position_input: Tensor,
@@ -1073,6 +1075,30 @@ struct GlmVerificationCudaGraph {
     token_output: Tensor,
     cache_len: usize,
     query_len: usize,
+}
+
+#[cfg(feature = "cuda")]
+impl GlmVerificationCudaGraph {
+    fn dispose(self) {
+        let Self {
+            graph,
+            hidden_input,
+            position_input,
+            _query_lengths,
+            kv_lengths,
+            hidden_output,
+            token_output,
+            cache_len: _,
+            query_len: _,
+        } = self;
+        std::mem::forget(token_output);
+        std::mem::forget(hidden_output);
+        std::mem::forget(kv_lengths);
+        std::mem::forget(_query_lengths);
+        std::mem::forget(position_input);
+        std::mem::forget(hidden_input);
+        drop(graph);
+    }
 }
 
 #[cfg(feature = "cuda")]
@@ -1632,8 +1658,12 @@ impl GlmOcrTextModel {
 
     #[cfg(feature = "cuda")]
     fn invalidate_cuda_graph(&self) {
-        self.decode_graph.borrow_mut().take();
-        self.verification_graph.borrow_mut().take();
+        if let Some(graph) = self.decode_graph.borrow_mut().take() {
+            graph.dispose();
+        }
+        if let Some(graph) = self.verification_graph.borrow_mut().take() {
+            graph.dispose();
+        }
     }
 
     #[cfg(feature = "cuda")]

--- a/oar-ocr-vl/src/glmocr/text.rs
+++ b/oar-ocr-vl/src/glmocr/text.rs
@@ -1091,12 +1091,14 @@ impl GlmVerificationCudaGraph {
             cache_len: _,
             query_len: _,
         } = self;
-        std::mem::forget(token_output);
-        std::mem::forget(hidden_output);
+        // Leak the two small length buffers; the rest was allocated outside
+        // the capture (see SingleTokenDecoderCudaGraph::dispose).
         std::mem::forget(kv_lengths);
         std::mem::forget(_query_lengths);
-        std::mem::forget(position_input);
-        std::mem::forget(hidden_input);
+        drop(token_output);
+        drop(hidden_output);
+        drop(position_input);
+        drop(hidden_input);
         drop(graph);
     }
 }
@@ -1416,28 +1418,37 @@ impl GlmOcrTextModel {
         )?;
         let warm_logits = self.project_logits(&warm, lm_head)?;
         sync_graph_tensor("GLM-OCR", &warm_logits, "warm decoder CUDA graph")?;
+        // Allocate the output buffer before capture so it belongs to the
+        // regular stream-ordered pool; a capture-time allocation lives in the
+        // graph's private pool and can never be returned to the allocator
+        // safely. Prime the copy so the captured run sees a warm kernel.
+        let logits_output = Tensor::zeros_like(&warm_logits)
+            .map_err(|e| candle_to_ocr_inference("GLM-OCR", "graph logits output", e))?;
+        logits_output
+            .slice_set(&warm_logits, 0, 0)
+            .map_err(|e| candle_to_ocr_inference("GLM-OCR", "prime graph logits copy", e))?;
 
         stream
             .begin_capture(CUstreamCaptureMode_enum::CU_STREAM_CAPTURE_MODE_GLOBAL)
             .map_err(|e| cuda_graph_error("GLM-OCR", "begin decoder CUDA graph capture", e))?;
-        let captured_output = (|| {
+        let captured_output: Result<(), Error> = (|| {
             let hidden = self.forward_dynamic(
                 &hidden_input,
                 &position_input,
                 &query_lengths,
                 kv_lengths.tensor(),
             )?;
-            self.project_logits(&hidden, lm_head)
+            let logits = self.project_logits(&hidden, lm_head)?;
+            logits_output
+                .slice_set(&logits, 0, 0)
+                .map_err(|e| candle_to_ocr_inference("GLM-OCR", "record graph logits copy", e))
         })();
-        let logits_output = match captured_output {
-            Ok(output) => output,
-            Err(error) => {
-                let _ = stream.end_capture(
-                    CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
-                );
-                return Err(error);
-            }
-        };
+        if let Err(error) = captured_output {
+            let _ = stream.end_capture(
+                CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
+            );
+            return Err(error);
+        }
         let graph = stream
             .end_capture(
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
@@ -1512,11 +1523,25 @@ impl GlmOcrTextModel {
             .argmax(D::Minus1)
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "warm verification argmax", e))?;
         sync_graph_tensor("GLM-OCR", &warm_tokens, "warm verification CUDA graph")?;
+        // Allocate the output buffers before capture so they belong to the
+        // regular stream-ordered pool; a capture-time allocation lives in the
+        // graph's private pool and can never be returned to the allocator
+        // safely. Prime the copies so the captured run sees warm kernels.
+        let hidden_output = Tensor::zeros_like(&warm)
+            .map_err(|e| candle_to_ocr_inference("GLM-OCR", "verification hidden output", e))?;
+        let token_output = Tensor::zeros_like(&warm_tokens)
+            .map_err(|e| candle_to_ocr_inference("GLM-OCR", "verification token output", e))?;
+        hidden_output
+            .slice_set(&warm, 0, 0)
+            .map_err(|e| candle_to_ocr_inference("GLM-OCR", "prime verification hidden copy", e))?;
+        token_output
+            .slice_set(&warm_tokens, 0, 0)
+            .map_err(|e| candle_to_ocr_inference("GLM-OCR", "prime verification token copy", e))?;
 
         stream
             .begin_capture(CUstreamCaptureMode_enum::CU_STREAM_CAPTURE_MODE_GLOBAL)
             .map_err(|e| cuda_graph_error("GLM-OCR", "begin verification graph capture", e))?;
-        let captured_output = (|| {
+        let captured_output: Result<(), Error> = (|| {
             let hidden = self.forward_dynamic(
                 &hidden_input,
                 &position_input,
@@ -1529,17 +1554,19 @@ impl GlmOcrTextModel {
                 .map_err(|e| {
                     candle_to_ocr_inference("GLM-OCR", "captured verification argmax", e)
                 })?;
-            Ok::<_, Error>((hidden, tokens))
+            hidden_output.slice_set(&hidden, 0, 0).map_err(|e| {
+                candle_to_ocr_inference("GLM-OCR", "record verification hidden copy", e)
+            })?;
+            token_output.slice_set(&tokens, 0, 0).map_err(|e| {
+                candle_to_ocr_inference("GLM-OCR", "record verification token copy", e)
+            })
         })();
-        let (hidden_output, token_output) = match captured_output {
-            Ok(output) => output,
-            Err(error) => {
-                let _ = stream.end_capture(
-                    CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
-                );
-                return Err(error);
-            }
-        };
+        if let Err(error) = captured_output {
+            let _ = stream.end_capture(
+                CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
+            );
+            return Err(error);
+        }
         let graph = stream
             .end_capture(
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
@@ -1685,6 +1712,15 @@ impl GlmOcrTextModel {
             layer.trim_kv_cache(len)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl Drop for GlmOcrTextModel {
+    fn drop(&mut self) {
+        // A cached graph must go through dispose: plainly dropping it returns
+        // graph-bound buffers to the allocator and poisons it.
+        self.invalidate_cuda_graph();
     }
 }
 

--- a/oar-ocr-vl/src/glmocr/text.rs
+++ b/oar-ocr-vl/src/glmocr/text.rs
@@ -5,7 +5,7 @@ use crate::decoder_graph::decoder_cache_capacity;
 #[cfg(feature = "cuda")]
 use crate::decoder_graph::{
     CudaGraphKvLengths, SingleTokenDecoderCudaGraph, cuda_graph_error, decoder_attention_is_causal,
-    sync_graph_tensor,
+    drain_cuda_graph_drop_errors, report_stashed_cuda_error, sync_graph_tensor,
 };
 use crate::error::Error;
 #[cfg(feature = "cuda")]
@@ -1092,6 +1092,7 @@ impl GlmVerificationCudaGraph {
             query_len: _,
         } = self;
         let device = hidden_input.device().clone();
+        report_stashed_cuda_error(&device, "CUDA graph disposal");
         drop(graph);
         drop(token_output);
         drop(hidden_output);
@@ -1099,12 +1100,7 @@ impl GlmVerificationCudaGraph {
         drop(_query_lengths);
         drop(position_input);
         drop(hidden_input);
-        // Drops above may stash errors on the context; drain them so they
-        // cannot poison the next CUDA call (see
-        // SingleTokenDecoderCudaGraph::dispose).
-        if let Device::Cuda(cuda) = device {
-            let _ = cuda.cuda_stream().context().check_err();
-        }
+        drain_cuda_graph_drop_errors(&device);
     }
 }
 

--- a/oar-ocr-vl/src/glmocr/text.rs
+++ b/oar-ocr-vl/src/glmocr/text.rs
@@ -1091,15 +1091,20 @@ impl GlmVerificationCudaGraph {
             cache_len: _,
             query_len: _,
         } = self;
-        // Leak the two small length buffers; the rest was allocated outside
-        // the capture (see SingleTokenDecoderCudaGraph::dispose).
-        std::mem::forget(kv_lengths);
-        std::mem::forget(_query_lengths);
+        let device = hidden_input.device().clone();
+        drop(graph);
         drop(token_output);
         drop(hidden_output);
+        drop(kv_lengths);
+        drop(_query_lengths);
         drop(position_input);
         drop(hidden_input);
-        drop(graph);
+        // Drops above may stash errors on the context; drain them so they
+        // cannot poison the next CUDA call (see
+        // SingleTokenDecoderCudaGraph::dispose).
+        if let Device::Cuda(cuda) = device {
+            let _ = cuda.cuda_stream().context().check_err();
+        }
     }
 }
 

--- a/oar-ocr-vl/src/glmocr/text.rs
+++ b/oar-ocr-vl/src/glmocr/text.rs
@@ -4,8 +4,8 @@ use crate::attention::{flash_attention, scaled_dot_product_attention_gqa};
 use crate::decoder_graph::decoder_cache_capacity;
 #[cfg(feature = "cuda")]
 use crate::decoder_graph::{
-    CudaGraphKvLengths, SingleTokenDecoderCudaGraph, cuda_graph_error, decoder_attention_is_causal,
-    drain_cuda_graph_drop_errors, report_stashed_cuda_error, sync_graph_tensor,
+    CudaGraphDrainGuard, CudaGraphKvLengths, SingleTokenDecoderCudaGraph, cuda_graph_error,
+    decoder_attention_is_causal, drop_and_drain, report_stashed_cuda_error, sync_graph_tensor,
 };
 use crate::error::Error;
 #[cfg(feature = "cuda")]
@@ -1093,14 +1093,13 @@ impl GlmVerificationCudaGraph {
         } = self;
         let device = hidden_input.device().clone();
         report_stashed_cuda_error(&device, "CUDA graph disposal");
-        drop(graph);
-        drop(token_output);
-        drop(hidden_output);
-        drop(kv_lengths);
-        drop(_query_lengths);
-        drop(position_input);
-        drop(hidden_input);
-        drain_cuda_graph_drop_errors(&device);
+        drop_and_drain(graph, &device);
+        drop_and_drain(token_output, &device);
+        drop_and_drain(hidden_output, &device);
+        drop_and_drain(kv_lengths, &device);
+        drop_and_drain(_query_lengths, &device);
+        drop_and_drain(position_input, &device);
+        drop_and_drain(hidden_input, &device);
     }
 }
 
@@ -1124,6 +1123,10 @@ pub struct GlmOcrTextModel {
     layers: Vec<GlmOcrTextDecoderLayer>,
     norm: RmsNorm,
     rotary_emb: GlmOcrTextRotaryEmbedding,
+    // Must stay the last field: it drops last and drains CUDA errors the
+    // other fields' frees may stash (see CudaGraphDrainGuard).
+    #[cfg(feature = "cuda")]
+    _drain_guard: CudaGraphDrainGuard,
 }
 
 impl GlmOcrTextModel {
@@ -1140,6 +1143,8 @@ impl GlmOcrTextModel {
         let norm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("norm"))
             .map_err(|e| candle_to_ocr_inference("GLM-OCR", "text norm", e))?;
 
+        #[cfg(feature = "cuda")]
+        let _drain_guard = CudaGraphDrainGuard::new(vb.device());
         Ok(Self {
             #[cfg(feature = "cuda")]
             decode_graph: RefCell::new(None),
@@ -1149,6 +1154,8 @@ impl GlmOcrTextModel {
             layers,
             norm,
             rotary_emb,
+            #[cfg(feature = "cuda")]
+            _drain_guard,
         })
     }
 

--- a/oar-ocr-vl/src/hunyuanocr/dflash.rs
+++ b/oar-ocr-vl/src/hunyuanocr/dflash.rs
@@ -871,13 +871,15 @@ impl DFlashCudaGraph {
             hidden_output,
             proposals_output,
         } = self;
-        std::mem::forget(proposals_output);
-        std::mem::forget(hidden_output);
+        // Leak the two small length buffers; the rest was allocated outside
+        // the capture (see SingleTokenDecoderCudaGraph::dispose).
         std::mem::forget(kv_lengths);
         std::mem::forget(_query_lengths);
-        std::mem::forget(sin_input);
-        std::mem::forget(cos_input);
-        std::mem::forget(query_input);
+        drop(proposals_output);
+        drop(hidden_output);
+        drop(sin_input);
+        drop(cos_input);
+        drop(query_input);
         drop(graph);
     }
 }
@@ -1269,13 +1271,27 @@ impl DFlashModel {
             &warm_proposals,
             "warm full draft graph",
         )?;
+        // Allocate the output buffers before capture so they belong to the
+        // regular stream-ordered pool; a capture-time allocation lives in the
+        // graph's private pool and can never be returned to the allocator
+        // safely. Prime the copies so the captured run sees warm kernels.
+        let hidden_output = Tensor::zeros_like(&warm)
+            .map_err(|e| tensor_err("HunyuanOCR DFlash: full graph hidden output", e))?;
+        let proposals_output = Tensor::zeros_like(&warm_proposals)
+            .map_err(|e| tensor_err("HunyuanOCR DFlash: full graph proposals output", e))?;
+        hidden_output
+            .slice_set(&warm, 0, 0)
+            .map_err(|e| tensor_err("HunyuanOCR DFlash: prime full hidden copy", e))?;
+        proposals_output
+            .slice_set(&warm_proposals, 0, 0)
+            .map_err(|e| tensor_err("HunyuanOCR DFlash: prime full proposals copy", e))?;
 
         stream
             .begin_capture(CUstreamCaptureMode_enum::CU_STREAM_CAPTURE_MODE_GLOBAL)
             .map_err(|e| {
                 cuda_graph_error("HunyuanOCR DFlash", "begin full draft graph capture", e)
             })?;
-        let captured_output = (|| {
+        let captured_output: Result<(), Error> = (|| {
             let hidden = self.forward_queries_dynamic(
                 &query_input,
                 &cos_input,
@@ -1284,17 +1300,19 @@ impl DFlashModel {
                 kv_lengths.tensor(),
             )?;
             let proposals = self.proposals_from_hidden(&hidden)?;
-            Ok::<_, Error>((hidden, proposals))
+            hidden_output
+                .slice_set(&hidden, 0, 0)
+                .map_err(|e| tensor_err("HunyuanOCR DFlash: record full hidden copy", e))?;
+            proposals_output
+                .slice_set(&proposals, 0, 0)
+                .map_err(|e| tensor_err("HunyuanOCR DFlash: record full proposals copy", e))
         })();
-        let (hidden_output, proposals_output) = match captured_output {
-            Ok(output) => output,
-            Err(error) => {
-                let _ = stream.end_capture(
-                    CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
-                );
-                return Err(error);
-            }
-        };
+        if let Err(error) = captured_output {
+            let _ = stream.end_capture(
+                CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
+            );
+            return Err(error);
+        }
         let graph = stream
             .end_capture(
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
@@ -1417,6 +1435,15 @@ impl DFlashModel {
         for cache in self.caches.borrow_mut().iter_mut() {
             cache.reset();
         }
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl Drop for DFlashModel {
+    fn drop(&mut self) {
+        // A cached graph must go through dispose: plainly dropping it returns
+        // graph-bound buffers to the allocator and poisons it.
+        self.invalidate_cuda_graph();
     }
 }
 

--- a/oar-ocr-vl/src/hunyuanocr/dflash.rs
+++ b/oar-ocr-vl/src/hunyuanocr/dflash.rs
@@ -15,8 +15,8 @@ use crate::attention::{RotaryEmbedding, flash_attention, scaled_dot_product_atte
 use crate::cuda_kernels::ArgmaxFirstBf16;
 #[cfg(feature = "cuda")]
 use crate::decoder_graph::{
-    CudaGraphKvLengths, cuda_graph_error, drain_cuda_graph_drop_errors, report_stashed_cuda_error,
-    sync_graph_tensor,
+    CudaGraphDrainGuard, CudaGraphKvLengths, cuda_graph_error, drop_and_drain,
+    report_stashed_cuda_error, sync_graph_tensor,
 };
 use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing, rotate_half};
@@ -876,15 +876,14 @@ impl DFlashCudaGraph {
         } = self;
         let device = query_input.device().clone();
         report_stashed_cuda_error(&device, "CUDA graph disposal");
-        drop(graph);
-        drop(proposals_output);
-        drop(hidden_output);
-        drop(kv_lengths);
-        drop(_query_lengths);
-        drop(sin_input);
-        drop(cos_input);
-        drop(query_input);
-        drain_cuda_graph_drop_errors(&device);
+        drop_and_drain(graph, &device);
+        drop_and_drain(proposals_output, &device);
+        drop_and_drain(hidden_output, &device);
+        drop_and_drain(kv_lengths, &device);
+        drop_and_drain(_query_lengths, &device);
+        drop_and_drain(sin_input, &device);
+        drop_and_drain(cos_input, &device);
+        drop_and_drain(query_input, &device);
     }
 }
 
@@ -916,6 +915,10 @@ pub(crate) struct DFlashModel {
     caches: RefCell<Vec<ContextKv>>,
     dtype: DType,
     device: Device,
+    // Must stay the last field: it drops last and drains CUDA errors the
+    // other fields' frees may stash (see CudaGraphDrainGuard).
+    #[cfg(feature = "cuda")]
+    _drain_guard: CudaGraphDrainGuard,
 }
 
 impl DFlashModel {
@@ -997,6 +1000,8 @@ impl DFlashModel {
             caches: RefCell::new(caches),
             dtype,
             device: device.clone(),
+            #[cfg(feature = "cuda")]
+            _drain_guard: CudaGraphDrainGuard::new(device),
         };
         model.prepare_cuda_graph()?;
         Ok(model)

--- a/oar-ocr-vl/src/hunyuanocr/dflash.rs
+++ b/oar-ocr-vl/src/hunyuanocr/dflash.rs
@@ -14,7 +14,10 @@ use crate::attention::{RotaryEmbedding, flash_attention, scaled_dot_product_atte
 #[cfg(feature = "cuda")]
 use crate::cuda_kernels::ArgmaxFirstBf16;
 #[cfg(feature = "cuda")]
-use crate::decoder_graph::{CudaGraphKvLengths, cuda_graph_error, sync_graph_tensor};
+use crate::decoder_graph::{
+    CudaGraphKvLengths, cuda_graph_error, drain_cuda_graph_drop_errors, report_stashed_cuda_error,
+    sync_graph_tensor,
+};
 use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing, rotate_half};
 use candle_core::{D, DType, Device, Tensor};
@@ -872,6 +875,7 @@ impl DFlashCudaGraph {
             proposals_output,
         } = self;
         let device = query_input.device().clone();
+        report_stashed_cuda_error(&device, "CUDA graph disposal");
         drop(graph);
         drop(proposals_output);
         drop(hidden_output);
@@ -880,12 +884,7 @@ impl DFlashCudaGraph {
         drop(sin_input);
         drop(cos_input);
         drop(query_input);
-        // Drops above may stash errors on the context; drain them so they
-        // cannot poison the next CUDA call (see
-        // SingleTokenDecoderCudaGraph::dispose).
-        if let Device::Cuda(cuda) = device {
-            let _ = cuda.cuda_stream().context().check_err();
-        }
+        drain_cuda_graph_drop_errors(&device);
     }
 }
 

--- a/oar-ocr-vl/src/hunyuanocr/dflash.rs
+++ b/oar-ocr-vl/src/hunyuanocr/dflash.rs
@@ -871,16 +871,21 @@ impl DFlashCudaGraph {
             hidden_output,
             proposals_output,
         } = self;
-        // Leak the two small length buffers; the rest was allocated outside
-        // the capture (see SingleTokenDecoderCudaGraph::dispose).
-        std::mem::forget(kv_lengths);
-        std::mem::forget(_query_lengths);
+        let device = query_input.device().clone();
+        drop(graph);
         drop(proposals_output);
         drop(hidden_output);
+        drop(kv_lengths);
+        drop(_query_lengths);
         drop(sin_input);
         drop(cos_input);
         drop(query_input);
-        drop(graph);
+        // Drops above may stash errors on the context; drain them so they
+        // cannot poison the next CUDA call (see
+        // SingleTokenDecoderCudaGraph::dispose).
+        if let Device::Cuda(cuda) = device {
+            let _ = cuda.cuda_stream().context().check_err();
+        }
     }
 }
 

--- a/oar-ocr-vl/src/hunyuanocr/dflash.rs
+++ b/oar-ocr-vl/src/hunyuanocr/dflash.rs
@@ -846,6 +846,8 @@ impl DFlashLayer {
 
 #[cfg(feature = "cuda")]
 struct DFlashCudaGraph {
+    // Dispose via `dispose` so capture-touched buffers are never returned to
+    // the stream-ordered allocator (see SingleTokenDecoderCudaGraph::dispose).
     graph: candle_core::cuda_backend::cudarc::driver::CudaGraph,
     query_input: Tensor,
     cos_input: Tensor,
@@ -854,6 +856,30 @@ struct DFlashCudaGraph {
     kv_lengths: CudaGraphKvLengths,
     hidden_output: Tensor,
     proposals_output: Tensor,
+}
+
+#[cfg(feature = "cuda")]
+impl DFlashCudaGraph {
+    fn dispose(self) {
+        let Self {
+            graph,
+            query_input,
+            cos_input,
+            sin_input,
+            _query_lengths,
+            kv_lengths,
+            hidden_output,
+            proposals_output,
+        } = self;
+        std::mem::forget(proposals_output);
+        std::mem::forget(hidden_output);
+        std::mem::forget(kv_lengths);
+        std::mem::forget(_query_lengths);
+        std::mem::forget(sin_input);
+        std::mem::forget(cos_input);
+        std::mem::forget(query_input);
+        drop(graph);
+    }
 }
 
 #[cfg(feature = "cuda")]
@@ -1011,7 +1037,9 @@ impl DFlashModel {
         // A captured graph owns raw pointers into the fixed-size cache. Once
         // that cache must grow, the graph cannot safely be reused, including
         // after a later page-level reset.
-        self.decode_graph.borrow_mut().take();
+        if let Some(graph) = self.decode_graph.borrow_mut().take() {
+            graph.dispose();
+        }
     }
 
     fn rope(&self, start: usize, len: usize) -> Result<(Tensor, Tensor), Error> {

--- a/oar-ocr-vl/src/hunyuanocr/llm.rs
+++ b/oar-ocr-vl/src/hunyuanocr/llm.rs
@@ -688,17 +688,22 @@ impl TargetDecoderCudaGraph {
             aux_layer_ids: _,
             cache_len: _,
         } = self;
-        // Leak the two small length buffers; the rest was allocated outside
-        // the capture (see SingleTokenDecoderCudaGraph::dispose).
-        std::mem::forget(kv_lengths);
-        std::mem::forget(_query_lengths);
+        let device = hidden_input.device().clone();
+        drop(graph);
         drop(aux_output);
         drop(logits_output);
         drop(hidden_output);
+        drop(kv_lengths);
+        drop(_query_lengths);
         drop(sin_input);
         drop(cos_input);
         drop(hidden_input);
-        drop(graph);
+        // Drops above may stash errors on the context; drain them so they
+        // cannot poison the next CUDA call (see
+        // SingleTokenDecoderCudaGraph::dispose).
+        if let Device::Cuda(cuda) = device {
+            let _ = cuda.cuda_stream().context().check_err();
+        }
     }
 }
 

--- a/oar-ocr-vl/src/hunyuanocr/llm.rs
+++ b/oar-ocr-vl/src/hunyuanocr/llm.rs
@@ -879,6 +879,10 @@ pub struct HunyuanLlm {
     /// per `forward` to section-mix the rotary `cos`/`sin` tensors before they
     /// fan out to every layer — see [`apply_xdrope_rotary_pos_emb`].
     xdrope_section: Vec<usize>,
+    // Must stay the last field: it drops last and drains CUDA errors the
+    // other fields' frees may stash (see CudaGraphDrainGuard).
+    #[cfg(feature = "cuda")]
+    _drain_guard: CudaGraphDrainGuard,
 }
 
 impl HunyuanLlm {
@@ -919,6 +923,8 @@ impl HunyuanLlm {
             .to_dtype(candle_core::DType::F32)
             .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "decode rope sin f32", e))?;
 
+        #[cfg(feature = "cuda")]
+        let _drain_guard = CudaGraphDrainGuard::new(vb.device());
         Ok(Self {
             #[cfg(feature = "cuda")]
             decode_graph: RefCell::new(None),
@@ -929,6 +935,8 @@ impl HunyuanLlm {
             decode_cos,
             decode_sin,
             xdrope_section: cfg.rope_scaling.xdrope_section.clone(),
+            #[cfg(feature = "cuda")]
+            _drain_guard,
         })
     }
 

--- a/oar-ocr-vl/src/hunyuanocr/llm.rs
+++ b/oar-ocr-vl/src/hunyuanocr/llm.rs
@@ -656,7 +656,9 @@ impl HunyuanAttention {
 #[cfg(feature = "cuda")]
 struct TargetDecoderCudaGraph {
     // The executable graph owns raw pointers into every tensor below and into
-    // the decoder weights, so it must be dropped first.
+    // the decoder weights; dispose via `dispose` so capture-touched buffers
+    // are never returned to the stream-ordered allocator (see
+    // SingleTokenDecoderCudaGraph::dispose).
     graph: candle_core::cuda_backend::cudarc::driver::CudaGraph,
     hidden_input: Tensor,
     cos_input: Tensor,
@@ -668,6 +670,36 @@ struct TargetDecoderCudaGraph {
     aux_output: Option<Tensor>,
     aux_layer_ids: Vec<usize>,
     cache_len: usize,
+}
+
+#[cfg(feature = "cuda")]
+impl TargetDecoderCudaGraph {
+    fn dispose(self) {
+        let Self {
+            graph,
+            hidden_input,
+            cos_input,
+            sin_input,
+            _query_lengths,
+            kv_lengths,
+            hidden_output,
+            logits_output,
+            aux_output,
+            aux_layer_ids: _,
+            cache_len: _,
+        } = self;
+        if let Some(aux_output) = aux_output {
+            std::mem::forget(aux_output);
+        }
+        std::mem::forget(logits_output);
+        std::mem::forget(hidden_output);
+        std::mem::forget(kv_lengths);
+        std::mem::forget(_query_lengths);
+        std::mem::forget(sin_input);
+        std::mem::forget(cos_input);
+        std::mem::forget(hidden_input);
+        drop(graph);
+    }
 }
 
 #[cfg(feature = "cuda")]
@@ -1432,7 +1464,9 @@ impl HunyuanLlm {
         // Eager cache growth reallocates the storage whose raw pointers were
         // captured by the graph. Dropping it before growth also prevents a
         // stale replay after the logical cache is reset for another document.
-        self.decode_graph.borrow_mut().take();
+        if let Some(graph) = self.decode_graph.borrow_mut().take() {
+            graph.dispose();
+        }
     }
 
     /// Drop any captured target-decoder CUDA graph.

--- a/oar-ocr-vl/src/hunyuanocr/llm.rs
+++ b/oar-ocr-vl/src/hunyuanocr/llm.rs
@@ -8,7 +8,8 @@ use crate::attention::{
 };
 #[cfg(feature = "cuda")]
 use crate::decoder_graph::{
-    CudaGraphKvLengths, cuda_graph_error, decoder_attention_is_causal, sync_graph_tensor,
+    CudaGraphKvLengths, cuda_graph_error, decoder_attention_is_causal,
+    drain_cuda_graph_drop_errors, report_stashed_cuda_error, sync_graph_tensor,
 };
 use crate::error::Error;
 use crate::kv_trim::TrimmableKvCache;
@@ -689,6 +690,7 @@ impl TargetDecoderCudaGraph {
             cache_len: _,
         } = self;
         let device = hidden_input.device().clone();
+        report_stashed_cuda_error(&device, "CUDA graph disposal");
         drop(graph);
         drop(aux_output);
         drop(logits_output);
@@ -698,12 +700,7 @@ impl TargetDecoderCudaGraph {
         drop(sin_input);
         drop(cos_input);
         drop(hidden_input);
-        // Drops above may stash errors on the context; drain them so they
-        // cannot poison the next CUDA call (see
-        // SingleTokenDecoderCudaGraph::dispose).
-        if let Device::Cuda(cuda) = device {
-            let _ = cuda.cuda_stream().context().check_err();
-        }
+        drain_cuda_graph_drop_errors(&device);
     }
 }
 

--- a/oar-ocr-vl/src/hunyuanocr/llm.rs
+++ b/oar-ocr-vl/src/hunyuanocr/llm.rs
@@ -8,8 +8,8 @@ use crate::attention::{
 };
 #[cfg(feature = "cuda")]
 use crate::decoder_graph::{
-    CudaGraphKvLengths, cuda_graph_error, decoder_attention_is_causal,
-    drain_cuda_graph_drop_errors, report_stashed_cuda_error, sync_graph_tensor,
+    CudaGraphDrainGuard, CudaGraphKvLengths, cuda_graph_error, decoder_attention_is_causal,
+    drop_and_drain, report_stashed_cuda_error, sync_graph_tensor,
 };
 use crate::error::Error;
 use crate::kv_trim::TrimmableKvCache;
@@ -691,16 +691,15 @@ impl TargetDecoderCudaGraph {
         } = self;
         let device = hidden_input.device().clone();
         report_stashed_cuda_error(&device, "CUDA graph disposal");
-        drop(graph);
-        drop(aux_output);
-        drop(logits_output);
-        drop(hidden_output);
-        drop(kv_lengths);
-        drop(_query_lengths);
-        drop(sin_input);
-        drop(cos_input);
-        drop(hidden_input);
-        drain_cuda_graph_drop_errors(&device);
+        drop_and_drain(graph, &device);
+        drop_and_drain(aux_output, &device);
+        drop_and_drain(logits_output, &device);
+        drop_and_drain(hidden_output, &device);
+        drop_and_drain(kv_lengths, &device);
+        drop_and_drain(_query_lengths, &device);
+        drop_and_drain(sin_input, &device);
+        drop_and_drain(cos_input, &device);
+        drop_and_drain(hidden_input, &device);
     }
 }
 

--- a/oar-ocr-vl/src/hunyuanocr/llm.rs
+++ b/oar-ocr-vl/src/hunyuanocr/llm.rs
@@ -688,16 +688,16 @@ impl TargetDecoderCudaGraph {
             aux_layer_ids: _,
             cache_len: _,
         } = self;
-        if let Some(aux_output) = aux_output {
-            std::mem::forget(aux_output);
-        }
-        std::mem::forget(logits_output);
-        std::mem::forget(hidden_output);
+        // Leak the two small length buffers; the rest was allocated outside
+        // the capture (see SingleTokenDecoderCudaGraph::dispose).
         std::mem::forget(kv_lengths);
         std::mem::forget(_query_lengths);
-        std::mem::forget(sin_input);
-        std::mem::forget(cos_input);
-        std::mem::forget(hidden_input);
+        drop(aux_output);
+        drop(logits_output);
+        drop(hidden_output);
+        drop(sin_input);
+        drop(cos_input);
+        drop(hidden_input);
         drop(graph);
     }
 }
@@ -1396,13 +1396,38 @@ impl HunyuanLlm {
         )?;
         let warm_logits = self.project_logits(&warm.hidden_states)?;
         sync_graph_tensor("HunyuanOCR", &warm_logits, "warm full target decoder graph")?;
+        // Allocate the output buffers before capture so they belong to the
+        // regular stream-ordered pool; a capture-time allocation lives in the
+        // graph's private pool and can never be returned to the allocator
+        // safely. Prime the copies so the captured run sees warm kernels.
+        let hidden_output = Tensor::zeros_like(&warm.hidden_states)
+            .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "full graph hidden output", e))?;
+        let logits_output = Tensor::zeros_like(&warm_logits)
+            .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "full graph logits output", e))?;
+        let aux_output = warm
+            .aux_hidden_states
+            .as_ref()
+            .map(Tensor::zeros_like)
+            .transpose()
+            .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "full graph aux output", e))?;
+        hidden_output
+            .slice_set(&warm.hidden_states, 0, 0)
+            .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "prime full hidden copy", e))?;
+        logits_output
+            .slice_set(&warm_logits, 0, 0)
+            .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "prime full logits copy", e))?;
+        if let (Some(buffer), Some(source)) = (&aux_output, &warm.aux_hidden_states) {
+            buffer
+                .slice_set(source, 0, 0)
+                .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "prime full aux copy", e))?;
+        }
 
         stream
             .begin_capture(CUstreamCaptureMode_enum::CU_STREAM_CAPTURE_MODE_GLOBAL)
             .map_err(|e| {
                 cuda_graph_error("HunyuanOCR", "begin full target decoder graph capture", e)
             })?;
-        let captured_output = (|| {
+        let captured_output: Result<(), Error> = (|| {
             let output = self.forward_with_aux_dynamic(
                 &hidden_input,
                 &cos_input,
@@ -1412,17 +1437,25 @@ impl HunyuanLlm {
                 aux_layer_ids,
             )?;
             let logits = self.project_logits(&output.hidden_states)?;
-            Ok::<_, Error>((output, logits))
-        })();
-        let (output, logits_output) = match captured_output {
-            Ok(output) => output,
-            Err(error) => {
-                let _ = stream.end_capture(
-                    CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
-                );
-                return Err(error);
+            hidden_output
+                .slice_set(&output.hidden_states, 0, 0)
+                .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "record full hidden copy", e))?;
+            logits_output
+                .slice_set(&logits, 0, 0)
+                .map_err(|e| candle_to_ocr_inference("HunyuanOCR", "record full logits copy", e))?;
+            if let (Some(buffer), Some(source)) = (&aux_output, &output.aux_hidden_states) {
+                buffer.slice_set(source, 0, 0).map_err(|e| {
+                    candle_to_ocr_inference("HunyuanOCR", "record full aux copy", e)
+                })?;
             }
-        };
+            Ok(())
+        })();
+        if let Err(error) = captured_output {
+            let _ = stream.end_capture(
+                CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
+            );
+            return Err(error);
+        }
         let graph = stream
             .end_capture(
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
@@ -1433,7 +1466,6 @@ impl HunyuanLlm {
             .ok_or_else(|| Error::Config {
                 message: "HunyuanOCR full target decoder capture returned no graph".to_string(),
             })?;
-        let aux_output = output.aux_hidden_states;
         graph
             .launch()
             .map_err(|e| cuda_graph_error("HunyuanOCR", "warm full target decoder graph", e))?;
@@ -1450,7 +1482,7 @@ impl HunyuanLlm {
             sin_input,
             _query_lengths: query_lengths,
             kv_lengths,
-            hidden_output: output.hidden_states,
+            hidden_output,
             logits_output,
             aux_output,
             aux_layer_ids: aux_layer_ids.to_vec(),
@@ -1493,6 +1525,15 @@ impl HunyuanLlm {
         self.layers
             .first()
             .map_or(0, HunyuanDecoderLayer::kv_cache_len)
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl Drop for HunyuanLlm {
+    fn drop(&mut self) {
+        // A cached graph must go through dispose: plainly dropping it returns
+        // graph-bound buffers to the allocator and poisons it.
+        self.invalidate_cuda_graph();
     }
 }
 

--- a/oar-ocr-vl/src/mineru/model.rs
+++ b/oar-ocr-vl/src/mineru/model.rs
@@ -7,6 +7,8 @@ use crate::attention::{
 };
 #[cfg(feature = "cuda")]
 use crate::cuda_kernels::{ArgmaxFirstBf16, ArgmaxFirstF32, MaskTokenIds};
+#[cfg(feature = "cuda")]
+use crate::decoder_graph::CudaGraphDrainGuard;
 use crate::error::Error;
 use crate::structure::LayoutElementType;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
@@ -98,6 +100,11 @@ pub struct MinerU {
     top_k: usize,
     #[cfg(feature = "cuda")]
     gpu_greedy_sampling: bool,
+    // Must stay the last field: the captured decoder graphs read the LM head
+    // owned here, so this guard drops last and drains CUDA errors the head's
+    // free may stash (see CudaGraphDrainGuard).
+    #[cfg(feature = "cuda")]
+    _drain_guard: CudaGraphDrainGuard,
 }
 
 #[derive(Debug, Deserialize)]
@@ -242,6 +249,8 @@ impl MinerU {
                 .map_err(|e| candle_to_ocr_inference("MinerU2.5", "load lm_head", e))?
         };
 
+        #[cfg(feature = "cuda")]
+        let _drain_guard = CudaGraphDrainGuard::new(&device);
         Ok(Self {
             device,
             dtype,
@@ -265,6 +274,8 @@ impl MinerU {
             top_k,
             #[cfg(feature = "cuda")]
             gpu_greedy_sampling: std::env::var_os("OAR_MINERU_DISABLE_GPU_SAMPLING").is_none(),
+            #[cfg(feature = "cuda")]
+            _drain_guard,
         })
     }
 

--- a/oar-ocr-vl/src/mineru/text.rs
+++ b/oar-ocr-vl/src/mineru/text.rs
@@ -6,8 +6,8 @@ use crate::attention::{
 use crate::decoder_graph::decoder_cache_capacity;
 #[cfg(feature = "cuda")]
 use crate::decoder_graph::{
-    CudaGraphKvLengths, SingleTokenDecoderCudaGraph, cuda_graph_error, decoder_attention_is_causal,
-    sync_graph_tensor,
+    CudaGraphDrainGuard, CudaGraphKvLengths, SingleTokenDecoderCudaGraph, cuda_graph_error,
+    decoder_attention_is_causal, sync_graph_tensor,
 };
 use crate::error::Error;
 #[cfg(feature = "cuda")]
@@ -535,6 +535,10 @@ pub struct MinerUTextModel {
     layers: Vec<MinerUDecoderLayer>,
     norm: candle_nn::RmsNorm,
     rotary_emb: Arc<RotaryEmbedding>,
+    // Must stay the last field: it drops last and drains CUDA errors the
+    // other fields' frees may stash (see CudaGraphDrainGuard).
+    #[cfg(feature = "cuda")]
+    _drain_guard: CudaGraphDrainGuard,
 }
 
 impl MinerUTextModel {
@@ -558,6 +562,8 @@ impl MinerUTextModel {
             vb.device(),
         )?);
 
+        #[cfg(feature = "cuda")]
+        let _drain_guard = CudaGraphDrainGuard::new(vb.device());
         Ok(Self {
             #[cfg(feature = "cuda")]
             decode_graph: RefCell::new(None),
@@ -565,6 +571,8 @@ impl MinerUTextModel {
             layers,
             norm,
             rotary_emb,
+            #[cfg(feature = "cuda")]
+            _drain_guard,
         })
     }
 

--- a/oar-ocr-vl/src/mineru/text.rs
+++ b/oar-ocr-vl/src/mineru/text.rs
@@ -732,28 +732,37 @@ impl MinerUTextModel {
         )?;
         let warm_logits = self.project_logits(&warm, lm_head)?;
         sync_graph_tensor("MinerU2.5", &warm_logits, "warm decoder CUDA graph")?;
+        // Allocate the output buffer before capture so it belongs to the
+        // regular stream-ordered pool; a capture-time allocation lives in the
+        // graph's private pool and can never be returned to the allocator
+        // safely. Prime the copy so the captured run sees a warm kernel.
+        let logits_output = Tensor::zeros_like(&warm_logits)
+            .map_err(|e| candle_to_ocr_inference("MinerU2.5", "graph logits output", e))?;
+        logits_output
+            .slice_set(&warm_logits, 0, 0)
+            .map_err(|e| candle_to_ocr_inference("MinerU2.5", "prime graph logits copy", e))?;
 
         stream
             .begin_capture(CUstreamCaptureMode_enum::CU_STREAM_CAPTURE_MODE_GLOBAL)
             .map_err(|e| cuda_graph_error("MinerU2.5", "begin decoder CUDA graph capture", e))?;
-        let captured_output = (|| {
+        let captured_output: Result<(), Error> = (|| {
             let hidden = self.forward_dynamic(
                 &hidden_input,
                 &position_input,
                 &query_lengths,
                 kv_lengths.tensor(),
             )?;
-            self.project_logits(&hidden, lm_head)
+            let logits = self.project_logits(&hidden, lm_head)?;
+            logits_output
+                .slice_set(&logits, 0, 0)
+                .map_err(|e| candle_to_ocr_inference("MinerU2.5", "record graph logits copy", e))
         })();
-        let logits_output = match captured_output {
-            Ok(output) => output,
-            Err(error) => {
-                let _ = stream.end_capture(
-                    CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
-                );
-                return Err(error);
-            }
-        };
+        if let Err(error) = captured_output {
+            let _ = stream.end_capture(
+                CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
+            );
+            return Err(error);
+        }
         let graph = stream
             .end_capture(
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
@@ -849,5 +858,14 @@ impl MinerUTextModel {
         for layer in &self.layers {
             layer.clear_kv_cache();
         }
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl Drop for MinerUTextModel {
+    fn drop(&mut self) {
+        // A cached graph must go through dispose: plainly dropping it returns
+        // graph-bound buffers to the allocator and poisons it.
+        self.invalidate_cuda_graph();
     }
 }

--- a/oar-ocr-vl/src/mineru/text.rs
+++ b/oar-ocr-vl/src/mineru/text.rs
@@ -824,7 +824,9 @@ impl MinerUTextModel {
 
     #[cfg(feature = "cuda")]
     fn invalidate_cuda_graph(&self) {
-        self.decode_graph.borrow_mut().take();
+        if let Some(graph) = self.decode_graph.borrow_mut().take() {
+            graph.dispose();
+        }
     }
 
     pub(crate) fn invalidate_ar_cuda_graph(&self) {

--- a/oar-ocr-vl/src/paddleocr_vl/ernie.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/ernie.rs
@@ -830,7 +830,9 @@ impl Ernie4_5Model {
 
     #[cfg(feature = "cuda")]
     fn invalidate_cuda_graph(&self) {
-        self.decode_graph.borrow_mut().take();
+        if let Some(graph) = self.decode_graph.borrow_mut().take() {
+            graph.dispose();
+        }
     }
 
     pub(crate) fn invalidate_ar_cuda_graph(&self) {

--- a/oar-ocr-vl/src/paddleocr_vl/ernie.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/ernie.rs
@@ -738,28 +738,37 @@ impl Ernie4_5Model {
         )?;
         let warm_logits = self.project_logits(&warm, lm_head)?;
         sync_graph_tensor("PaddleOCR-VL", &warm_logits, "warm decoder CUDA graph")?;
+        // Allocate the output buffer before capture so it belongs to the
+        // regular stream-ordered pool; a capture-time allocation lives in the
+        // graph's private pool and can never be returned to the allocator
+        // safely. Prime the copy so the captured run sees a warm kernel.
+        let logits_output = Tensor::zeros_like(&warm_logits)
+            .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "graph logits output", e))?;
+        logits_output
+            .slice_set(&warm_logits, 0, 0)
+            .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "prime graph logits copy", e))?;
 
         stream
             .begin_capture(CUstreamCaptureMode_enum::CU_STREAM_CAPTURE_MODE_GLOBAL)
             .map_err(|e| cuda_graph_error("PaddleOCR-VL", "begin decoder CUDA graph capture", e))?;
-        let captured_output = (|| {
+        let captured_output: Result<(), Error> = (|| {
             let hidden = self.forward_dynamic(
                 &hidden_input,
                 &position_input,
                 &query_lengths,
                 kv_lengths.tensor(),
             )?;
-            self.project_logits(&hidden, lm_head)
+            let logits = self.project_logits(&hidden, lm_head)?;
+            logits_output
+                .slice_set(&logits, 0, 0)
+                .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "record graph logits copy", e))
         })();
-        let logits_output = match captured_output {
-            Ok(output) => output,
-            Err(error) => {
-                let _ = stream.end_capture(
-                    CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
-                );
-                return Err(error);
-            }
-        };
+        if let Err(error) = captured_output {
+            let _ = stream.end_capture(
+                CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
+            );
+            return Err(error);
+        }
         let graph = stream
             .end_capture(
                 CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
@@ -851,5 +860,14 @@ impl Ernie4_5Model {
         for layer in &self.layers {
             layer.clear_kv_cache();
         }
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl Drop for Ernie4_5Model {
+    fn drop(&mut self) {
+        // A cached graph must go through dispose: plainly dropping it returns
+        // graph-bound buffers to the allocator and poisons it.
+        self.invalidate_cuda_graph();
     }
 }

--- a/oar-ocr-vl/src/paddleocr_vl/ernie.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/ernie.rs
@@ -6,8 +6,8 @@ use crate::attention::{
 use crate::decoder_graph::decoder_cache_capacity;
 #[cfg(feature = "cuda")]
 use crate::decoder_graph::{
-    CudaGraphKvLengths, SingleTokenDecoderCudaGraph, cuda_graph_error, decoder_attention_is_causal,
-    sync_graph_tensor,
+    CudaGraphDrainGuard, CudaGraphKvLengths, SingleTokenDecoderCudaGraph, cuda_graph_error,
+    decoder_attention_is_causal, sync_graph_tensor,
 };
 use crate::error::Error;
 #[cfg(feature = "cuda")]
@@ -537,6 +537,10 @@ pub struct Ernie4_5Model {
     layers: Vec<Ernie4_5DecoderLayer>,
     norm: candle_nn::RmsNorm,
     rotary: RotaryEmbedding,
+    // Must stay the last field: it drops last and drains CUDA errors the
+    // other fields' frees may stash (see CudaGraphDrainGuard).
+    #[cfg(feature = "cuda")]
+    _drain_guard: CudaGraphDrainGuard,
 }
 
 impl Ernie4_5Model {
@@ -554,6 +558,8 @@ impl Ernie4_5Model {
         let norm = candle_nn::rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("norm"))
             .map_err(|e| candle_to_ocr_inference("PaddleOCR-VL", "load final norm", e))?;
         let rotary = RotaryEmbedding::new_multi_axis(cfg.head_dim, cfg.rope_theta, 3, vb.device())?;
+        #[cfg(feature = "cuda")]
+        let _drain_guard = CudaGraphDrainGuard::new(vb.device());
         Ok(Self {
             #[cfg(feature = "cuda")]
             decode_graph: RefCell::new(None),
@@ -561,6 +567,8 @@ impl Ernie4_5Model {
             layers,
             norm,
             rotary,
+            #[cfg(feature = "cuda")]
+            _drain_guard,
         })
     }
 

--- a/oar-ocr-vl/src/paddleocr_vl/model.rs
+++ b/oar-ocr-vl/src/paddleocr_vl/model.rs
@@ -8,6 +8,8 @@ use super::vision::VisionModel;
 use crate::attention::{
     combine_masks, create_causal_mask, create_generation_mask_if_needed, create_left_padding_mask,
 };
+#[cfg(feature = "cuda")]
+use crate::decoder_graph::CudaGraphDrainGuard;
 use crate::error::Error;
 use crate::utils::{candle_to_ocr_inference, candle_to_ocr_processing};
 use candle_core::{D, DType, Device, IndexOp, Tensor};
@@ -71,6 +73,11 @@ pub struct PaddleOcrVl {
     image_placeholder_token_id: u32,
     /// Assistant prefix derived from chat template (e.g., "Assistant: " vs "Assistant:\n")
     assistant_prefix: String,
+    // Must stay the last field: the captured decoder graphs read the LM head
+    // owned here, so this guard drops last and drains CUDA errors the head's
+    // free may stash (see CudaGraphDrainGuard).
+    #[cfg(feature = "cuda")]
+    _drain_guard: CudaGraphDrainGuard,
 }
 
 impl PaddleOcrVl {
@@ -123,6 +130,8 @@ impl PaddleOcrVl {
         let vision = VisionModel::load(&cfg.vision_config, vb.pp("visual").pp("vision_model"))?;
         let projector = Projector::load(&cfg, &cfg.vision_config, vb.pp("mlp_AR"))?;
 
+        #[cfg(feature = "cuda")]
+        let _drain_guard = CudaGraphDrainGuard::new(&device);
         Ok(Self {
             device,
             dtype,
@@ -137,6 +146,8 @@ impl PaddleOcrVl {
             sep_token_id,
             image_placeholder_token_id,
             assistant_prefix,
+            #[cfg(feature = "cuda")]
+            _drain_guard,
         })
     }
 


### PR DESCRIPTION
## Problem

After #180 enabled batched content extraction in the MinerU example, every batched (B>=2) prefill that ran **after** a batch-1 pass failed on CUDA:

```
Batch inference failed for blocks [0, 1]: tensor operation failed: RotaryEmbedding: position_ids cast to f32 failed
  caused by: DriverError(CUDA_ERROR_INVALID_VALUE, "invalid argument")
```

The per-block retry masked it, so results stayed correct but MinerU silently lost all batching speedup (12/12 batches fell back in `run_vl.sh`).

## Root cause

The batch-1 pass captures the single-token AR CUDA graph; the batched pass then invalidates it. Invalidation plain-dropped the captured graph struct:

- the capture-time output tensor lives in the graph's **private memory pool** (instantiated with `AUTO_FREE_ON_LAUNCH`), and
- the captured input buffers have their addresses baked into graph nodes,

so handing those allocations back to cudarc's stream-ordered allocator poisons the pool. The next unrelated allocation then fails with `CUDA_ERROR_INVALID_VALUE` — in MinerU's case surfacing in the multi-axis RoPE position cast of the batched prefill. Reproducible 100%: any batch >= 2 after a graph capture; fresh-process batches pass.

## Fix

Dispose captured graphs by **leaking their device buffers** (a few hundred KB per cache bucket, reclaimed at process exit) and destroying only the exec. Applied via a new `dispose()` to all five captured-graph structs:

- shared `SingleTokenDecoderCudaGraph` (MinerU, GLM-OCR, PaddleOCR-VL)
- `GlmVerificationCudaGraph`, `GlmMtpCudaGraph` (GLM-OCR)
- `TargetDecoderCudaGraph`, `DFlashCudaGraph` (HunyuanOCR)

The RoPE cast error now also reports the offending shape for faster diagnosis.

Also included: `build.rs` detects nvcc >= 13 on Windows and passes `-Xcompiler /Zc:preprocessor`, because CUDA 13 CCCL headers hard-error (MSVC C1189) under cl.exe's traditional preprocessor.

## Validation

| Platform | run_tests.sh (ONNX) | run_vl.sh (VL) | MinerU batch fallbacks |
|---|---|---|---|
| Windows, RTX A4000, CUDA 13.2, driver 595.71 | ✅ 47/47, CUDA EP active | ✅ 35/35 | 12 → **0** |
| Linux, RTX 5090, CUDA 13.0, driver 580.105 | ✅ 47/47 (CUDA cases on CPU: prebuilt ORT provider .so needs glibc 2.38, host has 2.35) | ✅ 35/35 | 12 → **0** |

Both runs previously fell back per-block; after the fix all MinerU content batches succeed directly.